### PR TITLE
fix image pull secrets for metrics dashboard

### DIFF
--- a/charts/truefoundry-monitoring/Chart.yaml
+++ b/charts/truefoundry-monitoring/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: truefoundry-monitoring
 description: Monitoring stack for TrueFoundry control plane - Prometheus, Logs, and Grafana
-version: 0.1.5
+version: 0.1.6
 maintainers:
   - name: truefoundry
 dependencies:

--- a/charts/truefoundry-monitoring/README.md
+++ b/charts/truefoundry-monitoring/README.md
@@ -148,33 +148,33 @@ This Helm chart package, provided by TrueFoundry, contains the components needed
 
 ### Metrics Dashboard configuration
 
-| Name                                                              | Description                                                                                   | Value                                      |
-| ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------ |
-| `tfyMetricsDashboard.enabled`                                     | Deploy Metrics Dashboard Deployment and Service                                               | `false`                                    |
-| `tfyMetricsDashboard.nameOverride`                                | Override the component name used in labels and the Deployment name                            | `""`                                       |
-| `tfyMetricsDashboard.fullnameOverride`                            | If set, overrides the Deployment full name                                                    | `""`                                       |
-| `tfyMetricsDashboard.replicaCount`                                | Number of replicas                                                                            | `1`                                        |
-| `tfyMetricsDashboard.image.registry`                              | Image registry                                                                                | `tfy.jfrog.io`                             |
-| `tfyMetricsDashboard.image.repository`                            | Container image repository (path within registry)                                             | `tfy-private-images/tfy-metrics-dashboard` |
-| `tfyMetricsDashboard.image.tag`                                   | Image tag                                                                                     | `5940b1e5f60e003e973d7984f7b0f4aac03bcadd` |
-| `tfyMetricsDashboard.prometheusUrl`                               | Prometheus base URL (required)                                                                | `""`                                       |
-| `tfyMetricsDashboard.targetNamespace`                             | Kubernetes namespace to scope PromQL queries (used as $namespace in queries)                  | `""`                                       |
-| `tfyMetricsDashboard.dashboardVisibility`                         | Per-dashboard visibility toggle keyed by filename. Set a key to false to hide that dashboard. | `{}`                                       |
-| `tfyMetricsDashboard.imagePullPolicy`                             | Image pull policy                                                                             | `IfNotPresent`                             |
-| `tfyMetricsDashboard.serviceAccount.create`                       | Create a dedicated ServiceAccount                                                             | `false`                                    |
-| `tfyMetricsDashboard.serviceAccount.name`                         | Override ServiceAccount name                                                                  | `""`                                       |
-| `tfyMetricsDashboard.serviceAccount.annotations`                  | Service account annotations                                                                   | `{}`                                       |
-| `tfyMetricsDashboard.serviceAccount.labels`                       | Extra labels for the ServiceAccount                                                           | `{}`                                       |
-| `tfyMetricsDashboard.serviceAccount.automountServiceAccountToken` | Automount service account token                                                               | `false`                                    |
-| `tfyMetricsDashboard.imagePullSecrets`                            | Image pull secrets                                                                            | `[]`                                       |
-| `tfyMetricsDashboard.podSecurityContext`                          | Pod-level security context                                                                    | `{}`                                       |
-| `tfyMetricsDashboard.securityContext`                             | Container-level security context                                                              | `{}`                                       |
-| `tfyMetricsDashboard.service.type`                                | Kubernetes Service type                                                                       | `ClusterIP`                                |
-| `tfyMetricsDashboard.service.port`                                | Kubernetes Service port                                                                       | `80`                                       |
-| `tfyMetricsDashboard.resources`                                   | CPU/Memory resource requests/limits                                                           | `{}`                                       |
-| `tfyMetricsDashboard.nodeSelector`                                | Node labels for pod assignment                                                                | `{}`                                       |
-| `tfyMetricsDashboard.tolerations`                                 | Tolerations for pod assignment                                                                | `[]`                                       |
-| `tfyMetricsDashboard.affinity`                                    | Affinity for pod assignment                                                                   | `{}`                                       |
+| Name                                                              | Description                                                                                   | Value                                                          |
+| ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `tfyMetricsDashboard.enabled`                                     | Deploy Metrics Dashboard Deployment and Service                                               | `false`                                                        |
+| `tfyMetricsDashboard.nameOverride`                                | Override the component name used in labels and the Deployment name                            | `""`                                                           |
+| `tfyMetricsDashboard.fullnameOverride`                            | If set, overrides the Deployment full name                                                    | `""`                                                           |
+| `tfyMetricsDashboard.replicaCount`                                | Number of replicas                                                                            | `1`                                                            |
+| `tfyMetricsDashboard.image.registry`                              | Image registry                                                                                | `tfy.jfrog.io`                                                 |
+| `tfyMetricsDashboard.image.repository`                            | Container image repository (path within registry)                                             | `tfy-private-images/tfy-metrics-dashboard`                     |
+| `tfyMetricsDashboard.image.tag`                                   | Image tag                                                                                     | `5940b1e5f60e003e973d7984f7b0f4aac03bcadd`                     |
+| `tfyMetricsDashboard.prometheusUrl`                               | Prometheus base URL (required)                                                                | `http://prometheus-operated.prometheus.svc.cluster.local:9090` |
+| `tfyMetricsDashboard.targetNamespace`                             | Kubernetes namespace to scope PromQL queries (used as $namespace in queries)                  | `""`                                                           |
+| `tfyMetricsDashboard.dashboardVisibility`                         | Per-dashboard visibility toggle keyed by filename. Set a key to false to hide that dashboard. | `{}`                                                           |
+| `tfyMetricsDashboard.imagePullPolicy`                             | Image pull policy                                                                             | `IfNotPresent`                                                 |
+| `tfyMetricsDashboard.serviceAccount.create`                       | Create a dedicated ServiceAccount                                                             | `false`                                                        |
+| `tfyMetricsDashboard.serviceAccount.name`                         | Override ServiceAccount name                                                                  | `""`                                                           |
+| `tfyMetricsDashboard.serviceAccount.annotations`                  | Service account annotations                                                                   | `{}`                                                           |
+| `tfyMetricsDashboard.serviceAccount.labels`                       | Extra labels for the ServiceAccount                                                           | `{}`                                                           |
+| `tfyMetricsDashboard.serviceAccount.automountServiceAccountToken` | Automount service account token                                                               | `false`                                                        |
+| `tfyMetricsDashboard.imagePullSecrets`                            | Image pull secrets                                                                            | `[]`                                                           |
+| `tfyMetricsDashboard.podSecurityContext`                          | Pod-level security context                                                                    | `{}`                                                           |
+| `tfyMetricsDashboard.securityContext`                             | Container-level security context                                                              | `{}`                                                           |
+| `tfyMetricsDashboard.service.type`                                | Kubernetes Service type                                                                       | `ClusterIP`                                                    |
+| `tfyMetricsDashboard.service.port`                                | Kubernetes Service port                                                                       | `8080`                                                         |
+| `tfyMetricsDashboard.resources`                                   | CPU/Memory resource requests/limits                                                           | `{}`                                                           |
+| `tfyMetricsDashboard.nodeSelector`                                | Node labels for pod assignment                                                                | `{}`                                                           |
+| `tfyMetricsDashboard.tolerations`                                 | Tolerations for pod assignment                                                                | `[]`                                                           |
+| `tfyMetricsDashboard.affinity`                                    | Affinity for pod assignment                                                                   | `{}`                                                           |
 
 ### Headlamp configuration
 

--- a/charts/truefoundry-monitoring/templates/_helpers.tpl
+++ b/charts/truefoundry-monitoring/templates/_helpers.tpl
@@ -189,12 +189,14 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- tpl ((.Values.tfyNatsUi.env | default dict) | toYaml) . }}
 {{- end }}
 
-{{- define "truefoundry-monitoring.nats-ui.imagePullSecrets" -}}
-{{- if .Values.tfyNatsUi.imagePullSecrets -}}
-{{- toYaml .Values.tfyNatsUi.imagePullSecrets }}
-{{- else if .Values.global.imagePullSecrets -}}
-{{- toYaml .Values.global.imagePullSecrets }}
-{{- else if .Values.global.truefoundryImagePullConfigJSON -}}
+{{- define "truefoundry-monitoring.imagePullSecrets" -}}
+{{- $componentSecrets := index . 0 -}}
+{{- $ctx := index . 1 -}}
+{{- if $componentSecrets -}}
+{{- toYaml $componentSecrets }}
+{{- else if $ctx.Values.global.imagePullSecrets -}}
+{{- toYaml $ctx.Values.global.imagePullSecrets }}
+{{- else if $ctx.Values.global.truefoundryImagePullConfigJSON -}}
 - name: truefoundry-image-pull-secret
 {{- else -}}
 []

--- a/charts/truefoundry-monitoring/templates/metrics-dashboard/deployment.yaml
+++ b/charts/truefoundry-monitoring/templates/metrics-dashboard/deployment.yaml
@@ -58,10 +58,8 @@ spec:
             failureThreshold: 3
           resources:
             {{- include "truefoundry-monitoring.metrics-dashboard.resources" . | nindent 12 }}
-      {{- with .Values.tfyMetricsDashboard.imagePullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- include "truefoundry-monitoring.imagePullSecrets" (list .Values.tfyMetricsDashboard.imagePullSecrets .) | nindent 8 }}
       {{- with .Values.tfyMetricsDashboard.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/truefoundry-monitoring/templates/nats-ui/deployment.yaml
+++ b/charts/truefoundry-monitoring/templates/nats-ui/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       serviceAccountName: {{ include "truefoundry-monitoring.nats-ui.serviceAccountName" . }}
       imagePullSecrets:
-        {{- include "truefoundry-monitoring.nats-ui.imagePullSecrets" . | nindent 8 }}
+        {{- include "truefoundry-monitoring.imagePullSecrets" (list .Values.tfyNatsUi.imagePullSecrets .) | nindent 8 }}
       {{- with .Values.tfyNatsUi.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/charts/truefoundry-monitoring/values.yaml
+++ b/charts/truefoundry-monitoring/values.yaml
@@ -505,7 +505,7 @@ tfyMetricsDashboard:
     ## @param tfyMetricsDashboard.image.tag Image tag
     tag: "5940b1e5f60e003e973d7984f7b0f4aac03bcadd"
   ## @param tfyMetricsDashboard.prometheusUrl Prometheus base URL (required)
-  prometheusUrl: ""
+  prometheusUrl: "http://prometheus-operated.prometheus.svc.cluster.local:9090"
   ## @param tfyMetricsDashboard.targetNamespace Kubernetes namespace to scope PromQL queries (used as $namespace in queries)
   targetNamespace: ""
   ## @param tfyMetricsDashboard.dashboardVisibility [object] Per-dashboard visibility toggle keyed by filename. Set a key to false to hide that dashboard.
@@ -546,7 +546,7 @@ tfyMetricsDashboard:
   ## @param tfyMetricsDashboard.service.port Kubernetes Service port
   service:
     type: ClusterIP
-    port: 80
+    port: 8080
   ## @param tfyMetricsDashboard.resources [object] CPU/Memory resource requests/limits
   resources: {}
   ## @param tfyMetricsDashboard.nodeSelector [object] Node labels for pod assignment


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes Helm template behavior for `imagePullSecrets` resolution and updates default `tfyMetricsDashboard` connection/port values, which can affect existing deployments if they relied on previous defaults.
> 
> **Overview**
> Bumps the `truefoundry-monitoring` chart version to `0.1.6`.
> 
> Fixes `imagePullSecrets` handling by introducing a shared `truefoundry-monitoring.imagePullSecrets` helper that applies consistent fallback logic (component-specific → `global.imagePullSecrets` → auto-created `truefoundry-image-pull-secret`) and wiring it into both `tfy-metrics-dashboard` and `tfy-nats-ui` deployments.
> 
> Updates `tfyMetricsDashboard` defaults/documentation to use a concrete Prometheus service URL and changes the default service/container port from `80` to `8080`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7e4d89728907ebc734c1d574424ef66f923ec21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->