### PR TITLE
Add sec ctx enable toggle

### DIFF
--- a/charts/tfy-llm-gateway/templates/_helpers.tpl
+++ b/charts/tfy-llm-gateway/templates/_helpers.tpl
@@ -463,9 +463,11 @@ false
 {{- if eq (include "tfy-llm-gateway.customCA.useDirectMount" .) "false" }}
 - name: configure-custom-ca
   image: "{{ .Values.global.customCA.image.registry | default .Values.global.image.registry }}/{{ .Values.global.customCA.image.repository }}:{{ .Values.global.customCA.image.tag }}"
+  {{- if .Values.global.customCA.securityContext.enabled }}
   {{- with .Values.global.customCA.securityContext }}
   securityContext:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml (omit . "enabled") | nindent 4 }}
+  {{- end }}
   {{- end }}
   command: ["sh", "-c"]
   args:

--- a/charts/tfy-llm-gateway/templates/deployment.yaml
+++ b/charts/tfy-llm-gateway/templates/deployment.yaml
@@ -37,8 +37,10 @@ spec:
         {{- toYaml .Values.dnsConfig | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "tfy-llm-gateway.serviceAccountName" . }}
+      {{- if .Values.podSecurityContext.enabled }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml (omit .Values.podSecurityContext "enabled") | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 30 }}
       {{- if or .Values.initContainers (and .Values.global.customCA.enabled (eq (include "tfy-llm-gateway.customCA.useDirectMount" .) "false")) }}
       initContainers:
@@ -51,8 +53,10 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- if .Values.securityContext.enabled }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml (omit .Values.securityContext "enabled") | nindent 12 }}
+          {{- end }}
           env:
             {{- include "tfy-llm-gateway.env" . | trim | nindent 12 }}
           image: "{{ .Values.image.registry | default .Values.global.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/tfy-llm-gateway/values.yaml
+++ b/charts/tfy-llm-gateway/values.yaml
@@ -120,7 +120,7 @@ nameOverride: ""
 podAnnotations: {}
 ## @param commonAnnotations Common annotations
 commonAnnotations: {}
-## podSecurityContext Pod security context
+## @param podSecurityContext [object] Pod security context
 podSecurityContext:
   enabled: true
   runAsNonRoot: true
@@ -133,7 +133,7 @@ podLabels: {}
 deploymentLabels: {}
 ## @param deploymentAnnotations Deployment annotations
 deploymentAnnotations: {}
-## securityContext Security context configuration
+## @param securityContext [object] Security context configuration
 securityContext:
   enabled: true
   capabilities:

--- a/charts/tfy-llm-gateway/values.yaml
+++ b/charts/tfy-llm-gateway/values.yaml
@@ -79,6 +79,7 @@ global:
         sizeLimit: ""
     ## @param global.customCA.securityContext [object] Security context for the custom CA initContainer.
     securityContext:
+      enabled: true
       readOnlyRootFilesystem: true
       allowPrivilegeEscalation: false
       capabilities:
@@ -117,8 +118,9 @@ nameOverride: ""
 podAnnotations: {}
 ## @param commonAnnotations Common annotations
 commonAnnotations: {}
-## @param podSecurityContext [object] Pod security context
+## podSecurityContext Pod security context
 podSecurityContext:
+  enabled: true
   runAsNonRoot: true
   runAsUser: 1001
 ## @param commonLabels Common labels
@@ -129,8 +131,9 @@ podLabels: {}
 deploymentLabels: {}
 ## @param deploymentAnnotations Deployment annotations
 deploymentAnnotations: {}
-## @param securityContext [object] Security context configuration
+## securityContext Security context configuration
 securityContext:
+  enabled: true
   capabilities:
     drop:
       - ALL

--- a/charts/tfy-llm-gateway/values.yaml
+++ b/charts/tfy-llm-gateway/values.yaml
@@ -80,6 +80,8 @@ global:
     ## @param global.customCA.securityContext [object] Security context for the custom CA initContainer.
     securityContext:
       enabled: true
+      runAsUser: 1001
+      runAsGroup: 1001
       readOnlyRootFilesystem: true
       allowPrivilegeEscalation: false
       capabilities:

--- a/charts/tfy-otel-collector/templates/_helpers.tpl
+++ b/charts/tfy-otel-collector/templates/_helpers.tpl
@@ -476,9 +476,11 @@ false
 {{- if eq (include "tfy-otel-collector.customCA.useDirectMount" .) "false" }}
 - name: configure-custom-ca
   image: "{{ .Values.global.customCA.image.registry | default .Values.global.image.registry }}/{{ .Values.global.customCA.image.repository }}:{{ .Values.global.customCA.image.tag }}"
+  {{- if .Values.global.customCA.securityContext.enabled }}
   {{- with .Values.global.customCA.securityContext }}
   securityContext:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml (omit . "enabled") | nindent 4 }}
+  {{- end }}
   {{- end }}
   command: ["sh", "-c"]
   args:

--- a/charts/tfy-otel-collector/templates/deployment.yaml
+++ b/charts/tfy-otel-collector/templates/deployment.yaml
@@ -29,8 +29,10 @@ spec:
         {{- include "tfy-otel-collector.podLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "tfy-otel-collector.serviceAccountName" . }}
+      {{- if .Values.podSecurityContext.enabled }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml (omit .Values.podSecurityContext "enabled") | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 30 }}
       {{- $initContainers := include "tfy-otel-collector.customCA.initContainer" . | trim }}
       {{- if $initContainers }}
@@ -39,8 +41,10 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- if .Values.securityContext.enabled }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml (omit .Values.securityContext "enabled") | nindent 12 }}
+          {{- end }}
           env:
             {{- include "tfy-otel-collector.env" . | trim | nindent 12 }}
           args: ["--config", "/data/config.yaml"]

--- a/charts/tfy-otel-collector/values.yaml
+++ b/charts/tfy-otel-collector/values.yaml
@@ -67,6 +67,8 @@ global:
     ## @param global.customCA.securityContext [object] Security context for the custom CA initContainer.
     securityContext:
       enabled: true
+      runAsUser: 1001
+      runAsGroup: 1001
       readOnlyRootFilesystem: true
       allowPrivilegeEscalation: false
       capabilities:

--- a/charts/tfy-otel-collector/values.yaml
+++ b/charts/tfy-otel-collector/values.yaml
@@ -66,6 +66,7 @@ global:
         sizeLimit: ""
     ## @param global.customCA.securityContext [object] Security context for the custom CA initContainer.
     securityContext:
+      enabled: true
       readOnlyRootFilesystem: true
       allowPrivilegeEscalation: false
       capabilities:
@@ -135,6 +136,7 @@ podAnnotations: {}
 commonAnnotations: {}
 ## @param podSecurityContext [object] Pod security context
 podSecurityContext:
+  enabled: true
   runAsNonRoot: true
   runAsUser: 1001
 ## @param commonLabels [object] Common labels
@@ -147,6 +149,7 @@ deploymentAnnotations: {}
 deploymentLabels: {}
 ## @param securityContext [object] Security context configuration
 securityContext:
+  enabled: true
   capabilities:
     drop:
       - ALL


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Helm templating change with defaults preserving current behavior; risk is limited to users who override these new `enabled` flags or rely on the previous unconditional rendering.
> 
> **Overview**
> Adds **opt-in/opt-out toggles** for emitting `securityContext` in both `tfy-llm-gateway` and `tfy-otel-collector` charts.
> 
> `podSecurityContext`, container `securityContext`, and the custom CA initContainer `securityContext` are now wrapped in `*.enabled` conditionals, and templates omit the `enabled` key when rendering. Values files are updated to include these `enabled` flags (default `true`) and to set `runAsUser`/`runAsGroup` defaults for the custom CA initContainer security context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2692650ae46f7c51338625951b8d850bbd877bc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->