### PR TITLE
chore(infra-automation): bump pinned tool versions in pre-requisites

### DIFF
--- a/scripts/infra-automation/pre-requisites.sh
+++ b/scripts/infra-automation/pre-requisites.sh
@@ -40,14 +40,14 @@ EOF
 # Get required version for a tool
 get_tool_required_version() {
     case $1 in
-        terraform) echo "1.10.1" ;;
-        tofu) echo "1.10.6" ;;
-        kubectl) echo "1.31.8" ;;
-        helm) echo "3.17.3" ;;
-        jq) echo "1.7.1" ;;
-        aws) echo "2.17.0" ;;
-        gcloud) echo "500.0.0" ;;
-        az) echo "2.67.0" ;;
+        terraform) echo "1.14.8" ;;
+        tofu) echo "1.11.6" ;;
+        kubectl) echo "1.35.3" ;;
+        helm) echo "4.1.4" ;;
+        jq) echo "1.8.1" ;;
+        aws) echo "2.34.32" ;;
+        gcloud) echo "565.0.0" ;;
+        az) echo "2.85.0" ;;
         gke-gcloud-auth-plugin) echo "0.0.1" ;;
         *) echo "0.0.0" ;;  # Default case
     esac


### PR DESCRIPTION
## Summary
- Bumps the required/pinned tool versions in `scripts/infra-automation/pre-requisites.sh` (`get_tool_required_version`) to the current latest upstream releases.

| Tool | Before | After |
|------|--------|-------|
| terraform | 1.10.1 | 1.14.8 |
| tofu | 1.10.6 | 1.11.6 |
| kubectl | 1.31.8 | 1.35.3 |
| helm | 3.17.3 | 4.1.4 |
| jq | 1.7.1 | 1.8.1 |
| aws | 2.17.0 | 2.34.32 |
| gcloud | 500.0.0 | 565.0.0 |
| az | 2.67.0 | 2.85.0 |

`gke-gcloud-auth-plugin` is unchanged — its version check is intentionally skipped in the script.

Note: `helm 4.x` is a major version bump from `3.17.3`. Confirm downstream workflows/docs are compatible with Helm 4 before merging.

## Test plan
- [ ] Run `scripts/infra-automation/pre-requisites.sh` locally with each provider (aws/gcp/azure) and verify version checks behave as expected.
- [ ] Verify Helm 4 compatibility with existing charts in this repo (or downgrade the helm pin if Helm 3 is still required).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the minimum/pinned versions for core infra tooling (notably a major bump to `helm` 4.x), which could break existing scripts/charts or CI environments that rely on older CLI behavior.
> 
> **Overview**
> Updates `scripts/infra-automation/pre-requisites.sh` to require newer versions of the pinned tooling used by infra automation.
> 
> The `get_tool_required_version` pins are bumped for `terraform`, `tofu`, `kubectl`, `helm` (to 4.x), `jq`, `aws`, `gcloud`, and `az`, which will drive stricter version checks and trigger upgrades/installs when the script runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e64a01bd41de517efb5d12682648f9ae2f15a18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->