### PR TITLE
Add podSecurityContext and containerSecurityContext to proxy helm chart

### DIFF
--- a/charts/tfy-squid-proxy/README.md
+++ b/charts/tfy-squid-proxy/README.md
@@ -48,4 +48,6 @@ Tfy-squid-proxy is a Helm chart that facilitates the deployment and management o
 | `tolerations`                                | Tolerations                                                    | `[]`                      |
 | `affinity`                                   | Affinity                                                       | `{}`                      |
 | `nodeSelector`                               | Node selector                                                  | `{}`                      |
+| `containerSecurityContext`                   | Container Security Context                                     | `{}`                      |
+| `podSecurityContext`                         | Pod Security Context                                           | `{}`                      |
 

--- a/charts/tfy-squid-proxy/templates/_helpers.tpl
+++ b/charts/tfy-squid-proxy/templates/_helpers.tpl
@@ -245,3 +245,25 @@ Node Selector for tfy-squid-proxy deployment
 []
 {{- end }}
 {{- end }}
+
+{{/*
+Container Security Context for tfy-squid-proxy deployment
+*/}}
+{{- define "tfy-squid-proxy.containerSecurityContext" -}}
+{{- if .Values.containerSecurityContext -}}
+{{- toYaml .Values.containerSecurityContext }}
+{{- else -}}
+{}
+{{- end }}
+{{- end }}
+
+{{/*
+Pod Security Context for tfy-squid-proxy deployment
+*/}}
+{{- define "tfy-squid-proxy.podSecurityContext" -}}
+{{- if .Values.podSecurityContext -}}
+{{- toYaml .Values.podSecurityContext }}
+{{- else -}}
+{}
+{{- end }}
+{{- end }}

--- a/charts/tfy-squid-proxy/templates/deployment.yaml
+++ b/charts/tfy-squid-proxy/templates/deployment.yaml
@@ -44,8 +44,11 @@ spec:
               subPath: squid.conf
           resources:
             {{- include "tfy-squid-proxy.resources" . | nindent 12 }}
+          securityContext:
+            {{- include "tfy-squid-proxy.containerSecurityContext" . | nindent 12 }}
       volumes:
         - name: squid-config
           configMap:
             name: {{ include "tfy-squid-proxy.fullname" . }}-squid-proxy-config
-
+      securityContext:
+        {{- include "tfy-squid-proxy.podSecurityContext" . | nindent 8 }}

--- a/charts/tfy-squid-proxy/values.yaml
+++ b/charts/tfy-squid-proxy/values.yaml
@@ -115,3 +115,9 @@ affinity: {}
 
 ## @param nodeSelector [object] Node selector
 nodeSelector: {}
+
+## @param containerSecurityContext [object] Container Security Context
+containerSecurityContext: {}
+
+## @param podSecurityContext [object] Pod Security Context
+podSecurityContext: {}


### PR DESCRIPTION
This PR extends the try-squid-proxy chart to expose the different security contexts in values.yml.
Feedback welcome.

Here is how I use it to run as non-root and log directly to /dev/stdout.


```
# https://github.com/truefoundry/infra-charts/tree/main/charts/tfy-squid-proxy
---
fullnameOverride: 'outgoing'

global:
  resourceTier: small

config: |
  # ------------------------
  # Listens on 3128
  # ------------------------
  http_port 3128

  # Write pid to a location writable by the proxy user
  pid_filename /tmp/squid.pid

  # No caching
  cache deny all

  # Allow all by default
  http_access allow all

  # Log to stdout in custom format
  logformat custom %ts.%03tu %6tr %>A %Ss/%03>Hs %<st %rm %ru %[un %Sh/%<a %mt
  access_log stdio:/dev/stdout custom

containerSecurityContext:
  allowPrivilegeEscalation: false
  capabilities:
    drop:
      - ALL
  readOnlyRootFilesystem: false

podSecurityContext:
  runAsGroup: 0
  runAsNonRoot: true
  runAsUser: 13 # pid of 'proxy' user in the image
  seccompProfile:
    type: RuntimeDefault
```
