### PR TITLE
feat: add spark notebook image

### DIFF
--- a/charts/tfy-configs/files/workbench-images.yaml
+++ b/charts/tfy-configs/files/workbench-images.yaml
@@ -85,6 +85,15 @@ images:
         spec:
           image_uri: "public.ecr.aws/truefoundrycloud/jupyter:0.4.5-cu129-py3.12.12-sudo"
 
+  - name: Jupyter Lab Spark 3.5.1 (Python 3.11)
+    type: spark-notebook
+    enabled: true
+    description: Python 3.11 environment with Apache Spark 3.5.1, Scala 2.12, and PySpark pre-installed
+    image:
+      - match: []
+        spec:
+          image_uri: "public.ecr.aws/truefoundrycloud/jupyter-spark:0.4.9-py3.11.14-sc2.12-spark3.5.7-sudo"
+
   - name: SSH Server Minimal Image
     type: ssh-server
     enabled: true

--- a/charts/truefoundry/files/tfy-configs/workbench-images.yaml
+++ b/charts/truefoundry/files/tfy-configs/workbench-images.yaml
@@ -85,6 +85,15 @@ images:
         spec:
           image_uri: "public.ecr.aws/truefoundrycloud/jupyter:0.4.5-cu129-py3.12.12-sudo"
 
+  - name: Jupyter Lab Spark 3.5.1 (Python 3.11)
+    type: spark-notebook
+    enabled: true
+    description: Python 3.11 environment with Apache Spark 3.5.1, Scala 2.12, and PySpark pre-installed
+    image:
+      - match: []
+        spec:
+          image_uri: "public.ecr.aws/truefoundrycloud/jupyter-spark:0.4.9-py3.11.14-sc2.12-spark3.5.7-sudo"
+
   - name: SSH Server Minimal Image
     type: ssh-server
     enabled: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds a new workbench image entry in Helm chart configs without changing runtime logic; main risk is misconfiguration or image tag issues affecting users who select it.
> 
> **Overview**
> Adds a new **Spark-enabled** workbench image entry (`type: spark-notebook`) to both `charts/tfy-configs` and `charts/truefoundry` `workbench-images.yaml`, pointing to `public.ecr.aws/truefoundrycloud/jupyter-spark:0.4.9-py3.11.14-sc2.12-spark3.5.7-sudo` with a matching-free selector.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eebaeb216ea3dd021d44f444624449091f422ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->