### PR TITLE
Added sync wave annotation in cluster secret store chart

### DIFF
--- a/charts/tfy-agent/Chart.yaml
+++ b/charts/tfy-agent/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.93
+version: 0.2.94
 
 maintainers:
   - name: truefoundry

--- a/charts/tfy-agent/templates/cluster-secret-store.yaml
+++ b/charts/tfy-agent/templates/cluster-secret-store.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "tfy-agent.commonLabels" . | nindent 4 }}
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "10"
     {{- include "tfy-agent.commonAnnotations" . | nindent 4 }}
 spec:
   provider:

--- a/charts/tfy-agent/templates/cluster-secret-store.yaml
+++ b/charts/tfy-agent/templates/cluster-secret-store.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "tfy-agent.commonLabels" . | nindent 4 }}
   annotations:
+    argocd.argoproj.io/sync-wave: "1"
     {{- include "tfy-agent.commonAnnotations" . | nindent 4 }}
 spec:
   provider:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Helm-only sync ordering annotation; no changes to secret provider URLs, auth headers, or external-secrets spec.
> 
> **Overview**
> Bumps the **tfy-agent** chart to **0.2.94** and adds **`argocd.argoproj.io/sync-wave: "10"`** on the **ClusterSecretStore** manifest so Argo CD applies it in a later sync wave than default resources.
> 
> That defers creation of the cluster-wide secret store until prerequisites (e.g. the agent **Secret** / **CLUSTER_TOKEN** referenced in the webhook provider) are in place, reducing race failures during GitOps sync when external-secrets is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 913f04d552811e7e64dc51809a7b6c954d29f816. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->