### PR TITLE
bump truefoundry-monitoring version to 0.1.5-rc.2

### DIFF
--- a/charts/truefoundry-monitoring/Chart.yaml
+++ b/charts/truefoundry-monitoring/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: truefoundry-monitoring
 description: Monitoring stack for TrueFoundry control plane - Prometheus, Logs, and Grafana
-version: 0.1.5-rc.1
+version: 0.1.5-rc.2
 maintainers:
   - name: truefoundry
 dependencies:
@@ -20,7 +20,7 @@ dependencies:
     repository: https://grafana.github.io/helm-charts
     condition: grafana.enabled
   - name: tfy-monitoring-dashboards
-    version: 0.1.0
+    version: 0.1.1
     repository: https://truefoundry.github.io/infra-charts/
     alias: tfyMonitoringDashboards
     condition: tfyMonitoringDashboards.enabled


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk version bumps limited to Helm chart metadata and a dependency chart version; behavior changes are confined to whatever `tfy-monitoring-dashboards` 0.1.1 introduces.
> 
> **Overview**
> Bumps the `truefoundry-monitoring` Helm chart version from `0.1.5-rc.1` to `0.1.5-rc.2`.
> 
> Updates the `tfy-monitoring-dashboards` dependency from `0.1.0` to `0.1.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 877d633228295c8e265ea966886375acc594984d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->