### PR TITLE
Loop fake-toolkit-ready files creation instead of once

### DIFF
--- a/charts/tfy-gpu-operator/Chart.yaml
+++ b/charts/tfy-gpu-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: tfy-gpu-operator
-version: 0.1.29-rc.3
+version: 0.1.29-rc.4
 description: "Truefoundry GPU Operator"
 maintainers:
   - name: truefoundry

--- a/charts/tfy-gpu-operator/templates/fake-toolkit-ready.yaml
+++ b/charts/tfy-gpu-operator/templates/fake-toolkit-ready.yaml
@@ -41,10 +41,12 @@ spec:
           args:
             - |-
               set -ex;
-              touch /run/nvidia/validations/host-driver-ready;
-              touch /run/nvidia/validations/driver-ready;
-              touch /run/nvidia/validations/toolkit-ready;
-              sleep infinity;
+              while true; do
+                touch /run/nvidia/validations/host-driver-ready;
+                touch /run/nvidia/validations/driver-ready;
+                touch /run/nvidia/validations/toolkit-ready;
+                sleep 5;
+              done;
           resources: 
             {{- $fakeToolkitReady.resources | toYaml | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
Some container operating systems can wipe the files on reboot (say for e.g. mig manager forces a reboot) stalling all containers that internally wait for these files to be present