### PR TITLE
Adding optimized image tags for deltafusion services

### DIFF
--- a/scripts/generate-artifacts-manifest/artifacts_template_generator.py
+++ b/scripts/generate-artifacts-manifest/artifacts_template_generator.py
@@ -1,5 +1,6 @@
 from urllib.parse import urlparse
 import yaml
+import copy
 import sys
 import json
 import subprocess
@@ -230,7 +231,7 @@ def process_and_generate_chart_manifests(chart_info_list):
             
             # Adding -optimized images for deltafusion images
             if any(sub in image_registry_url for sub in ['deltafusion-query-server', 'deltafusion-ingestor']):
-                optimized_image_entry = image_entry.copy()
+                optimized_image_entry = copy.deepcopy(image_entry)
                 optimized_image_entry['details']['registryURL'] = f"{image_registry_url}-optimized"
                 chart_processed_images.append(optimized_image_entry)
             

--- a/scripts/generate-artifacts-manifest/artifacts_template_generator.py
+++ b/scripts/generate-artifacts-manifest/artifacts_template_generator.py
@@ -229,10 +229,11 @@ def process_and_generate_chart_manifests(chart_info_list):
                 continue
             
             # Adding -optimized images for deltafusion images
-            if image_registry_url.contains('deltafusion-query-server') or image_registry_url.contains('deltafusion-ingestor'):
-                chart_processed_images.append(f"{image_registry_url}-optimized")
-                continue
-                
+            if any(sub in image_registry_url for sub in ['deltafusion-query-server', 'deltafusion-ingestor']):
+                optimized_image_entry = image_entry.copy()
+                optimized_image_entry['details']['registryURL'] = f"{image_registry_url}-optimized"
+                chart_processed_images.append(optimized_image_entry)
+            
             # If the image is already seen before, use that platform info even if empty
             if image_registry_url in known_image_registry_urls:
                 # Reuse the existing platform info, even if empty

--- a/scripts/generate-artifacts-manifest/artifacts_template_generator.py
+++ b/scripts/generate-artifacts-manifest/artifacts_template_generator.py
@@ -227,6 +227,11 @@ def process_and_generate_chart_manifests(chart_info_list):
             if image_registry_url.startswith(('auto', 'cos-nvidia-installer')):
                 chart_processed_images.append(image_entry)
                 continue
+            
+            # Adding -optimized images for deltafusion images
+            if image_registry_url.contains('deltafusion-query-server') or image_registry_url.contains('deltafusion-ingestor'):
+                chart_processed_images.append(f"{image_registry_url}-optimized")
+                continue
                 
             # If the image is already seen before, use that platform info even if empty
             if image_registry_url in known_image_registry_urls:
@@ -236,6 +241,7 @@ def process_and_generate_chart_manifests(chart_info_list):
             else:
                 # This is truly a new image, add it to be processed
                 chart_processed_images.append(image_entry)
+            
         
         # Log a summary
         image_urls = [img['details']['registryURL'] for img in chart_processed_images]

--- a/scripts/generate-artifacts-manifest/requirements.txt
+++ b/scripts/generate-artifacts-manifest/requirements.txt
@@ -8,4 +8,3 @@ idna==3.7
 jmespath==1.0.1
 python-dateutil==2.9.0.post0
 PyYAML==6.0.1
-copy==1.110.0

--- a/scripts/generate-artifacts-manifest/requirements.txt
+++ b/scripts/generate-artifacts-manifest/requirements.txt
@@ -8,3 +8,4 @@ idna==3.7
 jmespath==1.0.1
 python-dateutil==2.9.0.post0
 PyYAML==6.0.1
+copy==1.110.0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes artifact manifest generation to emit additional image entries, which can affect downstream packaging/scanning and image allowlists. Risk is limited to the artifact-generation script but may increase image count and processing if assumptions about uniqueness/inspection change.
> 
> **Overview**
> Adds logic to `artifacts_template_generator.py` to automatically generate and include a corresponding `-optimized` image entry whenever a chart references `deltafusion-query-server` or `deltafusion-ingestor`, using a deep-copied image record.
> 
> This updates the produced image list/counts for affected charts (potentially impacting downstream consumers of the artifacts manifest) without changing image inspection behavior for the original image URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c828daa718aeb22bf9917321598d3bfb5f2e7f0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->