### PR TITLE
Pass device specs in device plugin on Azure

### DIFF
--- a/charts/tfy-gpu-operator/Chart.yaml
+++ b/charts/tfy-gpu-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: tfy-gpu-operator
-version: 0.1.6
+version: 0.1.7-rc.1
 description: "Truefoundry GPU Operator"
 maintainers:
   - name: truefoundry

--- a/charts/tfy-gpu-operator/Chart.yaml
+++ b/charts/tfy-gpu-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: tfy-gpu-operator
-version: 0.1.7-rc.1
+version: 0.1.7
 description: "Truefoundry GPU Operator"
 maintainers:
   - name: truefoundry

--- a/charts/tfy-gpu-operator/templates/aks-nvidia-device-plugin.yaml
+++ b/charts/tfy-gpu-operator/templates/aks-nvidia-device-plugin.yaml
@@ -56,6 +56,11 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
+          env:
+            - name: FAIL_ON_INIT_ERROR
+              value: "false"
+            - name: PASS_DEVICE_SPECS
+              value: "true"
           volumeMounts:
             - name: device-plugin
               mountPath: /var/lib/kubelet/device-plugins

--- a/charts/tfy-gpu-operator/templates/aks-nvidia-device-plugin.yaml
+++ b/charts/tfy-gpu-operator/templates/aks-nvidia-device-plugin.yaml
@@ -50,17 +50,15 @@ spec:
           value: spot
           effect: NoSchedule
       containers:
-        - image: mcr.microsoft.com/oss/nvidia/k8s-device-plugin:1.11
+        - image: nvcr.io/nvidia/k8s-device-plugin:v0.13.0-rc.1
           name: nvidia-device-plugin-ctr
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
           env:
             - name: FAIL_ON_INIT_ERROR
               value: "false"
             - name: PASS_DEVICE_SPECS
               value: "true"
+          securityContext:
+            privileged: true
           volumeMounts:
             - name: device-plugin
               mountPath: /var/lib/kubelet/device-plugins

--- a/charts/tfy-gpu-operator/templates/aks-nvidia-device-plugin.yaml
+++ b/charts/tfy-gpu-operator/templates/aks-nvidia-device-plugin.yaml
@@ -50,7 +50,7 @@ spec:
           value: spot
           effect: NoSchedule
       containers:
-        - image: nvcr.io/nvidia/k8s-device-plugin:v0.13.0-rc.1
+        - image: nvcr.io/nvidia/k8s-device-plugin:v0.14.1
           name: nvidia-device-plugin-ctr
           env:
             - name: FAIL_ON_INIT_ERROR

--- a/charts/tfy-gpu-operator/templates/aks-nvidia-device-plugin.yaml
+++ b/charts/tfy-gpu-operator/templates/aks-nvidia-device-plugin.yaml
@@ -53,8 +53,6 @@ spec:
         - image: nvcr.io/nvidia/k8s-device-plugin:v0.14.1
           name: nvidia-device-plugin-ctr
           env:
-            - name: FAIL_ON_INIT_ERROR
-              value: "false"
             - name: PASS_DEVICE_SPECS
               value: "true"
           securityContext:


### PR DESCRIPTION
See: https://github.com/Azure/AKS/issues/3680#issuecomment-1585298045
This fixes an issue when `SystemdCgroup` is enabled for containerd - which is the default on AKS 1.25+ running Ubuntu 22.04
In addition to this, it is necessary to run at least  VM image `202306.07.0` because that has udev rules to create symlinks in `/dev/char`