### PR TITLE
hl test vector windows

### DIFF
--- a/charts/tfy-logs/templates/_helpers.tpl
+++ b/charts/tfy-logs/templates/_helpers.tpl
@@ -31,6 +31,28 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Common labels
+*/}}
+{{- define "tfy-logs.labels" -}}
+helm.sh/chart: {{ include "tfy-logs.chart" . }}
+{{ include "tfy-logs.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "tfy-logs.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tfy-logs.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+
+
+{{/*
 Labels for resource quotas
 */}}
 {{- define "resource-quotas.labels" -}}

--- a/charts/tfy-logs/templates/windows-vector-daemonset.yaml
+++ b/charts/tfy-logs/templates/windows-vector-daemonset.yaml
@@ -37,6 +37,8 @@ spec:
             - --config-dir
             - /etc/vector/
           env:
+            - name: VECTOR_DATA_DIR
+              value: "C:\\vector-data"
             - name: VECTOR_SELF_NODE_NAME
               valueFrom:
                 fieldRef:

--- a/charts/tfy-logs/templates/windows-vector-daemonset.yaml
+++ b/charts/tfy-logs/templates/windows-vector-daemonset.yaml
@@ -53,13 +53,17 @@ spec:
               mountPath: /etc/vector
               readOnly: true
             - name: var-log
-              mountPath: /var/log
+              mountPath: C:\var\log
               readOnly: true
+            - name: data
+              mountPath: C:\vector-data
       volumes:
         - name: config
           configMap:
             name: vl-config
         - name: var-log
           hostPath:
-            path: /var/log
+            path: C:\var\log
+        - name: data
+          emptyDir: {}
 {{- end }}

--- a/charts/tfy-logs/templates/windows-vector-daemonset.yaml
+++ b/charts/tfy-logs/templates/windows-vector-daemonset.yaml
@@ -34,11 +34,9 @@ spec:
           image: {{ .Values.windowsVector.image.registry }}/{{ .Values.windowsVector.image.repository }}:{{ .Values.windowsVector.image.tag }}
           imagePullPolicy: IfNotPresent
           args:
-            - --config-dir
-            - C:\vector-config
+            - "--config"
+            - "C:\\Program Files\\Vector\\config\\vector.yaml"
           env:
-            - name: VECTOR_DATA_DIR
-              value: "C:\\vector-data"
             - name: VECTOR_SELF_NODE_NAME
               valueFrom:
                 fieldRef:
@@ -51,14 +49,12 @@ spec:
               cpu: 200m
               memory: 200Mi
           volumeMounts:
-            - name: config
-              mountPath: C:\vector-config
-              readOnly: true
-            - name: var-log
-              mountPath: C:\var\log
-              readOnly: true
+            - name: vl-config
+              mountPath: "C:\\Program Files\\Vector\\config"
             - name: data
               mountPath: C:\vector-data
+            - name: var-log
+              mountPath: C:\var\log
       volumes:
         - name: config
           configMap:

--- a/charts/tfy-logs/templates/windows-vector-daemonset.yaml
+++ b/charts/tfy-logs/templates/windows-vector-daemonset.yaml
@@ -35,7 +35,7 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - --config-dir
-            - /etc/vector/
+            - C:\vector-config
           env:
             - name: VECTOR_DATA_DIR
               value: "C:\\vector-data"
@@ -52,7 +52,7 @@ spec:
               memory: 200Mi
           volumeMounts:
             - name: config
-              mountPath: /etc/vector
+              mountPath: C:\vector-config
               readOnly: true
             - name: var-log
               mountPath: C:\var\log

--- a/charts/tfy-logs/templates/windows-vector-daemonset.yaml
+++ b/charts/tfy-logs/templates/windows-vector-daemonset.yaml
@@ -25,11 +25,13 @@ spec:
       tolerations:
         - operator: Exists
       nodeSelector:
-        kubernetes.io/os: windows
-      priorityClassName: system-node-critical
+        {{- toYaml .Values.windowsVector.nodeSelector | nindent 8 }}
+      {{- if .Values.podPriorityClassName }}
+      priorityClassName: {{ .Values.podPriorityClassName }}
+      {{- end }}
       containers:
         - name: vector
-          image: tfy.jfrog.io/tfy-mirror/djboris/vector-windows:0.46.1
+          image: {{ .Values.windowsVector.image.registry }}/{{ .Values.windowsVector.image.repository }}:{{ .Values.windowsVector.image.tag }}
           imagePullPolicy: IfNotPresent
           args:
             - --config-dir

--- a/charts/tfy-logs/templates/windows-vector-daemonset.yaml
+++ b/charts/tfy-logs/templates/windows-vector-daemonset.yaml
@@ -34,9 +34,22 @@ spec:
           image: {{ .Values.windowsVector.image.registry }}/{{ .Values.windowsVector.image.repository }}:{{ .Values.windowsVector.image.tag }}
           imagePullPolicy: IfNotPresent
           args:
-            - "--config"
-            - "C:\\Program Files\\Vector\\config\\vector.yaml"
+            - "-w"
+            - "--config-dir"
+            - "C:\\etc\\vector\\"
           env:
+            - name: VECTOR_LOG
+              value: info
+            - name: VECTOR_SELF_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: VECTOR_SELF_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: VECTOR_SELF_NODE_NAME
               valueFrom:
                 fieldRef:
@@ -50,18 +63,26 @@ spec:
               memory: 200Mi
           volumeMounts:
             - name: config
-              mountPath: "C:\\Program Files\\Vector\\config"
+              mountPath: "C:\\etc\\vector\\"
+              readOnly: true
             - name: data
-              mountPath: C:\vector-data
+              mountPath: "C:\\vector-data-dir"
             - name: var-log
-              mountPath: C:\var\log
+              mountPath: "C:\\var\\log\\"
+              readOnly: true
       volumes:
         - name: config
-          configMap:
-            name: vl-config
+          projected:
+            defaultMode: 420
+            sources:
+              - configMap:
+                  name: vl-config
+        - name: data
+          hostPath:
+            path: "C:\\var\\lib\\vector"
+            type: ""
         - name: var-log
           hostPath:
-            path: C:\var\log
-        - name: data
-          emptyDir: {}
+            path: "C:\\var\\log\\"
+            type: ""
 {{- end }}

--- a/charts/tfy-logs/templates/windows-vector-daemonset.yaml
+++ b/charts/tfy-logs/templates/windows-vector-daemonset.yaml
@@ -58,7 +58,7 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: {{ .Release.Name }}-victoria-logs-single-vector
+            name: vl-config
         - name: var-log
           hostPath:
             path: /var/log

--- a/charts/tfy-logs/templates/windows-vector-daemonset.yaml
+++ b/charts/tfy-logs/templates/windows-vector-daemonset.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.windowsVector.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "tfy-logs.fullname" . }}-windows
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tfy-logs.labels" . | nindent 4 }}
+    app.kubernetes.io/component: vector-windows
+spec:
+  selector:
+    matchLabels:
+      {{- include "tfy-logs.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: vector-windows
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        {{- include "tfy-logs.labels" . | nindent 8 }}
+        app.kubernetes.io/component: vector-windows
+    spec:
+      tolerations:
+        - operator: Exists
+      nodeSelector:
+        kubernetes.io/os: windows
+      priorityClassName: system-node-critical
+      containers:
+        - name: vector
+          image: tfy.jfrog.io/tfy-mirror/djboris/vector-windows:0.46.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config-dir
+            - /etc/vector/
+          env:
+            - name: VECTOR_SELF_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          resources:
+            requests:
+              cpu: 50m
+              memory: 80Mi
+            limits:
+              cpu: 200m
+              memory: 200Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/vector
+              readOnly: true
+            - name: var-log
+              mountPath: /var/log
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: {{ .Release.Name }}-victoria-logs-single-vector
+        - name: var-log
+          hostPath:
+            path: /var/log
+{{- end }}

--- a/charts/tfy-logs/templates/windows-vector-daemonset.yaml
+++ b/charts/tfy-logs/templates/windows-vector-daemonset.yaml
@@ -29,6 +29,8 @@ spec:
       {{- if .Values.podPriorityClassName }}
       priorityClassName: {{ .Values.podPriorityClassName }}
       {{- end }}
+      serviceAccount: {{ include "tfy-logs.fullname" . }}-vector
+      serviceAccountName: {{ include "tfy-logs.fullname" . }}-vector
       containers:
         - name: vector
           image: {{ .Values.windowsVector.image.registry }}/{{ .Values.windowsVector.image.repository }}:{{ .Values.windowsVector.image.tag }}

--- a/charts/tfy-logs/templates/windows-vector-daemonset.yaml
+++ b/charts/tfy-logs/templates/windows-vector-daemonset.yaml
@@ -26,6 +26,10 @@ spec:
         - operator: Exists
       nodeSelector:
         {{- toYaml .Values.windowsVector.nodeSelector | nindent 8 }}
+      {{- if .Values.windowsVector.affinity }}
+      affinity:
+        {{- toYaml .Values.windowsVector.affinity | nindent 8 }}
+      {{- end }}
       {{- if .Values.podPriorityClassName }}
       priorityClassName: {{ .Values.podPriorityClassName }}
       {{- end }}

--- a/charts/tfy-logs/templates/windows-vector-daemonset.yaml
+++ b/charts/tfy-logs/templates/windows-vector-daemonset.yaml
@@ -49,7 +49,7 @@ spec:
               cpu: 200m
               memory: 200Mi
           volumeMounts:
-            - name: vl-config
+            - name: config
               mountPath: "C:\\Program Files\\Vector\\config"
             - name: data
               mountPath: C:\vector-data

--- a/charts/tfy-logs/values.yaml
+++ b/charts/tfy-logs/values.yaml
@@ -134,7 +134,14 @@ victoria-logs-single:
 ##
 windowsVector:
   ## @param windowsVector.enabled Enable Windows Vector daemon set for Windows node log collection
-  enabled: false
+  enabled: true
+  image:
+    registry: tfy.jfrog.io/tfy-mirror
+    repository: djboris/vector-windows
+    tag: 0.46.1
+    pullPolicy: IfNotPresent
+  nodeSelector:
+    kubernetes.io/os: windows
 
 resourceQuota:
   ## @param resourceQuota.enabled Create the ResourceQuota.

--- a/charts/tfy-logs/values.yaml
+++ b/charts/tfy-logs/values.yaml
@@ -53,7 +53,14 @@ victoria-logs-single:
     ## @param victoria-logs-single.vector.enabled Enable vector
     enabled: true
     ## @param victoria-logs-single.vector.affinity Affinity
-    affinity: {}
+    affinity:
+      nodeAffinity:
+        required:
+          nodeSelectorTerm:
+            matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values: ["linux"]
     ## @param victoria-logs-single.vector.tolerations [array] Tolerations
     tolerations:
       - key: node-role.kubernetes.io/master

--- a/charts/tfy-logs/values.yaml
+++ b/charts/tfy-logs/values.yaml
@@ -56,11 +56,12 @@ victoria-logs-single:
     affinity:
       nodeAffinity:
         required:
-          nodeSelectorTerm:
-            matchExpressions:
-              - key: kubernetes.io/os
-                operator: In
-                values: ["linux"]
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                    - linux
     ## @param victoria-logs-single.vector.tolerations [array] Tolerations
     tolerations:
       - key: node-role.kubernetes.io/master

--- a/charts/tfy-logs/values.yaml
+++ b/charts/tfy-logs/values.yaml
@@ -55,11 +55,11 @@ victoria-logs-single:
     ## @param victoria-logs-single.vector.affinity Affinity
     affinity:
       nodeAffinity:
-        required:
+        requiredDuringSchedulingIgnoredDuringExecution:
           nodeSelectorTerms:
             - matchExpressions:
                 - key: kubernetes.io/os
-                  operator: In
+                  operator: In 
                   values:
                     - linux
     ## @param victoria-logs-single.vector.tolerations [array] Tolerations
@@ -150,6 +150,16 @@ windowsVector:
     pullPolicy: IfNotPresent
   nodeSelector:
     kubernetes.io/os: windows
+  ## @param windowsVector.affinity Affinity configuration for Windows Vector pods
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                  - windows
 
 resourceQuota:
   ## @param resourceQuota.enabled Create the ResourceQuota.

--- a/charts/tfy-logs/values.yaml
+++ b/charts/tfy-logs/values.yaml
@@ -130,6 +130,12 @@ victoria-logs-single:
 ## @section resourceQuota Add a ResourceQuota to enable priority class in a namespace.
 ##
 
+## @section Windows Vector configurations
+##
+windowsVector:
+  ## @param windowsVector.enabled Enable Windows Vector daemon set for Windows node log collection
+  enabled: false
+
 resourceQuota:
   ## @param resourceQuota.enabled Create the ResourceQuota.
   enabled: true


### PR DESCRIPTION
- **Add Windows Vector daemon set configuration and common labels**
- **Enable Windows Vector daemon set and update configuration in values.yaml**
- **Update Windows Vector daemon set configuration to use a specific configMap name**
- **Update Windows Vector daemon set to use Windows-style paths for log and data volumes**
- **Add VECTOR_DATA_DIR environment variable to Windows Vector daemon set configuration**
- **Update Windows Vector daemon set to use Windows-style paths for configuration directory**
- **Refactor Windows Vector daemon set configuration to use specific config file path and update volume mounts**
- **test**
- **test**
- **test**
- **Enhance victoria-logs-single configuration with node affinity for Linux nodes**
- **Fix node affinity configuration for victoria-logs-single to use correct YAML structure**
- **Enhance Windows Vector configuration with node affinity for Windows nodes**
