### PR TITLE
changed field name from eso to external-secrets-operator in tfy-agent chart

### DIFF
--- a/charts/tfy-agent/Chart.lock
+++ b/charts/tfy-agent/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: external-secrets
   repository: https://charts.external-secrets.io
   version: 2.4.1
-digest: sha256:b201c411852e78147fca127e54ac2a711c772bf0da7ae1a1662e71c86c784cde
-generated: "2026-05-17T12:21:19.748429+05:30"
+digest: sha256:efe8151ca4d4a856a8898d2f2ba79134873c9baf4cad5cfdbc613494bb615b26
+generated: "2026-05-20T17:05:42.956478+05:30"

--- a/charts/tfy-agent/Chart.yaml
+++ b/charts/tfy-agent/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.90
+version: 0.2.91
 
 maintainers:
   - name: truefoundry
@@ -24,5 +24,5 @@ dependencies:
   - name: external-secrets
     version: 2.4.1
     repository: https://charts.external-secrets.io
-    alias: eso
-    condition: eso.enabled
+    alias: external-secrets-operator
+    condition: external-secrets-operator.enabled

--- a/charts/tfy-agent/README.md
+++ b/charts/tfy-agent/README.md
@@ -296,5 +296,5 @@ If your control plane URL is using self-signed CA certificate, follow these step
 
 | Name                                               | Description                                                 | Value              |
 | -------------------------------------------------- | ----------------------------------------------------------- | ------------------ |
-| `external-secrets-operator.enabled`                | Bool value to deploy the external-secrets operator subchart | `false`            |
+| `external-secrets-operator.enabled`                | Bool value to deploy the external-secrets operator subchart | `true`             |
 | `external-secrets-operator.clusterSecretStoreName` | Name of the ClusterSecretStore resource                     | `tfy-secret-store` |

--- a/charts/tfy-agent/README.md
+++ b/charts/tfy-agent/README.md
@@ -294,8 +294,7 @@ If your control plane URL is using self-signed CA certificate, follow these step
 
 ### eso (external-secrets operator) configuration parameters
 
-| Name                         | Description                                                                             | Value              |
-| ---------------------------- | --------------------------------------------------------------------------------------- | ------------------ |
-| `eso.enabled`                | Bool value to deploy the external-secrets operator subchart                             | `false`            |
-| `eso.clusterSecretStoreName` | Name of the ClusterSecretStore resource                                                 | `tfy-secret-store` |
-| `eso.nameOverride`           | Overrides the subchart name segment in K8s resource names (release-name-{nameOverride}) | `external-secrets` |
+| Name                                               | Description                                                 | Value              |
+| -------------------------------------------------- | ----------------------------------------------------------- | ------------------ |
+| `external-secrets-operator.enabled`                | Bool value to deploy the external-secrets operator subchart | `false`            |
+| `external-secrets-operator.clusterSecretStoreName` | Name of the ClusterSecretStore resource                     | `tfy-secret-store` |

--- a/charts/tfy-agent/templates/cluster-secret-store.yaml
+++ b/charts/tfy-agent/templates/cluster-secret-store.yaml
@@ -1,8 +1,8 @@
-{{- if and .Values.external-secrets-operator.enabled -}}
+{{- if index .Values "external-secrets-operator" "enabled" -}}
 apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
-  name: {{ .Values.external-secrets-operator.clusterSecretStoreName }}
+  name: {{ index .Values "external-secrets-operator" "clusterSecretStoreName" }}
   labels:
     {{- include "tfy-agent.commonLabels" . | nindent 4 }}
   annotations:

--- a/charts/tfy-agent/templates/cluster-secret-store.yaml
+++ b/charts/tfy-agent/templates/cluster-secret-store.yaml
@@ -1,8 +1,8 @@
-{{- if and .Values.eso.enabled -}}
+{{- if and .Values.external-secrets-operator.enabled -}}
 apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
-  name: {{ .Values.eso.clusterSecretStoreName }}
+  name: {{ .Values.external-secrets-operator.clusterSecretStoreName }}
   labels:
     {{- include "tfy-agent.commonLabels" . | nindent 4 }}
   annotations:

--- a/charts/tfy-agent/templates/secret.yaml
+++ b/charts/tfy-agent/templates/secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "tfy-agent.secretName" . }}
   labels:
     {{- include "tfy-agent.commonLabels" . | nindent 4 }}
-    {{- if .Values.external-secrets-operator.enabled }}
+    {{- if index .Values "external-secrets-operator" "enabled" }}
     external-secrets.io/type: webhook
     {{- end }}
   annotations:

--- a/charts/tfy-agent/templates/secret.yaml
+++ b/charts/tfy-agent/templates/secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "tfy-agent.secretName" . }}
   labels:
     {{- include "tfy-agent.commonLabels" . | nindent 4 }}
-    {{- if .Values.eso.enabled }}
+    {{- if .Values.external-secrets-operator.enabled }}
     external-secrets.io/type: webhook
     {{- end }}
   annotations:

--- a/charts/tfy-agent/values.yaml
+++ b/charts/tfy-agent/values.yaml
@@ -791,13 +791,10 @@ sdsServer:
 
 ## @section eso (external-secrets operator) configuration parameters
 ##
-eso:
-  ## @param eso.enabled Bool value to deploy the external-secrets operator subchart
+external-secrets-operator:
+  ## @param external-secrets-operator.enabled Bool value to deploy the external-secrets operator subchart
   ##
   enabled: false
-  ## @param eso.clusterSecretStoreName Name of the ClusterSecretStore resource
+  ## @param external-secrets-operator.clusterSecretStoreName Name of the ClusterSecretStore resource
   ##
   clusterSecretStoreName: "tfy-secret-store"
-  ## @param eso.nameOverride Overrides the subchart name segment in K8s resource names (release-name-{nameOverride})
-  ##
-  nameOverride: external-secrets

--- a/charts/tfy-agent/values.yaml
+++ b/charts/tfy-agent/values.yaml
@@ -794,7 +794,7 @@ sdsServer:
 external-secrets-operator:
   ## @param external-secrets-operator.enabled Bool value to deploy the external-secrets operator subchart
   ##
-  enabled: false
+  enabled: true
   ## @param external-secrets-operator.clusterSecretStoreName Name of the ClusterSecretStore resource
   ##
   clusterSecretStoreName: "tfy-secret-store"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Helm values keys and dependency alias/condition for the External Secrets subchart, which can break existing user overrides and alter whether the operator/ClusterSecretStore resources are rendered.
> 
> **Overview**
> Updates the `tfy-agent` Helm chart to rename the external-secrets configuration block from `eso` to `external-secrets-operator`, including changing the dependency `alias`/`condition` and updating templates that gate and name the `ClusterSecretStore` and Secret labels.
> 
> Bumps chart version to `0.2.91`, refreshes `Chart.lock`, updates docs/values, and flips the default to deploy the external-secrets subchart by setting `external-secrets-operator.enabled: true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d21b3fde0b7f3107bc4215ac059b685c917d70d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->