### PR TITLE
chore: missing services/status resource permission

### DIFF
--- a/charts/tfy-agent/templates/tfy-agent-proxy-clusterrole-ns.yaml
+++ b/charts/tfy-agent/templates/tfy-agent-proxy-clusterrole-ns.yaml
@@ -27,7 +27,7 @@ rules:
     verbs: ["delete", "get"]
 
   - apiGroups: [""]
-    resources: ["pods/log", "events", "services", "persistentvolumes"]
+    resources: ["pods/log", "events", "services", "persistentvolumes", "services/status"]
     verbs: ["get", "list"]
 
   - apiGroups: ["apps"]


### PR DESCRIPTION
To allow access to sub resource `services/status` so that readNamespacedServiceStatus() does not throw a permission issue during cluster sync.