### PR TITLE
add release name to nats-ui service name

### DIFF
--- a/charts/truefoundry-monitoring/Chart.yaml
+++ b/charts/truefoundry-monitoring/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: truefoundry-monitoring
 description: Monitoring stack for TrueFoundry control plane - Prometheus, Logs, and Grafana
-version: 0.1.5-rc.5
+version: 0.1.5-rc.6
 maintainers:
   - name: truefoundry
 dependencies:

--- a/charts/truefoundry-monitoring/README.md
+++ b/charts/truefoundry-monitoring/README.md
@@ -134,7 +134,6 @@ This Helm chart package, provided by TrueFoundry, contains the components needed
 | `tfyNatsUi.natsUrl`                                     | NATS_URL env var when env is empty                                  | `http://{{ .Release.Name }}-tfy-nats:4222` |
 | `tfyNatsUi.accountSeedSecret.name`                      | Existing Secret name when env is empty                              | `truefoundry-tfy-nats-secret`              |
 | `tfyNatsUi.accountSeedSecret.key`                       | Key inside the Secret                                               | `NATS_CONTROLPLANE_ACCOUNT_SEED`           |
-| `tfyNatsUi.service.name`                                | Kubernetes Service metadata.name                                    | `tfy-nats-ui`                              |
 | `tfyNatsUi.service.type`                                | Service type                                                        | `ClusterIP`                                |
 | `tfyNatsUi.service.port`                                | Service port                                                        | `8080`                                     |
 | `tfyNatsUi.service.targetPort`                          | Container port (defaults to service.port)                           | `""`                                       |

--- a/charts/truefoundry-monitoring/templates/nats-ui/service.yaml
+++ b/charts/truefoundry-monitoring/templates/nats-ui/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ default "tfy-nats-ui" .Values.tfyNatsUi.service.name }}
+  name: {{ include "truefoundry-monitoring.nats-ui.fullname" . }}
   labels:
     {{- include "truefoundry-monitoring.nats-ui.labels" . | nindent 4 }}
   {{- with .Values.tfyNatsUi.service.annotations }}

--- a/charts/truefoundry-monitoring/values.yaml
+++ b/charts/truefoundry-monitoring/values.yaml
@@ -451,13 +451,11 @@ tfyNatsUi:
   accountSeedSecret:
     name: "truefoundry-tfy-nats-secret"
     key: NATS_CONTROLPLANE_ACCOUNT_SEED
-  ## @param tfyNatsUi.service.name Kubernetes Service metadata.name
   ## @param tfyNatsUi.service.type Service type
   ## @param tfyNatsUi.service.port Service port
   ## @param tfyNatsUi.service.targetPort Container port (defaults to service.port)
   ## @param tfyNatsUi.service.annotations [object] Service annotations
   service:
-    name: tfy-nats-ui
     type: ClusterIP
     port: 8080
     targetPort: ""


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Renaming the NATS UI `Service` changes its Kubernetes DNS/name and can break existing references or selectors during upgrades if clients expect the old fixed name.
> 
> **Overview**
> Bumps the `truefoundry-monitoring` chart version to `0.1.5-rc.6`.
> 
> Updates the NATS UI `Service` to use the chart `fullname` helper (release-prefixed naming) instead of a fixed/overridable `tfyNatsUi.service.name`, and removes the `service.name` value from `values.yaml` and the README parameters table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 630edb59297ea1fa93cbd4f01bb01ddb97f2f69a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->