### PR TITLE
Added tfy-nats-ui chart as an dependency in tfy monitoring chart

### DIFF
--- a/charts/truefoundry-monitoring/Chart.yaml
+++ b/charts/truefoundry-monitoring/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: truefoundry-monitoring
 description: Monitoring stack for TrueFoundry control plane - Prometheus, Logs, and Grafana
-version: 0.1.3
+version: 0.1.4
 maintainers:
   - name: truefoundry
 dependencies:
@@ -19,3 +19,8 @@ dependencies:
     version: 10.4.0
     repository: https://grafana.github.io/helm-charts
     condition: grafana.enabled
+  - name: tfy-nats-ui
+    version: 0.1.0
+    repository: https://truefoundry.github.io/infra-charts/
+    alias: tfyNatsUi
+    condition: tfyNatsUi.enabled

--- a/charts/truefoundry-monitoring/README.md
+++ b/charts/truefoundry-monitoring/README.md
@@ -109,3 +109,25 @@ This Helm chart package, provided by TrueFoundry, contains the components needed
 | `grafana.affinity`                                              | Affinity for Grafana pods                                        | `{}`                                      |
 | `grafana.tolerations`                                           | Tolerations for Grafana pods                                     | `[]`                                      |
 | `grafana.nodeSelector`                                          | Node selector for Grafana pods                                   | `{}`                                      |
+
+### tfy-nats-ui (NATS UI dashboard) configuration
+
+| Name                               | Description                                                                        | Value                                      |
+| ---------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------ |
+| `tfyNatsUi.enabled`                | Enable tfy-nats-ui                                                                 | `true`                                     |
+| `tfyNatsUi.nameOverride`           | Override the component name used in labels and the Deployment name                 | `""`                                       |
+| `tfyNatsUi.fullnameOverride`       | If set, overrides the Deployment full name (leave empty for <release>-tfy-nats-ui) | `""`                                       |
+| `tfyNatsUi.replicaCount`           | Number of replicas                                                                 | `1`                                        |
+| `tfyNatsUi.imagePullPolicy`        | Image pull policy                                                                  | `IfNotPresent`                             |
+| `tfyNatsUi.imagePullSecrets`       | Image pull secrets for this workload                                               | `[]`                                       |
+| `tfyNatsUi.envSecretName`          | Secret name for shorthand ${k8s-secret/<key>} entries in env                       | `""`                                       |
+| `tfyNatsUi.natsUrl`                | Value for NATS_URL when env is empty                                               | `http://{{ .Release.Name }}-tfy-nats:4222` |
+| `tfyNatsUi.accountSeedSecret.name` | Existing Secret name when env is empty                                             | `truefoundry-tfy-nats-secret`              |
+| `tfyNatsUi.accountSeedSecret.key`  | Key inside the Secret                                                              | `NATS_CONTROLPLANE_ACCOUNT_SEED`           |
+| `tfyNatsUi.extraEnv`               | Extra environment variables for the container                                      | `[]`                                       |
+| `tfyNatsUi.resources`              | Container resources                                                                | `{}`                                       |
+| `tfyNatsUi.podSecurityContext`     | Pod security context                                                               | `{}`                                       |
+| `tfyNatsUi.securityContext`        | Container security context                                                         | `{}`                                       |
+| `tfyNatsUi.nodeSelector`           | Node selector                                                                      | `{}`                                       |
+| `tfyNatsUi.tolerations`            | Tolerations                                                                        | `[]`                                       |
+| `tfyNatsUi.affinity`               | Affinity                                                                           | `{}`                                       |

--- a/charts/truefoundry-monitoring/values.yaml
+++ b/charts/truefoundry-monitoring/values.yaml
@@ -403,3 +403,44 @@ grafana:
   tolerations: []
   ## @param grafana.nodeSelector [object] Node selector for Grafana pods
   nodeSelector: {}
+
+## =============================================================================
+## @section tfy-nats-ui (NATS UI dashboard) configuration
+## NATS control plane UI subchart. See charts/tfy-nats-ui for template details.
+## =============================================================================
+tfyNatsUi:
+  ## @param tfyNatsUi.enabled Enable tfy-nats-ui
+  enabled: true
+  ## @param tfyNatsUi.nameOverride Override the component name used in labels and the Deployment name
+  nameOverride: ""
+  ## @param tfyNatsUi.fullnameOverride If set, overrides the Deployment full name (leave empty for <release>-tfy-nats-ui)
+  fullnameOverride: ""
+  ## @param tfyNatsUi.replicaCount Number of replicas
+  replicaCount: 1
+  ## @param tfyNatsUi.imagePullPolicy Image pull policy
+  imagePullPolicy: IfNotPresent
+  ## @param tfyNatsUi.imagePullSecrets [array] Image pull secrets for this workload
+  imagePullSecrets: []
+  ## @param tfyNatsUi.envSecretName Secret name for shorthand ${k8s-secret/<key>} entries in env
+  envSecretName: ""
+  ## @param tfyNatsUi.natsUrl Value for NATS_URL when env is empty
+  natsUrl: "http://{{ .Release.Name }}-tfy-nats:4222"
+  ## @param tfyNatsUi.accountSeedSecret.name Existing Secret name when env is empty
+  ## @param tfyNatsUi.accountSeedSecret.key Key inside the Secret
+  accountSeedSecret:
+    name: "truefoundry-tfy-nats-secret"
+    key: NATS_CONTROLPLANE_ACCOUNT_SEED
+  ## @param tfyNatsUi.extraEnv [array] Extra environment variables for the container
+  extraEnv: []
+  ## @param tfyNatsUi.resources [object] Container resources
+  resources: {}
+  ## @param tfyNatsUi.podSecurityContext [object] Pod security context
+  podSecurityContext: {}
+  ## @param tfyNatsUi.securityContext [object] Container security context
+  securityContext: {}
+  ## @param tfyNatsUi.nodeSelector [object] Node selector
+  nodeSelector: {}
+  ## @param tfyNatsUi.tolerations [array] Tolerations
+  tolerations: []
+  ## @param tfyNatsUi.affinity [object] Affinity
+  affinity: {}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because this introduces a new subchart that is enabled by default, changing what gets deployed and requiring a NATS URL/seed secret to be valid. Upgrade impact is mostly operational (additional workloads/values), not code-path logic changes.
> 
> **Overview**
> **Extends the `truefoundry-monitoring` Helm chart to optionally deploy the NATS control-plane UI.**
> 
> Bumps the chart version to `0.1.4`, adds `tfy-nats-ui` (`0.1.0`) as a dependency gated by `tfyNatsUi.enabled`, and introduces a new `tfyNatsUi` values section (NATS URL + seed secret refs, env/resources/scheduling knobs) with corresponding README parameter documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5f46b22f5f4cf5fda31c6dda51c99a3c8f591a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->