### PR TITLE
fix headlamp auth bypass with configmap

### DIFF
--- a/charts/tfy-monitoring-dashboards/README.md
+++ b/charts/tfy-monitoring-dashboards/README.md
@@ -49,30 +49,33 @@ Bundled monitoring dashboards for TrueFoundry: NATS UI, Metrics Dashboard, and H
 
 ### Metrics Dashboard configuration
 
-| Name                                                              | Description                                                        | Value                                      |
-| ----------------------------------------------------------------- | ------------------------------------------------------------------ | ------------------------------------------ |
-| `tfyMetricsDashboard.enabled`                                     | Deploy Metrics Dashboard Deployment and Service                    | `false`                                    |
-| `tfyMetricsDashboard.nameOverride`                                | Override the component name used in labels and the Deployment name | `""`                                       |
-| `tfyMetricsDashboard.fullnameOverride`                            | If set, overrides the Deployment full name                         | `""`                                       |
-| `tfyMetricsDashboard.replicaCount`                                | Number of replicas                                                 | `1`                                        |
-| `tfyMetricsDashboard.image.registry`                              | Image registry                                                     | `tfy.jfrog.io`                             |
-| `tfyMetricsDashboard.image.repository`                            | Container image repository (path within registry)                  | `tfy-private-images/tfy-metrics-dashboard` |
-| `tfyMetricsDashboard.image.tag`                                   | Image tag                                                          | `78049faac40e566f3d7014a39a310593254c69c8` |
-| `tfyMetricsDashboard.imagePullPolicy`                             | Image pull policy                                                  | `IfNotPresent`                             |
-| `tfyMetricsDashboard.serviceAccount.create`                       | Create a dedicated ServiceAccount                                  | `false`                                    |
-| `tfyMetricsDashboard.serviceAccount.name`                         | Override ServiceAccount name                                       | `""`                                       |
-| `tfyMetricsDashboard.serviceAccount.annotations`                  | Service account annotations                                        | `{}`                                       |
-| `tfyMetricsDashboard.serviceAccount.labels`                       | Extra labels for the ServiceAccount                                | `{}`                                       |
-| `tfyMetricsDashboard.serviceAccount.automountServiceAccountToken` | Automount service account token                                    | `false`                                    |
-| `tfyMetricsDashboard.imagePullSecrets`                            | Image pull secrets                                                 | `[]`                                       |
-| `tfyMetricsDashboard.podSecurityContext`                          | Pod-level security context                                         | `{}`                                       |
-| `tfyMetricsDashboard.securityContext`                             | Container-level security context                                   | `{}`                                       |
-| `tfyMetricsDashboard.service.type`                                | Kubernetes Service type                                            | `ClusterIP`                                |
-| `tfyMetricsDashboard.service.port`                                | Kubernetes Service port                                            | `80`                                       |
-| `tfyMetricsDashboard.resources`                                   | CPU/Memory resource requests/limits                                | `{}`                                       |
-| `tfyMetricsDashboard.nodeSelector`                                | Node labels for pod assignment                                     | `{}`                                       |
-| `tfyMetricsDashboard.tolerations`                                 | Tolerations for pod assignment                                     | `[]`                                       |
-| `tfyMetricsDashboard.affinity`                                    | Affinity for pod assignment                                        | `{}`                                       |
+| Name                                                              | Description                                                                                   | Value                                      |
+| ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| `tfyMetricsDashboard.enabled`                                     | Deploy Metrics Dashboard Deployment and Service                                               | `false`                                    |
+| `tfyMetricsDashboard.nameOverride`                                | Override the component name used in labels and the Deployment name                            | `""`                                       |
+| `tfyMetricsDashboard.fullnameOverride`                            | If set, overrides the Deployment full name                                                    | `""`                                       |
+| `tfyMetricsDashboard.replicaCount`                                | Number of replicas                                                                            | `1`                                        |
+| `tfyMetricsDashboard.image.registry`                              | Image registry                                                                                | `tfy.jfrog.io`                             |
+| `tfyMetricsDashboard.image.repository`                            | Container image repository (path within registry)                                             | `tfy-private-images/tfy-metrics-dashboard` |
+| `tfyMetricsDashboard.image.tag`                                   | Image tag                                                                                     | `b6585fa000977af22096d3f6e75b8625a11df66a` |
+| `tfyMetricsDashboard.prometheusUrl`                               | Prometheus base URL (required)                                                                | `""`                                       |
+| `tfyMetricsDashboard.targetNamespace`                             | Kubernetes namespace to scope PromQL queries (used as $namespace in queries)                  | `truefoundry`                              |
+| `tfyMetricsDashboard.dashboardVisibility`                         | Per-dashboard visibility toggle keyed by filename. Set a key to false to hide that dashboard. | `{}`                                       |
+| `tfyMetricsDashboard.imagePullPolicy`                             | Image pull policy                                                                             | `IfNotPresent`                             |
+| `tfyMetricsDashboard.serviceAccount.create`                       | Create a dedicated ServiceAccount                                                             | `false`                                    |
+| `tfyMetricsDashboard.serviceAccount.name`                         | Override ServiceAccount name                                                                  | `""`                                       |
+| `tfyMetricsDashboard.serviceAccount.annotations`                  | Service account annotations                                                                   | `{}`                                       |
+| `tfyMetricsDashboard.serviceAccount.labels`                       | Extra labels for the ServiceAccount                                                           | `{}`                                       |
+| `tfyMetricsDashboard.serviceAccount.automountServiceAccountToken` | Automount service account token                                                               | `false`                                    |
+| `tfyMetricsDashboard.imagePullSecrets`                            | Image pull secrets                                                                            | `[]`                                       |
+| `tfyMetricsDashboard.podSecurityContext`                          | Pod-level security context                                                                    | `{}`                                       |
+| `tfyMetricsDashboard.securityContext`                             | Container-level security context                                                              | `{}`                                       |
+| `tfyMetricsDashboard.service.type`                                | Kubernetes Service type                                                                       | `ClusterIP`                                |
+| `tfyMetricsDashboard.service.port`                                | Kubernetes Service port                                                                       | `80`                                       |
+| `tfyMetricsDashboard.resources`                                   | CPU/Memory resource requests/limits                                                           | `{}`                                       |
+| `tfyMetricsDashboard.nodeSelector`                                | Node labels for pod assignment                                                                | `{}`                                       |
+| `tfyMetricsDashboard.tolerations`                                 | Tolerations for pod assignment                                                                | `[]`                                       |
+| `tfyMetricsDashboard.affinity`                                    | Affinity for pod assignment                                                                   | `{}`                                       |
 
 ### Headlamp configuration
 
@@ -80,6 +83,7 @@ Bundled monitoring dashboards for TrueFoundry: NATS UI, Metrics Dashboard, and H
 | ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
 | `headlamp.enabled`                       | Deploy Headlamp                                                                                                                                                      | `false`             |
 | `headlamp.clusterRoleBinding.create`     | Keep false — prevents headlamp subchart from creating a cluster-admin ClusterRoleBinding. Read-only RBAC is always created by this chart when headlamp.enabled=true. | `false`             |
+| `headlamp.config.inCluster`              | Use in-cluster auth mode. Must be false to enable the kubeconfig auto-auth bypass.                                                                                   | `false`             |
 | `headlamp.config.pluginsDir`             | Directory for Headlamp plugins                                                                                                                                       | `/headlamp/plugins` |
 | `headlamp.persistentVolumeClaim.enabled` | Enable PVC for plugin storage                                                                                                                                        | `false`             |
 | `headlamp.service.port`                  | Service port for Headlamp                                                                                                                                            | `4466`              |

--- a/charts/tfy-monitoring-dashboards/values.yaml
+++ b/charts/tfy-monitoring-dashboards/values.yaml
@@ -94,7 +94,20 @@ tfyMetricsDashboard:
     ## @param tfyMetricsDashboard.image.repository Container image repository (path within registry)
     repository: "tfy-private-images/tfy-metrics-dashboard"
     ## @param tfyMetricsDashboard.image.tag Image tag
-    tag: "78049faac40e566f3d7014a39a310593254c69c8"
+    tag: "b6585fa000977af22096d3f6e75b8625a11df66a"
+  ## @param tfyMetricsDashboard.prometheusUrl Prometheus base URL (required)
+  prometheusUrl: ""
+  ## @param tfyMetricsDashboard.targetNamespace Kubernetes namespace to scope PromQL queries (used as $namespace in queries)
+  targetNamespace: "truefoundry"
+  ## @param tfyMetricsDashboard.dashboardVisibility [object] Per-dashboard visibility toggle keyed by filename. Set a key to false to hide that dashboard.
+  dashboardVisibility:
+    ai-gateway.json: true
+    build-pipeline.json: true
+    deltafusion.json: true
+    servicefoundry-server.json: true
+    tfy-controller.json: true
+    tfy-k8s-controller.json: true
+    tfy-proxy.json: true
   ## @param tfyMetricsDashboard.imagePullPolicy Image pull policy
   imagePullPolicy: IfNotPresent
   ## @param tfyMetricsDashboard.serviceAccount.create Create a dedicated ServiceAccount
@@ -139,30 +152,55 @@ headlamp:
   clusterRoleBinding:
     create: false
   config:
+    ## @param headlamp.config.inCluster Use in-cluster auth mode. Must be false to enable the kubeconfig auto-auth bypass.
+    inCluster: false
     ## @param headlamp.config.pluginsDir Directory for Headlamp plugins
     pluginsDir: "/headlamp/plugins"
+    ## @skip headlamp.config.extraArgs
+    extraArgs:
+      - "-kubeconfig=/etc/headlamp/kubeconfig"
   persistentVolumeClaim:
     ## @param headlamp.persistentVolumeClaim.enabled Enable PVC for plugin storage
     enabled: false
   ## @param headlamp.service.port Service port for Headlamp
   service:
     port: 4466
-  ## Projected volume that injects the service account token so Headlamp auto-authenticates without a login screen.
+  ## Mount a pre-configured kubeconfig so Headlamp auto-authenticates using the pod's SA token without showing a login screen.
   ## @skip headlamp.volumeMounts
   volumeMounts:
-    - name: sa-token
-      mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+    - name: kubeconfig
+      mountPath: /etc/headlamp/kubeconfig
+      subPath: kubeconfig
       readOnly: true
   ## @skip headlamp.volumes
   volumes:
-    - name: sa-token
-      projected:
-        sources:
-          - serviceAccountToken:
-              path: token
-              expirationSeconds: 3607
-          - configMap:
-              name: kube-root-ca.crt
-              items:
-                - key: ca.crt
-                  path: ca.crt
+    - name: kubeconfig
+      configMap:
+        name: headlamp-kubeconfig
+  ## @skip headlamp.extraManifests
+  extraManifests:
+    - |
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: headlamp-kubeconfig
+        namespace: {{ .Release.Namespace }}
+      data:
+        kubeconfig: |
+          apiVersion: v1
+          kind: Config
+          clusters:
+          - cluster:
+              certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              server: https://kubernetes.default.svc
+            name: in-cluster
+          contexts:
+          - context:
+              cluster: in-cluster
+              user: headlamp-sa
+            name: in-cluster
+          current-context: in-cluster
+          users:
+          - name: headlamp-sa
+            user:
+              tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes Headlamp deployment auth wiring by mounting a generated kubeconfig and passing it via args, which can affect cluster access/login behavior if misconfigured. Also introduces new required/behavioral config for the Metrics Dashboard (Prometheus URL, namespace scoping, per-dashboard visibility).
> 
> **Overview**
> Updates the `tfy-metrics-dashboard` chart values/docs to bump the image tag and add new runtime configuration: a required `prometheusUrl`, a `targetNamespace` used in PromQL queries, and a `dashboardVisibility` map to enable/disable individual dashboards.
> 
> Fixes Headlamp “auth bypass” setup by disabling in-cluster auth (`headlamp.config.inCluster=false`) and instead mounting a kubeconfig from a new `headlamp-kubeconfig` ConfigMap (rendered via `headlamp.extraManifests`) and passing it through `headlamp.config.extraArgs`, replacing the prior projected service-account token mount approach.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11b8d9bff16b48c3659020461981b95896a18e3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->