### PR TITLE
feat: add notebook images wrt databricks verion

### DIFF
--- a/charts/tfy-configs/files/workbench-images.yaml
+++ b/charts/tfy-configs/files/workbench-images.yaml
@@ -85,14 +85,41 @@ images:
         spec:
           image_uri: "public.ecr.aws/truefoundrycloud/jupyter:0.4.5-cu129-py3.12.12-sudo"
 
-  - name: Jupyter Lab Spark 3.5.1 (Python 3.11)
+  - name: Jupyter Lab Spark 4.0.2 (Python 3.12) - Databricks 17.3 LTS
     type: spark-notebook
     enabled: true
-    description: Python 3.11 environment with Apache Spark 3.5.1, Scala 2.12, and PySpark pre-installed
+    description: Python 3.12 environment with Apache Spark 4.0.2, Scala 2.13, Delta 4.0.1, and PySpark pre-installed (Databricks 17.3 LTS compatible)
     image:
       - match: []
         spec:
-          image_uri: "public.ecr.aws/truefoundrycloud/jupyter-spark:0.4.9-py3.11.14-sc2.12-spark3.5.7-sudo"
+          image_uri: "public.ecr.aws/truefoundrycloud/jupyter-spark:0.4.10-py3.12.3-sc2.13-spark4.0.2-delta4.0.1-sudo"
+
+  - name: Jupyter Lab Spark 3.5.7 (Python 3.11) - Databricks 16.4 LTS
+    type: spark-notebook
+    enabled: true
+    description: Python 3.11 environment with Apache Spark 3.5.7, Scala 2.12, Delta 3.3.2, and PySpark pre-installed (Databricks 16.4 LTS compatible)
+    image:
+      - match: []
+        spec:
+          image_uri: "public.ecr.aws/truefoundrycloud/jupyter-spark:0.4.10-py3.11.14-sc2.12-spark3.5.7-delta3.3.2-sudo"
+
+  - name: Jupyter Lab Spark 3.5.7 (Python 3.10) - Databricks 15.4 LTS
+    type: spark-notebook
+    enabled: true
+    description: Python 3.10 environment with Apache Spark 3.5.7, Scala 2.12, Delta 3.3.2, and PySpark pre-installed (Databricks 15.4 LTS compatible)
+    image:
+      - match: []
+        spec:
+          image_uri: "public.ecr.aws/truefoundrycloud/jupyter-spark:0.4.10-py3.10.16-sc2.12-spark3.5.7-delta3.3.2-sudo"
+
+  - name: Jupyter Lab Spark 3.5.7 (Python 3.10, Delta 3.1.0) - Databricks 14.3 LTS
+    type: spark-notebook
+    enabled: true
+    description: Python 3.10 environment with Apache Spark 3.5.7, Scala 2.12, Delta 3.1.0, and PySpark pre-installed (Databricks 14.3 LTS compatible)
+    image:
+      - match: []
+        spec:
+          image_uri: "public.ecr.aws/truefoundrycloud/jupyter-spark:0.4.10-py3.10.16-sc2.12-spark3.5.7-delta3.1.0-sudo"
 
   - name: SSH Server Minimal Image
     type: ssh-server


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Config-only changes to `workbench-images.yaml` with no application logic; main risk is users picking a new image tag or losing the old single Spark 3.5.1 entry name if anything referenced it explicitly.
> 
> **Overview**
> Replaces the single **Jupyter Lab Spark 3.5.1 (Python 3.11)** catalog entry with **four** `spark-notebook` options, each labeled for a **Databricks LTS** version (17.3, 16.4, 15.4, 14.3).
> 
> The top entry moves to **Spark 4.0.2 / Python 3.12 / Scala 2.13 / Delta 4.0.1** on `jupyter-spark:0.4.10-…`. The other three keep **Spark 3.5.7** with **Python 3.11 or 3.10** and **Delta 3.3.2 or 3.1.0**, all on the **0.4.10** image line instead of the previous **0.4.9** tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c81d1dae2b8732a584cbb41551952d0dffd93f8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->