### PR TITLE
fix: OOM Kill alert considers container restart

### DIFF
--- a/charts/tfy-prometheus-config/templates/prometheusRules/alerting-rules.yaml
+++ b/charts/tfy-prometheus-config/templates/prometheusRules/alerting-rules.yaml
@@ -56,6 +56,8 @@ spec:
     - for: 2m
       expr: >-
         sum by (container, pod, namespace) (sum_over_time(kube_pod_container_status_last_terminated_reason{reason="OOMKilled", job="kube-state-metrics"}[5m])) > 0
+        and
+        max by (container, pod, namespace) (increase(kube_pod_container_status_restarts_total[5m]) > 0)
       alert: ContainerOOMKilled
       labels:
         entity: container

--- a/charts/tfy-prometheus-config/templates/prometheusRules/alerting-rules.yaml
+++ b/charts/tfy-prometheus-config/templates/prometheusRules/alerting-rules.yaml
@@ -55,7 +55,7 @@ spec:
             VALUE = {{`{{ $value }}`}}
     - for: 2m
       expr: >-
-        sum by (container, pod, namespace) (sum_over_time(kube_pod_container_status_last_terminated_reason{reason="OOMKilled", job="kube-state-metrics"}[5m])) > 0
+        max by (container, pod, namespace) (max_over_time(kube_pod_container_status_last_terminated_reason{reason="OOMKilled", job="kube-state-metrics"}[5m])) > 0
         and
         max by (container, pod, namespace) (increase(kube_pod_container_status_restarts_total[5m]) > 0)
       alert: ContainerOOMKilled
@@ -68,7 +68,6 @@ spec:
         description: |-
           Container {{`{{ $labels.container }}`}} in pod {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}}
           has been OOM killed in the last 5 minutes
-            VALUE = {{`{{ $value }}`}} times
     - for: 10m
       expr: >-
         (sum(kubelet_volume_stats_used_bytes{job="kubelet"}) by (persistentvolumeclaim, namespace) /


### PR DESCRIPTION
The `kube_pod_container_status_last_terminated_reason` gives us the reasons of the last terminated container.

If the container restarts due to OOM Kill but then runs succesfully, the metric will continue to report the OOM Kill for the same pod.

Therefore, we need to also consider whether a container restart happened in the last 5 minutes.

The ideal solution is to use the metric -- `container_oom_events_total`, but it reports 0 always[1]. 

1. https://github.com/google/cadvisor/issues/3015