### PR TITLE
updated workflow and script to cater truefoundry chart

### DIFF
--- a/.github/workflows/update-artifacts.yml
+++ b/.github/workflows/update-artifacts.yml
@@ -87,14 +87,14 @@ jobs:
         run: |
           charts_list=("tfy-k8s-aws-eks-inframold" "tfy-k8s-azure-aks-inframold" "tfy-k8s-gcp-gke-standard-inframold" "tfy-k8s-civo-talos-inframold" "tfy-k8s-generic-inframold" "truefoundry")
           for chart in "${charts_list[@]}"; do
-            version=$(cat charts/$chart/Chart.yaml | grep version | awk '{print $2}')
+            version=$(grep '^version:' "charts/$chart/Chart.yaml" | awk '{print $2}')
             if [ "$chart" = "truefoundry" ]; then
               repo_url="oci://tfy.jfrog.io/tfy-helm"
-              python scripts/generate-artifacts-manifest/artifacts_template_generator.py $chart $repo_url \
-                $version charts/$chart/values-artifact-manifest.yaml charts/$chart/artifacts-manifest.json
+              python scripts/generate-artifacts-manifest/artifacts_template_generator.py "$chart" "$repo_url" \
+                "$version" "charts/$chart/values-artifact-manifest.yaml" "charts/$chart/artifacts-manifest.json"
             else
-              python scripts/generate-artifacts-manifest/artifacts_template_generator.py $chart https://truefoundry.github.io/infra-charts/ \
-                $version charts/$chart/values-artifact-manifest.yaml charts/$chart/artifacts-manifest.json scripts/generate-artifacts-manifest/extra.json
+              python scripts/generate-artifacts-manifest/artifacts_template_generator.py "$chart" "https://truefoundry.github.io/infra-charts/" \
+                "$version" "charts/$chart/values-artifact-manifest.yaml" "charts/$chart/artifacts-manifest.json" scripts/generate-artifacts-manifest/extra.json
             fi
           done
         env:

--- a/.github/workflows/update-artifacts.yml
+++ b/.github/workflows/update-artifacts.yml
@@ -11,6 +11,7 @@ on:
       - 'charts/tfy-k8s-civo-talos-inframold/**'
       - 'charts/tfy-k8s-gcp-gke-standard-inframold/**'
       - 'charts/tfy-k8s-generic-inframold/**'
+      - 'charts/truefoundry/**'
       - 'scripts/generate-artifacts-manifest/**'
       - 'scripts/upload-artifacts/**'
       - 'scripts/get-release-notes/**'
@@ -81,24 +82,32 @@ jobs:
           cp charts/tfy-k8s-aws-eks-inframold/artifacts-manifest.json charts/tfy-k8s-aws-eks-inframold/old-artifacts-manifest.json
 
 
-      # Generate artifacts manifest for inframold charts
+      # Generate artifacts manifest for inframold charts and truefoundry chart
       - name: Generate Artifacts Manifest for Each Chart
         run: |
-          charts_list=("tfy-k8s-aws-eks-inframold" "tfy-k8s-azure-aks-inframold" "tfy-k8s-gcp-gke-standard-inframold" "tfy-k8s-civo-talos-inframold" "tfy-k8s-generic-inframold")
+          charts_list=("tfy-k8s-aws-eks-inframold" "tfy-k8s-azure-aks-inframold" "tfy-k8s-gcp-gke-standard-inframold" "tfy-k8s-civo-talos-inframold" "tfy-k8s-generic-inframold" "truefoundry")
           for chart in "${charts_list[@]}"; do
             version=$(cat charts/$chart/Chart.yaml | grep version | awk '{print $2}')
-          
-            python scripts/generate-artifacts-manifest/artifacts_template_generator.py $chart https://truefoundry.github.io/infra-charts/ \
-              $version charts/$chart/values-artifact-manifest.yaml charts/$chart/artifacts-manifest.json scripts/generate-artifacts-manifest/extra.json
+            if [ "$chart" = "truefoundry" ]; then
+              repo_url="oci://tfy.jfrog.io/tfy-helm"
+              python scripts/generate-artifacts-manifest/artifacts_template_generator.py $chart $repo_url \
+                $version charts/$chart/values-artifact-manifest.yaml charts/$chart/artifacts-manifest.json
+            else
+              python scripts/generate-artifacts-manifest/artifacts_template_generator.py $chart https://truefoundry.github.io/infra-charts/ \
+                $version charts/$chart/values-artifact-manifest.yaml charts/$chart/artifacts-manifest.json scripts/generate-artifacts-manifest/extra.json
+            fi
           done
         env:
           MODE: 'local'
 
-      # Check if truefoundry chart images support amd64 and arm64 using AWS chart
+      # Check if truefoundry chart images support amd64 and arm64
       - name: Check if Truefoundry Chart Images Support Multiple Architectures
         run: |
           python scripts/generate-artifacts-manifest/check_chart_images_support_multiple_architectures.py \
           charts/tfy-k8s-aws-eks-inframold/artifacts-manifest.json \
+          scripts/generate-artifacts-manifest/multi-arch-image-whitelist.json
+          python scripts/generate-artifacts-manifest/check_chart_images_support_multiple_architectures.py \
+          charts/truefoundry/artifacts-manifest.json \
           scripts/generate-artifacts-manifest/multi-arch-image-whitelist.json
 
       # Generate changelog step is run on only tfy-k8s-aws-eks-inframold chart

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ charts/tfy-gpu-operator/charts/
 **/venv
 __pycache__
 charts/tfy-agent/charts/
+charts/truefoundry/charts/

--- a/charts/truefoundry/artifacts-manifest.json
+++ b/charts/truefoundry/artifacts-manifest.json
@@ -1,0 +1,434 @@
+[
+    {
+        "type": "helm",
+        "details": {
+            "chart": "truefoundry",
+            "repoURL": "oci://tfy.jfrog.io/tfy-helm",
+            "targetRevision": "0.147.0",
+            "images": [
+                "tfy.jfrog.io/tfy-private-images/tfy-llm-gateway:v0.147.0",
+                "tfy.jfrog.io/tfy-private-images/tfy-otel-collector:v0.145.0",
+                "tfy.jfrog.io/tfy-private-images/deltafusion-query-server:v0.146.0-optimized",
+                "tfy.jfrog.io/tfy-private-images/deltafusion-query-server:v0.146.0",
+                "tfy.jfrog.io/tfy-private-images/mlfoundry-server:v0.147.0",
+                "tfy.jfrog.io/tfy-private-images/s3proxy:v0.57.0",
+                "tfy.jfrog.io/tfy-private-images/servicefoundry-server:v0.147.0",
+                "tfy.jfrog.io/tfy-private-images/sfy-manifest-service:v0.133.0",
+                "tfy.jfrog.io/tfy-private-images/spark-history-server:v0.105.0",
+                "tfy.jfrog.io/tfy-private-images/tfy-controller:v0.130.0",
+                "tfy.jfrog.io/tfy-private-images/tfy-k8s-controller:v0.147.0",
+                "tfy.jfrog.io/tfy-private-images/tfy-proxy:v0.147.0",
+                "tfy.jfrog.io/tfy-private-images/tfy-workflow-admin:v0.80.0",
+                "tfy.jfrog.io/tfy-images/postgresql:16.6.0-debian-12-r2",
+                "tfy.jfrog.io/tfy-mirror/bitnamilegacy/redis:8.2.1-debian-12-r0",
+                "tfy.jfrog.io/tfy-mirror/nats:2.12.3-alpine",
+                "tfy.jfrog.io/tfy-mirror/natsio/nats-server-config-reloader:0.21.1",
+                "tfy.jfrog.io/tfy-mirror/natsio/prometheus-nats-exporter:0.18.0",
+                "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.147.0-optimized",
+                "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.147.0",
+                "tfy.jfrog.io/tfy-mirror/moby/buildkit:v0.26.2",
+                "tfy.jfrog.io/tfy-images/truefoundry-bootstrap:0.1.5"
+            ]
+        }
+    },
+    {
+        "type": "image",
+        "details": {
+            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-llm-gateway:v0.147.0",
+            "platforms": [
+                {
+                    "os": "linux",
+                    "architecture": "amd64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm64"
+                }
+            ]
+        }
+    },
+    {
+        "type": "image",
+        "details": {
+            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-otel-collector:v0.145.0",
+            "platforms": [
+                {
+                    "os": "linux",
+                    "architecture": "amd64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm64"
+                }
+            ]
+        }
+    },
+    {
+        "type": "image",
+        "details": {
+            "registryURL": "tfy.jfrog.io/tfy-private-images/deltafusion-query-server:v0.146.0-optimized",
+            "platforms": [
+                {
+                    "os": "linux",
+                    "architecture": "amd64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm64"
+                }
+            ]
+        }
+    },
+    {
+        "type": "image",
+        "details": {
+            "registryURL": "tfy.jfrog.io/tfy-private-images/deltafusion-query-server:v0.146.0",
+            "platforms": [
+                {
+                    "os": "linux",
+                    "architecture": "amd64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm64"
+                }
+            ]
+        }
+    },
+    {
+        "type": "image",
+        "details": {
+            "registryURL": "tfy.jfrog.io/tfy-private-images/mlfoundry-server:v0.147.0",
+            "platforms": [
+                {
+                    "os": "linux",
+                    "architecture": "amd64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm64"
+                }
+            ]
+        }
+    },
+    {
+        "type": "image",
+        "details": {
+            "registryURL": "tfy.jfrog.io/tfy-private-images/s3proxy:v0.57.0",
+            "platforms": [
+                {
+                    "os": "linux",
+                    "architecture": "amd64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm64"
+                }
+            ]
+        }
+    },
+    {
+        "type": "image",
+        "details": {
+            "registryURL": "tfy.jfrog.io/tfy-private-images/servicefoundry-server:v0.147.0",
+            "platforms": [
+                {
+                    "os": "linux",
+                    "architecture": "amd64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm64"
+                }
+            ]
+        }
+    },
+    {
+        "type": "image",
+        "details": {
+            "registryURL": "tfy.jfrog.io/tfy-private-images/sfy-manifest-service:v0.133.0",
+            "platforms": [
+                {
+                    "os": "linux",
+                    "architecture": "amd64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm64"
+                }
+            ]
+        }
+    },
+    {
+        "type": "image",
+        "details": {
+            "registryURL": "tfy.jfrog.io/tfy-private-images/spark-history-server:v0.105.0",
+            "platforms": [
+                {
+                    "os": "linux",
+                    "architecture": "amd64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm64"
+                }
+            ]
+        }
+    },
+    {
+        "type": "image",
+        "details": {
+            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-controller:v0.130.0",
+            "platforms": [
+                {
+                    "os": "linux",
+                    "architecture": "amd64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm64"
+                }
+            ]
+        }
+    },
+    {
+        "type": "image",
+        "details": {
+            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-k8s-controller:v0.147.0",
+            "platforms": [
+                {
+                    "os": "linux",
+                    "architecture": "amd64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm64"
+                }
+            ]
+        }
+    },
+    {
+        "type": "image",
+        "details": {
+            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-proxy:v0.147.0",
+            "platforms": [
+                {
+                    "os": "linux",
+                    "architecture": "amd64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm64"
+                }
+            ]
+        }
+    },
+    {
+        "type": "image",
+        "details": {
+            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-workflow-admin:v0.80.0",
+            "platforms": [
+                {
+                    "os": "linux",
+                    "architecture": "amd64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm64"
+                }
+            ]
+        }
+    },
+    {
+        "type": "image",
+        "details": {
+            "registryURL": "tfy.jfrog.io/tfy-images/postgresql:16.6.0-debian-12-r2",
+            "platforms": [
+                {
+                    "os": "linux",
+                    "architecture": "amd64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm64"
+                }
+            ]
+        }
+    },
+    {
+        "type": "image",
+        "details": {
+            "registryURL": "tfy.jfrog.io/tfy-mirror/bitnamilegacy/redis:8.2.1-debian-12-r0",
+            "platforms": [
+                {
+                    "os": "linux",
+                    "architecture": "amd64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm64"
+                }
+            ]
+        }
+    },
+    {
+        "type": "image",
+        "details": {
+            "registryURL": "tfy.jfrog.io/tfy-mirror/nats:2.12.3-alpine",
+            "platforms": [
+                {
+                    "os": "linux",
+                    "architecture": "amd64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "ppc64le"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "s390x"
+                }
+            ]
+        }
+    },
+    {
+        "type": "image",
+        "details": {
+            "registryURL": "tfy.jfrog.io/tfy-mirror/natsio/nats-server-config-reloader:0.21.1",
+            "platforms": [
+                {
+                    "os": "linux",
+                    "architecture": "amd64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm64"
+                }
+            ]
+        }
+    },
+    {
+        "type": "image",
+        "details": {
+            "registryURL": "tfy.jfrog.io/tfy-mirror/natsio/prometheus-nats-exporter:0.18.0",
+            "platforms": [
+                {
+                    "os": "linux",
+                    "architecture": "amd64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm64"
+                }
+            ]
+        }
+    },
+    {
+        "type": "image",
+        "details": {
+            "registryURL": "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.147.0-optimized",
+            "platforms": [
+                {
+                    "os": "linux",
+                    "architecture": "amd64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm64"
+                }
+            ]
+        }
+    },
+    {
+        "type": "image",
+        "details": {
+            "registryURL": "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.147.0",
+            "platforms": [
+                {
+                    "os": "linux",
+                    "architecture": "amd64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm64"
+                }
+            ]
+        }
+    },
+    {
+        "type": "image",
+        "details": {
+            "registryURL": "tfy.jfrog.io/tfy-mirror/moby/buildkit:v0.26.2",
+            "platforms": [
+                {
+                    "os": "linux",
+                    "architecture": "amd64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "s390x"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "ppc64le"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "riscv64"
+                }
+            ]
+        }
+    },
+    {
+        "type": "image",
+        "details": {
+            "registryURL": "tfy.jfrog.io/tfy-images/truefoundry-bootstrap:0.1.5",
+            "platforms": [
+                {
+                    "os": "linux",
+                    "architecture": "amd64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm64"
+                }
+            ]
+        }
+    }
+]

--- a/charts/truefoundry/values-artifact-manifest.yaml
+++ b/charts/truefoundry/values-artifact-manifest.yaml
@@ -1,0 +1,33 @@
+global:
+  tenantName: ""
+  controlPlaneURL: ""
+  truefoundryImagePullConfigJSON: ""
+  database:
+    host: ""
+    name: ""
+    username: ""
+    password: ""
+  tfyApiKey: ""
+
+tags:
+  tracing: true
+  llmGateway: true
+  llmGatewayRequestLogging: true
+
+devMode:
+  enabled: true
+
+truefoundryBootstrap:
+  enabled: true
+
+s3proxy:
+  enabled: true
+
+sparkHistoryServer:
+  enabled: true
+
+tfyWorkflowAdmin:
+  enabled: true
+
+truefoundryFrontendApp:
+  enabled: false

--- a/scripts/generate-artifacts-manifest/artifacts_template_generator.py
+++ b/scripts/generate-artifacts-manifest/artifacts_template_generator.py
@@ -190,6 +190,31 @@ def generate_manifests_local(chart_name, values_file):
     return manifest_file_path
 
 # Process charts and gather images
+def process_images_for_chart(raw_images):
+    processed_images = []
+    image_urls = []
+
+    for image_entry in raw_images:
+        image_registry_url = image_entry['details']['registryURL']
+
+        if image_registry_url.startswith(('auto', 'cos-nvidia-installer')):
+            processed_images.append(image_entry)
+            image_urls.append(image_registry_url)
+            continue
+
+        if any(sub in image_registry_url for sub in ['deltafusion-query-server', 'deltafusion-ingestor']):
+            optimized_image_entry = copy.deepcopy(image_entry)
+            optimized_image_entry['details']['registryURL'] = f"{image_registry_url}-optimized"
+            if image_entry['details'].get('platforms'):
+                optimized_image_entry['details']['platforms'] = image_entry['details']['platforms']
+            processed_images.append(optimized_image_entry)
+            image_urls.append(f"{image_registry_url}-optimized")
+
+        processed_images.append(image_entry)
+        image_urls.append(image_registry_url)
+
+    return processed_images, make_image_list_unique(image_urls)
+
 def process_and_generate_chart_manifests(chart_info_list):
     all_processed_images = []
     
@@ -219,34 +244,14 @@ def process_and_generate_chart_manifests(chart_info_list):
 
         # Get raw images from the manifest
         chart_raw_images = make_image_list_unique(extract_images_from_k8s_manifests(open(f"{temp_dir}/charts/{chart_name}.yaml").read()))
-        
-        # Process each image, setting platform info from previous_platform_data if already known
-        chart_processed_images = []
-        for image_entry in chart_raw_images:
+        chart_processed_images, image_urls = process_images_for_chart(chart_raw_images)
+
+        for image_entry in chart_processed_images:
             image_registry_url = image_entry['details']['registryURL']
-            
-            if image_registry_url.startswith(('auto', 'cos-nvidia-installer')):
-                chart_processed_images.append(image_entry)
-                continue
-            
-            # Adding -optimized images for deltafusion images
-            if any(sub in image_registry_url for sub in ['deltafusion-query-server', 'deltafusion-ingestor']):
-                optimized_image_entry = copy.deepcopy(image_entry)
-                optimized_image_entry['details']['registryURL'] = f"{image_registry_url}-optimized"
-                chart_processed_images.append(optimized_image_entry)
-            
-            # If the image is already seen before, use that platform info even if empty
             if image_registry_url in known_image_registry_urls:
-                # Reuse the existing platform info, even if empty
                 image_entry['details']['platforms'] = previous_platform_data[image_registry_url]
-                chart_processed_images.append(image_entry)
-            else:
-                # This is truly a new image, add it to be processed
-                chart_processed_images.append(image_entry)
-            
         
         # Log a summary
-        image_urls = [img['details']['registryURL'] for img in chart_processed_images]
         previously_known_count = len([url for url in image_urls if url in known_image_registry_urls])
         new_image_count = len(image_urls) - previously_known_count
         
@@ -350,7 +355,21 @@ if __name__ == '__main__':
         manifest_file_path = generate_manifests(args.chart_name, args.chart_repo_url, args.chart_version, args.values_file_path)
 
     chart_list = extract_chart_info(manifest_file_path)
-    new_chart_images = process_and_generate_chart_manifests(chart_list) if chart_list else make_image_list_unique(extract_images_from_k8s_manifests(open(manifest_file_path).read()))
+    if chart_list:
+        new_chart_images = process_and_generate_chart_manifests(chart_list)
+    else:
+        raw_images = make_image_list_unique(extract_images_from_k8s_manifests(open(manifest_file_path).read()))
+        new_chart_images, image_urls = process_images_for_chart(raw_images)
+        chart_list = [{
+            "type": "helm",
+            "details": {
+                "chart": args.chart_name,
+                "repoURL": normalize_repo_url(args.chart_repo_url),
+                "targetRevision": args.chart_version,
+                "images": image_urls,
+            }
+        }]
+        logging.info(f"Standalone chart {args.chart_name}@{args.chart_version} images: {len(image_urls)}")
 
     # Inject images with empty platforms from output_file into new_images
     images_to_inject = []
@@ -449,9 +468,19 @@ if __name__ == '__main__':
     
     # Track which images are actually inspected in this run
     newly_inspected_count = 0
-    
+
     for image_entry in new_chart_images:
         image_registry_url = image_entry['details']['registryURL']
+        if image_registry_url.endswith('-optimized') and not image_entry['details'].get('platforms'):
+            base_image_url = image_registry_url[:-len('-optimized')]
+            base_platforms = previous_platform_data.get(base_image_url)
+            if not base_platforms:
+                for candidate in new_chart_images:
+                    if candidate['details']['registryURL'] == base_image_url:
+                        base_platforms = candidate['details'].get('platforms', [])
+                        break
+            if base_platforms:
+                image_entry['details']['platforms'] = base_platforms
         
         # Skip if already has platforms (from output file or otherwise)
         if image_entry['details'].get('platforms') or image_registry_url in previous_platform_data:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes affect release automation and the canonical image/platform manifest used for multi-arch checks; misconfiguration of OCI repo or standalone-chart logic could produce incomplete manifests.
> 
> **Overview**
> Extends the **update-artifacts** workflow so the **`truefoundry`** chart is maintained like the inframold charts: path triggers, manifest generation, and a second multi-arch check against **`charts/truefoundry/artifacts-manifest.json`**. For **truefoundry**, generation uses the **OCI** repo `oci://tfy.jfrog.io/tfy-helm` and omits **`extra.json`**; inframold charts still use the GitHub Pages repo and **`extra.json`**.
> 
> **`artifacts_template_generator.py`** now supports **standalone** charts whose templated output has no nested Helm/Argo chart entries—it builds a single helm entry from CLI args and extracted images. Image handling is centralized in **`process_images_for_chart`**, and **`-optimized`** deltafusion tags can reuse platform metadata from the base image.
> 
> Adds **`charts/truefoundry/values-artifact-manifest.yaml`**, a generated **`artifacts-manifest.json`**, and ignores **`charts/truefoundry/charts/`** in **`.gitignore`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89537ce0c7c3a5ba38f4d3c95d2c504e01649e46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->