### PR TITLE
Added drift budget explicitly

### DIFF
--- a/charts/tfy-karpenter-config/Chart.yaml
+++ b/charts/tfy-karpenter-config/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: tfy-karpenter-config
 description: "Karpenter resources to manage workloads"
 type: application
-version: 0.1.40
+version: 0.1.41

--- a/charts/tfy-karpenter-config/values.yaml
+++ b/charts/tfy-karpenter-config/values.yaml
@@ -65,7 +65,7 @@ karpenter:
     disruption:
       budgets:
       - nodes: 10%
-      - nodes: 1
+      - nodes: "1"
         reasons:
         - "Drifted"
       consolidateAfter: 15m
@@ -147,7 +147,7 @@ karpenter:
     disruption:
       budgets:
       - nodes: 10%
-      - nodes: 1
+      - nodes: "1"
         reasons:
         - "Drifted"
       consolidateAfter: 5m
@@ -254,7 +254,7 @@ karpenter:
     disruption:
       budgets:
       - nodes: 10%
-      - nodes: 1
+      - nodes: "1"
         reasons:
         - "Drifted"
       consolidateAfter: 15m
@@ -340,7 +340,7 @@ karpenter:
     disruption:
       budgets:
       - nodes: 10%
-      - nodes: 1
+      - nodes: "1"
         reasons:
         - "Drifted"
       consolidateAfter: 15m
@@ -385,7 +385,7 @@ karpenter:
     disruption:
       budgets:
       - nodes: 10%
-      - nodes: 1
+      - nodes: "1"
         reasons:
         - "Drifted"
       consolidateAfter: 15m

--- a/charts/tfy-karpenter-config/values.yaml
+++ b/charts/tfy-karpenter-config/values.yaml
@@ -65,6 +65,9 @@ karpenter:
     disruption:
       budgets:
       - nodes: 10%
+      - nodes: 1
+        reasons:
+        - "Drifted"
       consolidateAfter: 15m
       consolidationPolicy: WhenEmptyOrUnderutilized
     ## @param karpenter.defaultNodePool.capacityTypes [array] Capacity types for the default node pool
@@ -78,7 +81,7 @@ karpenter:
     - amd64
     ## @param karpenter.defaultNodePool.instanceFamilies.notAllowed [array] Not allowed instance families for the default node pool
     instanceFamilies:
-      notAllowed: ["t3", "t2", "t3a", "p2", "p3", "p4d", "p4de", "p5", "p5e", "p5en", "g4dn", "g4ad", "g5", "g6", "gr6", "g6e", "c1", "cc1", "cc2", "cg1", "cg2", "cr1", "g1", "g2", "hi1", "hs1", "m1", "m2", "m3", "g4ad", "inf1", "inf2", "trn1", "trn1n"]
+      notAllowed: ["t3", "t2", "t3a", "p2", "p3", "p4d", "p4de", "p5", "p5e", "p5en", "g4dn", "g4ad", "g5", "g6", "gr6", "g6e", "c1", "cc1", "cc2", "cg1", "cg2", "cr1", "g1", "g2", "hi1", "hs1", "m1", "m2", "m3", "m5a", "m5ad", "r5a" , "r5ad", "g4ad", "inf1", "inf2", "trn1", "trn1n"]
     ## @param karpenter.defaultNodePool.instanceSizes.notAllowed [array] Not allowed instance sizes for the default node pool
     instanceSizes:
       notAllowed: ["nano", "micro", "small", "medium", "large", "metal", "metal-16xl", "metal-24xl", "metal-48xl"]
@@ -144,6 +147,9 @@ karpenter:
     disruption:
       budgets:
       - nodes: 10%
+      - nodes: 1
+        reasons:
+        - "Drifted"
       consolidateAfter: 5m
       consolidationPolicy: WhenEmptyOrUnderutilized
     ## @param karpenter.gpuNodePool.capacityTypes [array] Capacity types for the GPU node pool
@@ -248,6 +254,9 @@ karpenter:
     disruption:
       budgets:
       - nodes: 10%
+      - nodes: 1
+        reasons:
+        - "Drifted"
       consolidateAfter: 15m
       consolidationPolicy: WhenEmptyOrUnderutilized
     ## @param karpenter.controlPlaneNodePool.capacityTypes [array] Capacity types for the control plane node pool
@@ -331,6 +340,9 @@ karpenter:
     disruption:
       budgets:
       - nodes: 10%
+      - nodes: 1
+        reasons:
+        - "Drifted"
       consolidateAfter: 15m
       consolidationPolicy: WhenEmptyOrUnderutilized
     ## @param karpenter.inferentiaNodePool.capacityTypes [array] Capacity types for the Inferentia node pool
@@ -373,6 +385,9 @@ karpenter:
     disruption:
       budgets:
       - nodes: 10%
+      - nodes: 1
+        reasons:
+        - "Drifted"
       consolidateAfter: 15m
       consolidationPolicy: WhenEmptyOrUnderutilized
     ## @param karpenter.critical.capacityTypes [array] Capacity types for the critical node pool


### PR DESCRIPTION
1. Added drift budget to drift 1 node at a time
2. Excluded `m5a, m5ad, r5a, r5ad` instances