### PR TITLE
add: tmp emptydir for llmgateway

### DIFF
--- a/charts/tfy-llm-gateway/templates/_helpers.tpl
+++ b/charts/tfy-llm-gateway/templates/_helpers.tpl
@@ -322,6 +322,18 @@ limits:
   ephemeral-storage: 512Mi
 {{- end }}
 
+{{- define "tfy-llm-gateway.ephemeralStorage.limit" }}
+{{- $tier := .Values.global.resourceTier | default "medium" }}
+{{- $ephemeralLimit := "512Mi" }}
+{{- if eq $tier "small" }}
+  {{- $ephemeralLimit = "256Mi" }}
+{{- end }}
+{{- if and .Values.resources .Values.resources.limits (index .Values.resources.limits "ephemeral-storage") }}
+  {{- $ephemeralLimit = index .Values.resources.limits "ephemeral-storage" }}
+{{- end }}
+{{- $ephemeralLimit }}
+{{- end }}
+
 {{- define "tfy-llm-gateway.resources" }}
 {{- $tier := .Values.global.resourceTier | default "medium" }}
 

--- a/charts/tfy-llm-gateway/templates/deployment.yaml
+++ b/charts/tfy-llm-gateway/templates/deployment.yaml
@@ -84,6 +84,8 @@ spec:
             failureThreshold: {{ .Values.healthcheck.readiness.failureThreshold | default 3 }}
           {{- end }}
           volumeMounts:
+          - name: tmp-dir
+            mountPath: /tmp
           {{- if gt (len .Values.extraVolumeMounts) 0 }}
           {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
           {{- end }}
@@ -98,6 +100,9 @@ spec:
       imagePullSecrets:
         {{- include "tfy-llm-gateway.imagePullSecrets" . | nindent 8 }}
       volumes:
+      - name: tmp-dir
+        emptyDir:
+          sizeLimit: {{ include "tfy-llm-gateway.ephemeralStorage.limit" . }}
       {{- if gt (len .Values.extraVolumes) 0 }}
       {{- toYaml .Values.extraVolumes | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the `tfy-llm-gateway` Deployment’s filesystem layout and ephemeral storage limits by adding a sized `/tmp` `emptyDir`, which could affect pods that rely on node ephemeral storage or need larger temp space. Misconfigured limits may lead to write failures or evictions under load.
> 
> **Overview**
> Adds a dedicated `/tmp` `emptyDir` volume to the `tfy-llm-gateway` Deployment and mounts it into the main container.
> 
> Introduces a new Helm helper `tfy-llm-gateway.ephemeralStorage.limit` to set the `emptyDir.sizeLimit` based on `global.resourceTier` (with an override from `resources.limits.ephemeral-storage`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9aa7afac312022d0b624ee5c77db76abde7b40a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->