### PR TITLE
Upgrading karpenter to v1.1.1

### DIFF
--- a/charts/tfy-karpenter/Chart.yaml
+++ b/charts/tfy-karpenter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tfy-karpenter
 description: Truefoundry karpenter provisioner
 type: application
-version: 0.4.1
+version: 0.4.2
 # upstream karpenter version
 appVersion: "1.1.1"
 maintainers:

--- a/charts/tfy-karpenter/Chart.yaml
+++ b/charts/tfy-karpenter/Chart.yaml
@@ -4,15 +4,15 @@ description: Truefoundry karpenter provisioner
 type: application
 version: 0.4.1
 # upstream karpenter version
-appVersion: "1.0.8"
+appVersion: "1.1.1"
 maintainers:
 - name: truefoundry
 
 # Upstream karpenter dependecy
 dependencies:
 - name: karpenter-crd
-  version: "1.0.8"
+  version: "1.1.1"
   repository: "oci://public.ecr.aws/karpenter"
 - name: karpenter
-  version: "1.0.8"
+  version: "1.1.1"
   repository: "oci://public.ecr.aws/karpenter"

--- a/charts/tfy-karpenter/README.md
+++ b/charts/tfy-karpenter/README.md
@@ -16,9 +16,3 @@ A Helm chart for Karpenter, an open-source node provisioning project built for K
 | `karpenter.controller.resources.requests.memory`                  | Memory requests for karpenter container           | `100Mi` |
 | `karpenter.controller.resources.limits.cpu`                       | CPU limits for karpenter container                | `200m`  |
 | `karpenter.controller.resources.limits.memory`                    | Memory requests for karpenter container           | `256Mi` |
-
-### Upstream karpenter crd configurations
-
-| Name                            | Description                      | Value  |
-| ------------------------------- | -------------------------------- | ------ |
-| `karpenter-crd.webhook.enabled` | Enable webhook in karpenter CRDs | `true` |

--- a/charts/tfy-karpenter/values.yaml
+++ b/charts/tfy-karpenter/values.yaml
@@ -22,11 +22,6 @@ karpenter:
     ## @param karpenter.settings.reservedENIs reserved ENIs for the custom networking CNI setup
     ##
     reservedENIs: "0"
-
-  webhook:
-    ## @skip karpenter.webhook.enabled Enable karpenter webhook
-    ##
-    enabled: true
   ## @param karpenter.controller.resources.requests.cpu CPU requests for karpenter container
   ## @param karpenter.controller.resources.requests.memory Memory requests for karpenter container
   ## @param karpenter.controller.resources.limits.cpu CPU limits for karpenter container
@@ -40,9 +35,3 @@ karpenter:
       limits:
         cpu: 200m
         memory: 256Mi
-
-## @section Upstream karpenter crd configurations
-karpenter-crd:
-  ## @param karpenter-crd.webhook.enabled Enable webhook in karpenter CRDs
-  webhook:
-    enabled: true


### PR DESCRIPTION
1. Upgrading karpenter and karpenter-crd to v1.1.1
2. Removing webhook support in both the dependencies