### PR TITLE
Karpenter released to version 1.36

### DIFF
--- a/charts/tfy-karpenter-config/Chart.yaml
+++ b/charts/tfy-karpenter-config/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: tfy-karpenter-config
 description: "ArgoCD Applications for karpenter config"
 type: application
-version: 0.1.35
+version: 0.1.36


### PR DESCRIPTION
Releasing karpenter config with critical nodepool