### PR TITLE
fixed cm sync in existing ns

### DIFF
--- a/charts/tfy-kyverno-config/Chart.yaml
+++ b/charts/tfy-kyverno-config/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: tfy-kyverno-config
 description: A Helm chart for kyverno configuration
 type: application
-version: 0.1.7
+version: 0.1.8
 maintainers:
   - name: truefoundry

--- a/charts/tfy-kyverno-config/templates/sync-configmaps.yaml
+++ b/charts/tfy-kyverno-config/templates/sync-configmaps.yaml
@@ -7,6 +7,8 @@ spec:
   evaluation:
     synchronize:
       enabled: true
+    generateExisting:
+      enabled: true
   matchConstraints:
     {{- if or .Values.syncConfigMaps.excludeNamespaces .Values.syncConfigMaps.includeNamespaces }}
     namespaceSelector:


### PR DESCRIPTION
https://linear.app/truefoundry/issue/INFRA-774/upgrade-tfy-kyverno-config-helm-chart-to-enable-configmap-sync-for

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Helm/Kyverno policy tweak with no auth or data-path changes; main effect is backfilling ConfigMaps in existing namespaces when the policy is applied.
> 
> **Overview**
> Bumps **tfy-kyverno-config** from `0.1.7` to `0.1.8` and turns on **`generateExisting`** on the ConfigMap **GeneratingPolicy** so synced ConfigMaps are created in namespaces that already exist, not only when new namespaces are created.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 693c269fe0a84fd3920ff3151eeb2e1ab61d16de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->