### PR TITLE
feat: security context in tfy-llm-gateway and tfy-otel-collector charts

### DIFF
--- a/charts/tfy-llm-gateway/values.yaml
+++ b/charts/tfy-llm-gateway/values.yaml
@@ -97,8 +97,10 @@ nameOverride: ""
 podAnnotations: {}
 ## @param commonAnnotations Common annotations
 commonAnnotations: {}
-## @param podSecurityContext Pod security context
-podSecurityContext: {}
+## @param podSecurityContext [object] Pod security context
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1001
 ## @param commonLabels Common labels
 commonLabels: {}
 ## @param podLabels Pod annotations
@@ -107,8 +109,13 @@ podLabels: {}
 deploymentLabels: {}
 ## @param deploymentAnnotations Deployment annotations
 deploymentAnnotations: {}
-## @param securityContext Security context configuration
-securityContext: {}
+## @param securityContext [object] Security context configuration
+securityContext:
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
 ## @param imagePullSecrets [array] Image pull secrets
 imagePullSecrets: []
 ## Healthcheck configuration

--- a/charts/tfy-otel-collector/templates/_helpers.tpl
+++ b/charts/tfy-otel-collector/templates/_helpers.tpl
@@ -254,9 +254,22 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Deployment Volumes
 */}}
 {{- define "tfy-otel-collector.volumes" -}}
+{{- $tier := .Values.global.resourceTier | default "medium" }}
+{{- $ephemeralLimit := "1024Mi" }}
+{{- if eq $tier "small" }}
+  {{- $ephemeralLimit = "512Mi" }}
+{{- else if eq $tier "large" }}
+  {{- $ephemeralLimit = "2048Mi" }}
+{{- end }}
+{{- if and .Values.resources .Values.resources.limits (index .Values.resources.limits "ephemeral-storage") }}
+  {{- $ephemeralLimit = index .Values.resources.limits "ephemeral-storage" }}
+{{- end }}
 - name: config-volume
   configMap:
     name: {{ include "tfy-otel-collector.fullname" . }}-cm
+- name: tmp-dir
+  emptyDir:
+    sizeLimit: {{ $ephemeralLimit }}
 {{- with .Values.extraVolumes }}
 {{- toYaml . | nindent 0 }}
 {{- end }}
@@ -270,6 +283,8 @@ Deployment VolumeMounts
   mountPath: /data/config.yaml
   readOnly: true
   subPath: config.yaml
+- name: tmp-dir
+  mountPath: /tmp
 {{- with .Values.extraVolumeMounts }}
 {{- toYaml . | nindent 0 }}
 {{- end }}

--- a/charts/tfy-otel-collector/values.yaml
+++ b/charts/tfy-otel-collector/values.yaml
@@ -96,7 +96,9 @@ podAnnotations: {}
 ## @param commonAnnotations Common annotations
 commonAnnotations: {}
 ## @param podSecurityContext [object] Pod security context
-podSecurityContext: {}
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1001
 ## @param commonLabels [object] Common labels
 commonLabels: {}
 ## @param podLabels [object] Pod annotations
@@ -105,8 +107,13 @@ podLabels: {}
 deploymentAnnotations: {}
 ## @param deploymentLabels [object] Deployment labels
 deploymentLabels: {}
-## @param securityContext Security context configuration
-securityContext: {}
+## @param securityContext [object] Security context configuration
+securityContext:
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
 ## Healthcheck configuration
 healthcheck:
   ## @param healthcheck.enabled Enable healthcheck


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Applies stricter pod/container security defaults (non-root, read-only root FS, dropped capabilities), which can break workloads that still need root or filesystem writes at runtime.
> 
> **Overview**
> **Hardens the default security posture** of the `tfy-llm-gateway` and `tfy-otel-collector` Helm charts by setting `podSecurityContext` to run as non-root (`runAsUser: 1001`) and adding a restrictive container `securityContext` (drop all capabilities, `readOnlyRootFilesystem`, and `allowPrivilegeEscalation: false`).
> 
> For `tfy-otel-collector`, adds an explicit `/tmp` `emptyDir` mount with a size limit derived from `global.resourceTier` (or overridden by `resources.limits.ephemeral-storage`) to support writable temp space under a read-only root filesystem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e13331866ae7fb4719a62ebc297e107eabf3a926. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->