### PR TITLE
fix: do not delete PVC when loki statefulset deleted

### DIFF
--- a/charts/tfy-loki/Chart.yaml
+++ b/charts/tfy-loki/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: tfy-loki
 description: Truefoundry Loki Provisioner
-version: 0.1.0
+version: 0.1.1
 maintainers:
   - name: truefoundry
 dependencies:

--- a/charts/tfy-loki/README.md
+++ b/charts/tfy-loki/README.md
@@ -12,23 +12,24 @@ https://github.com/grafana/helm-charts/tree/8b9ca8240e4e412f72af2df42f833c94142a
 
 ### Upstream Loki configurations
 
-| Name                                                  | Description                                                                                         | Value                               |
-| ----------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| `loki.enabled`                                        | Enable loki                                                                                         | `true`                              |
-| `loki.loki.storage.type`                              | Method to use for storage                                                                           | `filesystem`                        |
-| `loki.loki.compactor.shared_store`                    | The shared store used for storing boltdb files.                                                     | `filesystem`                        |
-| `loki.loki.compactor.retention_enabled`               | Activate custom (per-stream,per-tenant) retention.                                                  | `true`                              |
-| `loki.loki.auth_enabled`                              | Enables authentication through the X-Scope-OrgID header                                             | `false`                             |
-| `loki.loki.limits_config.retention_period`            | Retention period to apply to stored data.                                                           | `168h`                              |
-| `loki.loki.limits_config.max_query_lookback`          | Limit how far back in time series data and metadata can be queried, up until lookback duration ago. | `168h`                              |
-| `loki.loki.limits_config.split_queries_by_interval`   | Split queries by a time interval and execute in parallel.                                           | `10h`                               |
-| `loki.loki.limits_config.max_entries_limit_per_query` | Maximum number of log entries that will be returned for a query.                                    | `30000`                             |
-| `loki.singleBinary.replicas`                          | Number of replicas for the single binary                                                            | `1`                                 |
-| `loki.singleBinary.resources.requests.cpu`            | CPU requests for promtail container                                                                 | `0.03`                              |
-| `loki.singleBinary.resources.requests.memory`         | Memory requests for promtail container                                                              | `250Mi`                             |
-| `loki.singleBinary.persistence.size`                  | Size of persistent disk                                                                             | `50Gi`                              |
-| `promtail.enabled`                                    | Enable promtail                                                                                     | `true`                              |
-| `promtail.config.clients[0].url`                      | Loki push API URL                                                                                   | `http://loki:3100/loki/api/v1/push` |
-| `promtail.resources.requests.cpu`                     | CPU requests for promtail container                                                                 | `40m`                               |
-| `promtail.resources.requests.memory`                  | Memory requests for promtail container                                                              | `100Mi`                             |
-| `promtail.resources.requests.ephemeral-storage`       | Ephemeral storage requests for promtail container                                                   | `256Mi`                             |
+| Name                                                           | Description                                                                                         | Value                               |
+| -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| `loki.enabled`                                                 | Enable loki                                                                                         | `true`                              |
+| `loki.loki.storage.type`                                       | Method to use for storage                                                                           | `filesystem`                        |
+| `loki.loki.compactor.shared_store`                             | The shared store used for storing boltdb files.                                                     | `filesystem`                        |
+| `loki.loki.compactor.retention_enabled`                        | Activate custom (per-stream,per-tenant) retention.                                                  | `true`                              |
+| `loki.loki.auth_enabled`                                       | Enables authentication through the X-Scope-OrgID header                                             | `false`                             |
+| `loki.loki.limits_config.retention_period`                     | Retention period to apply to stored data.                                                           | `168h`                              |
+| `loki.loki.limits_config.max_query_lookback`                   | Limit how far back in time series data and metadata can be queried, up until lookback duration ago. | `168h`                              |
+| `loki.loki.limits_config.split_queries_by_interval`            | Split queries by a time interval and execute in parallel.                                           | `10h`                               |
+| `loki.loki.limits_config.max_entries_limit_per_query`          | Maximum number of log entries that will be returned for a query.                                    | `30000`                             |
+| `loki.singleBinary.replicas`                                   | Number of replicas for the single binary                                                            | `1`                                 |
+| `loki.singleBinary.resources.requests.cpu`                     | CPU requests for promtail container                                                                 | `0.03`                              |
+| `loki.singleBinary.resources.requests.memory`                  | Memory requests for promtail container                                                              | `250Mi`                             |
+| `loki.singleBinary.persistence.size`                           | Size of persistent disk                                                                             | `50Gi`                              |
+| `loki.singleBinary.persistence.enableStatefulSetAutoDeletePVC` | Enable StatefulSetAutoDeletePVC feature                                                             | `false`                             |
+| `promtail.enabled`                                             | Enable promtail                                                                                     | `true`                              |
+| `promtail.config.clients[0].url`                               | Loki push API URL                                                                                   | `http://loki:3100/loki/api/v1/push` |
+| `promtail.resources.requests.cpu`                              | CPU requests for promtail container                                                                 | `40m`                               |
+| `promtail.resources.requests.memory`                           | Memory requests for promtail container                                                              | `100Mi`                             |
+| `promtail.resources.requests.ephemeral-storage`                | Ephemeral storage requests for promtail container                                                   | `256Mi`                             |

--- a/charts/tfy-loki/values.yaml
+++ b/charts/tfy-loki/values.yaml
@@ -56,7 +56,9 @@ loki:
         cpu: 0.03
         memory: 250Mi
     ## @param loki.singleBinary.persistence.size Size of persistent disk
+    ## @param loki.singleBinary.persistence.enableStatefulSetAutoDeletePVC Enable StatefulSetAutoDeletePVC feature
     persistence:
+      enableStatefulSetAutoDeletePVC: false
       size: 50Gi
 
 promtail:


### PR DESCRIPTION
The user can delete it manually, if they are sure that they want to delete the logs