### PR TITLE
fix caddy host header for https upstreams

### DIFF
--- a/charts/tfy-cloudflared/Chart.yaml
+++ b/charts/tfy-cloudflared/Chart.yaml
@@ -26,4 +26,4 @@ sources:
 - https://github.com/truefoundry/infra-charts/tree/main/charts/tfy-cloudflared
 - https://github.com/cloudflare/cloudflared
 type: application
-version: 0.3.0
+version: 0.3.1

--- a/charts/tfy-cloudflared/templates/caddy/configmap.yaml
+++ b/charts/tfy-cloudflared/templates/caddy/configmap.yaml
@@ -34,6 +34,7 @@ data:
     		rewrite * /{re.direct_url_http.3}
 
     		reverse_proxy {re.direct_url_http.1}:{re.direct_url_http.2} {
+    			header_up Host {re.direct_url_http.1}
     			header_up X-Forwarded-Host {host}
     			header_up X-Original-URI {uri}
 
@@ -106,6 +107,7 @@ data:
     		rewrite * /{re.direct_http.3}
 
     		reverse_proxy {re.direct_http.1}:{re.direct_http.2} {
+    			header_up Host {re.direct_http.1}
     			header_up X-Forwarded-Host {host}
     			header_up X-Original-URI {uri}
 

--- a/charts/tfy-cloudflared/templates/caddy/configmap.yaml
+++ b/charts/tfy-cloudflared/templates/caddy/configmap.yaml
@@ -56,6 +56,7 @@ data:
     		rewrite * /{re.direct_url_https.3}
 
     		reverse_proxy {re.direct_url_https.1}:{re.direct_url_https.2} {
+    			header_up Host {re.direct_url_https.1}
     			header_up X-Forwarded-Host {host}
     			header_up X-Original-URI {uri}
 
@@ -80,6 +81,7 @@ data:
     		rewrite * /{re.direct_https.3}
 
     		reverse_proxy {re.direct_https.1}:{re.direct_https.2} {
+    			header_up Host {re.direct_https.1}
     			header_up X-Forwarded-Host {host}
     			header_up X-Original-URI {uri}
 


### PR DESCRIPTION
## Summary
- set the upstream Host header for tfy-cloudflared Caddy HTTPS proxy routes
- keep Host aligned with the upstream hostname used for TLS SNI so host-based upstream routers can match correctly

## Testing
- helm lint charts/tfy-cloudflared --set caddy.enabled=true
- rendered and applied the Caddy ConfigMap in devtest, then restarted tfy-cloudflared-caddy successfully

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Helm/Caddy proxy header tweak in the tunnel ingress path; no auth or data-model changes, with low blast radius beyond upstream routing behavior.
> 
> **Overview**
> Fixes **tfy-cloudflared** Caddy direct-URL reverse proxies so the upstream **`Host`** header matches the hostname parsed from the tunnel path (same value already used for **`tls_server_name`** on HTTPS routes). The change is applied to all four direct handlers (`direct_url_http`, `direct_url_https`, `direct_https`, `direct_http`).
> 
> Chart version is bumped **0.3.0 → 0.3.1** to ship the updated Caddy ConfigMap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c08e7da12003bad88d6762c9b8bb7d65418e3e45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->