### PR TITLE
Add KMS key support for EBS volume encryption in Karpenter templates

### DIFF
--- a/charts/tfy-karpenter-config/templates/controlplane/karpenter-control-plane-ec2nodeclass.yaml
+++ b/charts/tfy-karpenter-config/templates/controlplane/karpenter-control-plane-ec2nodeclass.yaml
@@ -57,6 +57,9 @@ spec:
         volumeType: gp3
         deleteOnTermination: true
         encrypted: {{ .Values.karpenter.controlPlaneNodeTemplate.encrypted }}
+        {{- if .Values.karpenter.controlPlaneNodeTemplate.kmsKeyID }}
+        kmsKeyID: {{ .Values.karpenter.controlPlaneNodeTemplate.kmsKeyID }}
+        {{- end }}
   {{- if not (eq .Values.karpenter.controlPlaneNodeTemplate.userData "")}}
   userData: {{- .Values.karpenter.controlPlaneNodeTemplate.userData | toYaml | indent 2 }}
   {{- end }}

--- a/charts/tfy-karpenter-config/templates/critical/karpenter-critical-ec2nodeclass.yaml
+++ b/charts/tfy-karpenter-config/templates/critical/karpenter-critical-ec2nodeclass.yaml
@@ -57,6 +57,9 @@ spec:
         volumeType: gp3
         deleteOnTermination: true
         encrypted: {{ .Values.karpenter.critical.nodeclass.encrypted }}
+        {{- if .Values.karpenter.critical.nodeclass.kmsKeyID }}
+        kmsKeyID: {{ .Values.karpenter.critical.nodeclass.kmsKeyID }}
+        {{- end }}
   {{- if not (eq .Values.karpenter.critical.nodeclass.userData "")}}
   userData: {{- .Values.karpenter.critical.nodeclass.userData | toYaml | indent 2 }}
   {{- end }}

--- a/charts/tfy-karpenter-config/templates/default/karpenter-default-ec2nodeclass.yaml
+++ b/charts/tfy-karpenter-config/templates/default/karpenter-default-ec2nodeclass.yaml
@@ -56,6 +56,9 @@ spec:
         volumeType: gp3
         deleteOnTermination: true
         encrypted: {{ .Values.karpenter.defaultNodeTemplate.encrypted }}
+        {{- if .Values.karpenter.defaultNodeTemplate.kmsKeyID }}
+        kmsKeyID: {{ .Values.karpenter.defaultNodeTemplate.kmsKeyID }}
+        {{- end }}
   {{- if and (.Values.karpenter.defaultNodeTemplate.enableSoci) (eq (include "defaultNodeTemplate.inferredAmiFamily" .) "al2023") }}
   userData: |
   {{- .Files.Get "files/al2023-soci-default-provisioner-userdata.sh" | nindent 4 }}

--- a/charts/tfy-karpenter-config/templates/gpu/karpenter-gpu-default-ec2nodeclass.yaml
+++ b/charts/tfy-karpenter-config/templates/gpu/karpenter-gpu-default-ec2nodeclass.yaml
@@ -56,6 +56,9 @@ spec:
         volumeType: gp3
         deleteOnTermination: true
         encrypted: {{ .Values.karpenter.gpuDefaultNodeTemplate.encrypted }}
+        {{- if .Values.karpenter.gpuDefaultNodeTemplate.kmsKeyID }}
+        kmsKeyID: {{ .Values.karpenter.gpuDefaultNodeTemplate.kmsKeyID }}
+        {{- end }}
   {{- if (eq (include "gpuDefaultNodeTemplate.inferredAmiFamily" .) "al2") }}
   {{- if .Values.karpenter.gpuDefaultNodeTemplate.enableSoci }}
   userData: |

--- a/charts/tfy-karpenter-config/templates/inferentia/karpenter-inferentia-default-ec2nodeclass.yaml
+++ b/charts/tfy-karpenter-config/templates/inferentia/karpenter-inferentia-default-ec2nodeclass.yaml
@@ -55,6 +55,9 @@ spec:
         volumeType: gp3
         deleteOnTermination: true
         encrypted: {{ .Values.karpenter.inferentiaDefaultNodeTemplate.encrypted }}
+        {{- if .Values.karpenter.inferentiaDefaultNodeTemplate.kmsKeyID }}
+        kmsKeyID: {{ .Values.karpenter.inferentiaDefaultNodeTemplate.kmsKeyID }}
+        {{- end }}
   {{- if not (eq .Values.karpenter.inferentiaDefaultNodeTemplate.userData "")}}
   userData: {{- .Values.karpenter.inferentiaDefaultNodeTemplate.userData | toYaml | indent 2 }}
   {{- end }}

--- a/charts/tfy-karpenter-config/values.yaml
+++ b/charts/tfy-karpenter-config/values.yaml
@@ -22,6 +22,8 @@ karpenter:
     rootVolumeSize: 100Gi
     ## @param karpenter.defaultNodeTemplate.encrypted Encryption for EBS volumes
     encrypted: true
+    ## @param karpenter.defaultNodeTemplate.kmsKeyID KMS key ARN for EBS volume encryption. Leave empty to use AWS default key.
+    kmsKeyID: ""
     ## @param karpenter.defaultNodeTemplate.extraTags [object] Additional tags for the node template.
     extraTags: {}
     ## @param karpenter.defaultNodeTemplate.amiFamily AMI family to use for node template
@@ -104,6 +106,8 @@ karpenter:
     rootVolumeSize: 100Gi
     ## @param karpenter.gpuDefaultNodeTemplate.encrypted Encryption for EBS volumes
     encrypted: true
+    ## @param karpenter.gpuDefaultNodeTemplate.kmsKeyID KMS key ARN for EBS volume encryption. Leave empty to use AWS default key.
+    kmsKeyID: ""
     ## @param karpenter.gpuDefaultNodeTemplate.extraTags [object] Additional tags for the gpu node template.
     extraTags: {}
     ## @param karpenter.gpuDefaultNodeTemplate.detailedMonitoring Set this to true to enable EC2 detailed cloudwatch monitoring.
@@ -211,6 +215,8 @@ karpenter:
     rootVolumeSize: 100Gi
     ## @param karpenter.controlPlaneNodeTemplate.encrypted Encryption for EBS volumes
     encrypted: true
+    ## @param karpenter.controlPlaneNodeTemplate.kmsKeyID KMS key ARN for EBS volume encryption. Leave empty to use AWS default key.
+    kmsKeyID: ""
     ## @param karpenter.controlPlaneNodeTemplate.extraTags [object] Additional tags for the node template.
     extraTags: {}
     ## @param karpenter.controlPlaneNodeTemplate.amiFamily AMI family to use for node template
@@ -301,6 +307,8 @@ karpenter:
     rootVolumeSize: 100Gi
     ## @param karpenter.inferentiaDefaultNodeTemplate.encrypted Encryption for EBS volumes
     encrypted: true
+    ## @param karpenter.inferentiaDefaultNodeTemplate.kmsKeyID KMS key ARN for EBS volume encryption. Leave empty to use AWS default key.
+    kmsKeyID: ""
     ## @param karpenter.inferentiaDefaultNodeTemplate.extraTags [object] Additional tags for the node template.
     extraTags: {}
     ## @param karpenter.inferentiaDefaultNodeTemplate.detailedMonitoring Set this to true to enable EC2 detailed cloudwatch monitoring
@@ -430,6 +438,8 @@ karpenter:
       rootVolumeSize: 100Gi
       ## @param karpenter.critical.nodeclass.encrypted Encryption for EBS volumes
       encrypted: true
+      ## @param karpenter.critical.nodeclass.kmsKeyID KMS key ARN for EBS volume encryption. Leave empty to use AWS default key.
+      kmsKeyID: ""
       ## @param karpenter.critical.nodeclass.extraTags [object] Additional tags for the node template.
       extraTags: {}
       ## @param karpenter.critical.nodeclass.detailedMonitoring Set this to true to enable EC2 detailed cloudwatch monitoring.


### PR DESCRIPTION
- Introduced `kmsKeyID` parameter for EBS volume encryption in the values.yaml file for various node templates (default, GPU, inferentia, control plane, and critical).
- Updated corresponding templates to conditionally include the `kmsKeyID` in the EC2 node class specifications.

This enhancement allows users to specify a custom KMS key for EBS encryption, improving security and compliance options.
