### PR TITLE
tfy-gpu-operator: Add `CriticalAddonsOnly` toleration for AKS

### DIFF
--- a/charts/tfy-gpu-operator/Chart.yaml
+++ b/charts/tfy-gpu-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: tfy-gpu-operator
-version: 0.1.25
+version: 0.1.26
 description: "Truefoundry GPU Operator"
 maintainers:
   - name: truefoundry

--- a/charts/tfy-gpu-operator/values.yaml
+++ b/charts/tfy-gpu-operator/values.yaml
@@ -1118,8 +1118,6 @@ generic-gpu-operator:
         memory: 300Mi
     ## @skip generic-gpu-operator.operator.tolerations
     tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Equal
         value: ''
@@ -1142,8 +1140,6 @@ generic-gpu-operator:
           memory: 200Mi
       ## @skip generic-gpu-operator.node-feature-discovery.master.tolerations
       tolerations:
-        - key: CriticalAddonsOnly
-          operator: Exists
         - key: node-role.kubernetes.io/master
           operator: Equal
           effect: NoSchedule
@@ -1164,8 +1160,6 @@ generic-gpu-operator:
           memory: 300Mi
       ## @skip generic-gpu-operator.node-feature-discovery.worker.tolerations
       tolerations:
-        - key: CriticalAddonsOnly
-          operator: Exists
         - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule

--- a/charts/tfy-gpu-operator/values.yaml
+++ b/charts/tfy-gpu-operator/values.yaml
@@ -563,6 +563,8 @@ azure-aks-gpu-operator:
         memory: 300Mi
     ## @skip azure-aks-gpu-operator.operator.tolerations
     tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Equal
         value: ''
@@ -589,6 +591,8 @@ azure-aks-gpu-operator:
           memory: 200Mi
       ## @skip azure-aks-gpu-operator.node-feature-discovery.master.tolerations
       tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
         - key: node-role.kubernetes.io/master
           operator: Equal
           effect: NoSchedule
@@ -623,6 +627,8 @@ azure-aks-gpu-operator:
                       - nvidia
       ## @skip azure-aks-gpu-operator.node-feature-discovery.worker.tolerations
       tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
         - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule
@@ -657,6 +663,8 @@ azure-aks-gpu-operator:
                       - nvidia
       ## @skip azure-aks-gpu-operator.node-feature-discovery.gc.tolerations
       tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
         - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule
@@ -1110,6 +1118,8 @@ generic-gpu-operator:
         memory: 300Mi
     ## @skip generic-gpu-operator.operator.tolerations
     tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Equal
         value: ''
@@ -1132,6 +1142,8 @@ generic-gpu-operator:
           memory: 200Mi
       ## @skip generic-gpu-operator.node-feature-discovery.master.tolerations
       tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
         - key: node-role.kubernetes.io/master
           operator: Equal
           effect: NoSchedule
@@ -1152,6 +1164,8 @@ generic-gpu-operator:
           memory: 300Mi
       ## @skip generic-gpu-operator.node-feature-discovery.worker.tolerations
       tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
         - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule


### PR DESCRIPTION
Marking this as draft, we need to carefully consider if `CriticalAddonsOnly` makes sense. It is ideally meant to reserve nodes for kubernetes control plane components