### PR TITLE
chore(truefoundry-monitoring): bump tfy-logs dependency to 0.1.20

### DIFF
--- a/charts/truefoundry-monitoring/Chart.yaml
+++ b/charts/truefoundry-monitoring/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
     alias: prometheus
     condition: prometheus.enabled
   - name: tfy-logs
-    version: 0.1.17
+    version: 0.1.20
     repository: https://truefoundry.github.io/infra-charts/
     alias: logs
     condition: logs.enabled


### PR DESCRIPTION
## Summary
- Bump `tfy-logs` chart dependency in `truefoundry-monitoring` from `0.1.17` to `0.1.20`

## Test plan
- [ ] CI passes
- [ ] Helm dependency resolution works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only bumps a Helm chart dependency version, with primary risk limited to deployment-time behavior changes introduced by `tfy-logs` 0.1.20.
> 
> **Overview**
> Updates `charts/truefoundry-monitoring/Chart.yaml` to bump the `tfy-logs` Helm dependency from `0.1.17` to `0.1.20` (no other chart versions or configuration changed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93809c7f44c5214911c1b805e576e96dbc538b57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->