### PR TITLE
bump monitoring dashboard version

### DIFF
--- a/charts/tfy-monitoring-dashboards/Chart.yaml
+++ b/charts/tfy-monitoring-dashboards/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: tfy-monitoring-dashboards
 description: Bundled monitoring dashboards for TrueFoundry - NATS UI, Metrics Dashboard, and Headlamp
-version: 0.1.0
+version: 0.1.1
 maintainers:
   - name: truefoundry
 dependencies:

--- a/charts/truefoundry-monitoring/Chart.yaml
+++ b/charts/truefoundry-monitoring/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: truefoundry-monitoring
 description: Monitoring stack for TrueFoundry control plane - Prometheus, Logs, and Grafana
-version: 0.1.5-rc.2
+version: 0.1.5-rc.1
 maintainers:
   - name: truefoundry
 dependencies:
@@ -20,7 +20,7 @@ dependencies:
     repository: https://grafana.github.io/helm-charts
     condition: grafana.enabled
   - name: tfy-monitoring-dashboards
-    version: 0.1.1
+    version: 0.1.0
     repository: https://truefoundry.github.io/infra-charts/
     alias: tfyMonitoringDashboards
     condition: tfyMonitoringDashboards.enabled

--- a/charts/truefoundry-monitoring/Chart.yaml
+++ b/charts/truefoundry-monitoring/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: truefoundry-monitoring
 description: Monitoring stack for TrueFoundry control plane - Prometheus, Logs, and Grafana
-version: 0.1.5-rc.1
+version: 0.1.5-rc.2
 maintainers:
   - name: truefoundry
 dependencies:
@@ -20,7 +20,7 @@ dependencies:
     repository: https://grafana.github.io/helm-charts
     condition: grafana.enabled
   - name: tfy-monitoring-dashboards
-    version: 0.1.0
+    version: 0.1.1
     repository: https://truefoundry.github.io/infra-charts/
     alias: tfyMonitoringDashboards
     condition: tfyMonitoringDashboards.enabled


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only increments the Helm chart version with no functional or dependency changes, so rollout risk is minimal.
> 
> **Overview**
> Bumps the `tfy-monitoring-dashboards` Helm chart version from `0.1.0` to `0.1.1` in `Chart.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77b9be94f0ee34f6e03cf959dae054deab8f5280. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->