### PR TITLE
Remove `t3` type instances from default provisioner

### DIFF
--- a/charts/tfy-karpenter-config/Chart.yaml
+++ b/charts/tfy-karpenter-config/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: tfy-karpenter-config
 description: "ArgoCD Applications for karpenter config"
 type: application
-version: 0.1.5
+version: 0.1.6

--- a/charts/tfy-karpenter-config/values.yaml
+++ b/charts/tfy-karpenter-config/values.yaml
@@ -20,7 +20,10 @@ karpenter:
         values: ["amd64"]
       - key: karpenter.k8s.aws/instance-family
         operator: NotIn
-        values: ["p2", "p3", "p4d", "p4de", "g4dn", "g5", "g4ad", "inf1", "inf2", "trn1", "trn1n"]
+        values: ["t3", "t2", "t3a", "p2", "p3", "p4d", "p4de", "g4dn", "g5", "g4ad", "inf1", "inf2", "trn1", "trn1n"]
+      - key: karpenter.k8s.aws/instance-size
+        operator: NotIn
+        values: ["nano", "micro", "metal"]
   
   gpuProvisionerSpec:
     enabled: false


### PR DESCRIPTION
- Also allows larger instance types by default