### PR TITLE
Make controlPlaneURL string by default

### DIFF
--- a/charts/tfy-agent/Chart.yaml
+++ b/charts/tfy-agent/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.92
+version: 0.2.93
 
 maintainers:
   - name: truefoundry

--- a/charts/tfy-agent/templates/_helpers.tpl
+++ b/charts/tfy-agent/templates/_helpers.tpl
@@ -394,7 +394,12 @@ Create the name of the secret which will contain cluster token
 Trimmed external control plane base URL (https://...).
 */}}
 {{- define "tfy-agent.controlPlaneBaseURL" -}}
-{{- .Values.config.controlPlaneURL | trimSuffix "/" -}}
+{{- $controlPlaneURL := .Values.config.controlPlaneURL | toString -}}
+{{- if $controlPlaneURL -}}
+{{- $controlPlaneURL | trimSuffix "/" -}}
+{{- else -}}
+{{- .Values.config.controlPlaneClusterIP | toString | trimSuffix "/" -}}
+{{- end -}}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk Helm templating change that only affects how `CONTROL_PLANE_URL`/webhook URLs are rendered when `config.controlPlaneURL` is empty or non-string; main risk is altering the computed base URL in edge value configurations.
> 
> **Overview**
> Bumps the `tfy-agent` Helm chart version to `0.2.93`.
> 
> Updates `tfy-agent.controlPlaneBaseURL` to coerce `config.controlPlaneURL` to a string and, when it is empty/unset, fall back to trimming and using `config.controlPlaneClusterIP` instead of emitting an empty base URL (affecting rendered `CONTROL_PLANE_URL` and the external-secrets webhook URL).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c77e9546d334a29347dc7be15c8c703228f97e73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->