### PR TITLE
add controlPlaneURL to tfyAgent

### DIFF
--- a/charts/tfy-k8s-aws-eks-inframold/values-artifact-manifest.yaml
+++ b/charts/tfy-k8s-aws-eks-inframold/values-artifact-manifest.yaml
@@ -114,6 +114,7 @@ grafana:
 tfyAgent:
   enabled: true
   clusterToken: ""
+  controlPlaneURL: ""
 
 elasti:
   enabled: true

--- a/charts/tfy-k8s-azure-aks-inframold/values-artifact-manifest.yaml
+++ b/charts/tfy-k8s-azure-aks-inframold/values-artifact-manifest.yaml
@@ -82,6 +82,7 @@ grafana:
 tfyAgent:
   enabled: true
   clusterToken: ""
+  controlPlaneURL: ""
 
 elasti:
   enabled: true

--- a/charts/tfy-k8s-civo-talos-inframold/values-artifact-manifest.yaml
+++ b/charts/tfy-k8s-civo-talos-inframold/values-artifact-manifest.yaml
@@ -82,6 +82,7 @@ grafana:
 tfyAgent:
   enabled: true
   clusterToken: ""
+  controlPlaneURL: ""
 
 elasti:
   enabled: true

--- a/charts/tfy-k8s-gcp-gke-standard-inframold/values-artifact-manifest.yaml
+++ b/charts/tfy-k8s-gcp-gke-standard-inframold/values-artifact-manifest.yaml
@@ -82,6 +82,7 @@ grafana:
 tfyAgent:
   enabled: true
   clusterToken: ""
+  controlPlaneURL: ""
 
 elasti:
   enabled: true

--- a/charts/tfy-k8s-generic-inframold/values-artifact-manifest.yaml
+++ b/charts/tfy-k8s-generic-inframold/values-artifact-manifest.yaml
@@ -82,6 +82,7 @@ grafana:
 tfyAgent:
   enabled: true
   clusterToken: ""
+  controlPlaneURL: ""
 
 elasti:
   enabled: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds a new optional Helm values field to multiple `values-artifact-manifest.yaml` files without changing templates or runtime logic.
> 
> **Overview**
> Adds a new `tfyAgent.controlPlaneURL` value (default empty) to all inframold `values-artifact-manifest.yaml` variants (AWS EKS, Azure AKS, GCP GKE, Civo Talos, and generic), allowing the agent to be configured with an explicit control plane endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20a4cdb20ceed18960cdedbd62637e67450e5996. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->