### PR TITLE
Add kube_job_complete and kube_cronjob_* metrics to kube-state-metrics allowlist

### DIFF
--- a/charts/tfy-prometheus-config/Chart.yaml
+++ b/charts/tfy-prometheus-config/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: tfy-prometheus-config
 description: A Helm chart for Prometheus Config
-version: 0.2.19
+version: 0.2.20
 maintainers:
   - name: truefoundry

--- a/charts/tfy-prometheus-config/values.yaml
+++ b/charts/tfy-prometheus-config/values.yaml
@@ -972,7 +972,8 @@ serviceMonitors:
               kube_statefulset_metadata_generation|kube_statefulset_status_current_revision|kube_statefulset_status_update_revision|kube_statefulset_replicas|\
               kube_daemonset_status_current_number_scheduled|kube_daemonset_status_desired_number_scheduled|kube_daemonset_status_number_misscheduled|\
               kube_daemonset_status_updated_number_scheduled|kube_daemonset_status_number_available|\
-              kube_job_status_start_time|kube_job_status_active|kube_job_failed|kube_job_status_failed|kube_job_status_succeeded|kube_job_status_completion_time|\
+              kube_job_status_start_time|kube_job_status_active|kube_job_failed|kube_job_status_failed|kube_job_status_succeeded|kube_job_status_completion_time|kube_job_complete|\
+              kube_cronjob_status_last_schedule_time|kube_cronjob_next_schedule_time|\
               kube_horizontalpodautoscaler_status_desired_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_spec_min_replicas|\
               kube_horizontalpodautoscaler_spec_max_replicas|kube_persistentvolume_status_phase|kube_node_spec_taint|kube_state_metrics_list_total|kube_state_metrics_watch_total|\
               kube_state_metrics_total_shards|kube_state_metrics_shard_ordinal|kube_pod_container_state_started|kube_pod_status_container_ready_time|\


### PR DESCRIPTION
## Summary
- Adds three more `kube-state-metrics` series to the `serviceMonitors.kubeStateMetrics` keep-allowlist in `tfy-prometheus-config`:
  - `kube_job_complete` — job completion condition (with `condition=true|false|unknown`)
  - `kube_cronjob_status_last_schedule_time` — last time a CronJob was scheduled
  - `kube_cronjob_next_schedule_time` — next time a CronJob will be scheduled
- Bumps chart version `0.2.19` → `0.2.20`.

## Why
We want to push these metrics through Prometheus so we can build dashboards/alerts around CronJob scheduling and Job completion. They are emitted by `kube-state-metrics` by default but were being dropped by the existing scrape `keep` regex.

## Verification
- Confirmed `kube-state-metrics` already emits all three on a target cluster (`curl :8080/metrics`).
- Existing `kube_job_status_completion_time` was already in the allowlist as of 0.2.19; left unchanged.
- Diff is limited to the single `keep` regex line + chart version bump.

## Test plan
- [ ] `helm template` the chart and confirm the rendered ServiceMonitor's `keep` regex contains `kube_job_complete`, `kube_cronjob_status_last_schedule_time`, `kube_cronjob_next_schedule_time`.
- [ ] After deploy, on a cluster:
  - `kubectl -n prometheus get servicemonitor prometheus-kube-state-metrics -o yaml | grep -E 'kube_job_complete|kube_cronjob_'` shows the new names.
  - In Prometheus, `kube_job_complete`, `kube_cronjob_status_last_schedule_time`, `kube_cronjob_next_schedule_time` return non-empty results within one scrape interval.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only expands the kube-state-metrics metric `keep` allowlist and bumps the Helm chart version; main impact is slightly increased scraped series volume.
> 
> **Overview**
> Expands the `serviceMonitors.kubeStateMetrics` metric relabel `keep` allowlist to retain `kube_job_complete`, `kube_cronjob_status_last_schedule_time`, and `kube_cronjob_next_schedule_time` so Prometheus no longer drops these series.
> 
> Bumps the `tfy-prometheus-config` Helm chart version from `0.2.19` to `0.2.20`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dedb4d90222553f51be8c96e4b4721ce08452f63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->