### PR TITLE
tfy-agent: update images and bump chart to 0.2.81

### DIFF
--- a/charts/tfy-agent/Chart.yaml
+++ b/charts/tfy-agent/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.80
+\10.2.81
 
 maintainers:
   - name: truefoundry


### PR DESCRIPTION
Update tfy-agent images to latest SHAs and bump chart version to 0.2.81.

- tfyAgent.image.tag: N/A -> 2618fdfb58371b083c8eacabc4afba4b66c8696e
- tfyAgentProxy.image.tag: N/A -> 9b1cee43f0aae843c11bcc97c4d1e7f565d913dd