### PR TITLE
fix: create a priority class to ensure critical pods come up

### DIFF
--- a/charts/tfy-agent/Chart.yaml
+++ b/charts/tfy-agent/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.16-rc.1
+version: 0.2.16-rc.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/tfy-agent/README.md
+++ b/charts/tfy-agent/README.md
@@ -100,3 +100,10 @@ Tfy-agent is an applications that gets deployed on the kubernetes cluster to con
 | `tfyAgentProxy.nodeSelector`                         | Parameters to select for scheduling of pod on a node                                                                       | `{}`                                              |
 | `tfyAgentProxy.affinity`                             | Affinity rules for pod scheduling on a node                                                                                | `{}`                                              |
 | `tfyAgentProxy.priorityClassName`                    | PriorityClass name for the pod.                                                                                            | `system-cluster-critical`                         |
+
+### resourceQuota Add a ResourceQuota to enable priority class in a namspace.
+
+| Name                            | Description                | Value                         |
+| ------------------------------- | -------------------------- | ----------------------------- |
+| `resourceQuota.enabled`         | Create the ResourceQuota.  | `true`                        |
+| `resourceQuota.priorityClasses` | PriorityClasses to enable. | `["system-cluster-critical"]` |

--- a/charts/tfy-agent/templates/resource-quota.yaml
+++ b/charts/tfy-agent/templates/resource-quota.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.resourceQuota.enabled -}}
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: {{ include "tfy-agent.fullname" . }}-critical-pods
+spec:
+  scopeSelector:
+    matchExpressions:
+    - operator: In
+      scopeName: PriorityClass
+      values:
+      {{- with .Values.resourceQuota.priorityClasses }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/tfy-agent/values.yaml
+++ b/charts/tfy-agent/values.yaml
@@ -391,3 +391,13 @@ tfyAgentProxy:
 
   ## @param tfyAgentProxy.priorityClassName PriorityClass name for the pod.
   priorityClassName: system-cluster-critical
+
+
+## @section resourceQuota Add a ResourceQuota to enable priority class in a namspace.
+##
+resourceQuota:
+  ## @param resourceQuota.enabled Create the ResourceQuota.
+  enabled: true
+  ## @param resourceQuota.priorityClasses PriorityClasses to enable.
+  priorityClasses:
+    - system-cluster-critical


### PR DESCRIPTION
GKE does not allow creating a critical pods without the resource quota