### PR TITLE
Upload artifacts proper exit

### DIFF
--- a/.github/workflows/upload-artifacts.yml
+++ b/.github/workflows/upload-artifacts.yml
@@ -5,15 +5,15 @@ on:
     branches:
       - 'main'
       - upload-artifacts-proper-exit
-    paths:
-      - '.github/workflows/update-artifacts.yml'
-      - 'charts/tfy-k8s-aws-eks-inframold/**'
-      - 'charts/tfy-k8s-azure-aks-inframold/**'
-      - 'charts/tfy-k8s-civo-talos-inframold/**'
-      - 'charts/tfy-k8s-gcp-gke-standard-inframold/**'
-      - 'charts/tfy-k8s-generic-inframold/**'
-      - 'scripts/generate-artifacts-manifest/**'
-      - 'scripts/upload-artifacts/**'
+#    paths:
+#      - '.github/workflows/update-artifacts.yml'
+#      - 'charts/tfy-k8s-aws-eks-inframold/**'
+#      - 'charts/tfy-k8s-azure-aks-inframold/**'
+#      - 'charts/tfy-k8s-civo-talos-inframold/**'
+#      - 'charts/tfy-k8s-gcp-gke-standard-inframold/**'
+#      - 'charts/tfy-k8s-generic-inframold/**'
+#      - 'scripts/generate-artifacts-manifest/**'
+#      - 'scripts/upload-artifacts/**'
 
 jobs:
   upload-artifacts:

--- a/.github/workflows/upload-artifacts.yml
+++ b/.github/workflows/upload-artifacts.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'main'
+      - upload-artifacts-proper-exit
     paths:
       - '.github/workflows/update-artifacts.yml'
       - 'charts/tfy-k8s-aws-eks-inframold/**'

--- a/.github/workflows/upload-artifacts.yml
+++ b/.github/workflows/upload-artifacts.yml
@@ -79,5 +79,5 @@ jobs:
               image \
               charts/$chart/artifacts-manifest.json \
               ${{ env.ARTIFACTORY_REPOSITORY_URL }} \
-              --exclude-registries truefoundrycloud
+              --exclude-registries truefoundrycloud tfy.jfrog.io
           done

--- a/scripts/generate-artifacts-manifest/check_chart_images_support_multiple_architectures.py
+++ b/scripts/generate-artifacts-manifest/check_chart_images_support_multiple_architectures.py
@@ -45,9 +45,9 @@ def parse_args(args):
 def get_truefoundry_chart_images(artifacts_manifest):
     """Extract the list of images associated with the 'truefoundry' chart."""
     for artifact in artifacts_manifest:
-        if artifact.get("details", {}).get("chart") in truefoundry_charts:
-            return artifact["details"].get("images", [])
-    return []
+        # if artifact.get("details", {}).get("chart") in truefoundry_charts:
+        return artifact["details"].get("images", [])
+    # return []
 
 
 def check_image_architectures(artifacts_manifest, truefoundry_chart_images, whitelisted_images):

--- a/scripts/upload-artifacts/upload_artifacts.py
+++ b/scripts/upload-artifacts/upload_artifacts.py
@@ -126,6 +126,7 @@ def pull_and_push_images(image_list, destination_registry, excluded_registries=[
             logging.error(
                 f"Failed to create multi-arch image: {new_image_url}. Error: {e}"
             )
+            exit("Cannot create multi-arch image")
 
 
 # function to download and push Helm charts

--- a/scripts/upload-artifacts/upload_artifacts.py
+++ b/scripts/upload-artifacts/upload_artifacts.py
@@ -106,27 +106,20 @@ def pull_and_push_images(image_list, destination_registry, excluded_registries=[
         new_image_url = parse_image_url(image_url, destination_registry)
 
         # Check if the new_image_url already exists and has both architectures
-        image_exists, _ = check_image_exists_and_architectures(new_image_url)
+        image_exists, multi_arch = check_image_exists_and_architectures(new_image_url)
 
-        if image_exists:
-            logging.info(f"Image {new_image_url} already exists Skipping push...")
+        if image_exists and multi_arch:
             continue
-
-        try:
-            # Use buildx imagetool create for multi-arch support
-            logging.info(f"Creating multi-arch image: {new_image_url}")
+        elif image_exists and not multi_arch:
             logging.info(
-                f"docker buildx imagetools create -t {new_image_url} {image_url}"
+                f"Image {new_image_url} already exists but does not have both arm64 and amd64 architectures."
             )
-            run_command(
-                f"docker buildx imagetools create -t {new_image_url} {image_url}"
-            )
-            logging.info(f"Successfully created multi-arch image: {new_image_url}")
-        except Exception as e:
-            logging.error(
-                f"Failed to create multi-arch image: {new_image_url}. Error: {e}"
-            )
-            exit("Cannot create multi-arch image")
+            exit(f"{new_image_url} does not have both arm64 and amd64 architectures.")
+        else:
+            logging.info(f"Image {new_image_url} does not exist.")
+            exit(f"{new_image_url} does not exist.")
+
+
 
 
 # function to download and push Helm charts

--- a/scripts/upload-artifacts/upload_artifacts.py
+++ b/scripts/upload-artifacts/upload_artifacts.py
@@ -75,8 +75,6 @@ def check_image_exists_and_architectures(image_url):
 
 
 # function to pull and push images
-
-
 def pull_and_push_images(image_list, destination_registry, excluded_registries=[]):
     for image in image_list:
         image_url = image["details"]["registryURL"].strip()
@@ -103,28 +101,8 @@ def pull_and_push_images(image_list, destination_registry, excluded_registries=[
             logging.info("Skipping auto")
             continue
 
-        new_image_url = parse_image_url(image_url, destination_registry)
-
-        # Check if the new_image_url already exists and has both architectures
-        image_exists, multi_arch = check_image_exists_and_architectures(new_image_url)
-
-        if image_exists and multi_arch:
-            continue
-        elif image_exists and not multi_arch:
-            logging.info(
-                f"Image {new_image_url} already exists but does not have both arm64 and amd64 architectures."
-            )
-            exit(f"{new_image_url} does not have both arm64 and amd64 architectures.")
-        else:
-            logging.info(f"Image {new_image_url} does not exist.")
-            exit(f"{new_image_url} does not exist.")
-
-
-
 
 # function to download and push Helm charts
-
-
 def download_and_push_helm_charts(helm_list, destination_registry):
     for helm in helm_list:
         chart = helm["details"]["chart"]


### PR DESCRIPTION
Added `tfy.jfrog.io` to exclude-registries in upload-artifacts (images are already in jfrog no need uploading them again)
Removed `docker buildx imagetools create` step as it doesn't actually create a multi-arch compatible image -https://docs.docker.com/reference/cli/docker/buildx/imagetools/create/#description.

Images from truefoundry should be multi-arch compatible, non multi-arch compatible images would cause artifacts_template_generator to fail except whitelisted. Non multi-arch third party images should be whitelisted (not all images will be arm compatible)