### PR TITLE
fix: existing cm and secret sync by adding support for clusterpolicy

### DIFF
--- a/charts/tfy-kyverno-config/Chart.yaml
+++ b/charts/tfy-kyverno-config/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: tfy-kyverno-config
 description: A Helm chart for kyverno configuration
 type: application
-version: 0.1.8
+version: 0.1.9
 maintainers:
   - name: truefoundry

--- a/charts/tfy-kyverno-config/README.md
+++ b/charts/tfy-kyverno-config/README.md
@@ -23,21 +23,23 @@ A Helm chart for kyverno configurations
 
 ### syncConfigMaps Configuration options for syncing ConfigMaps across namespaces
 
-| Name                               | Description                                                                                          | Value   |
-| ---------------------------------- | ---------------------------------------------------------------------------------------------------- | ------- |
-| `syncConfigMaps.enabled`           | Enable or disable syncing ConfigMaps across namespaces                                               | `false` |
-| `syncConfigMaps.excludeNamespaces` | Namespaces to exclude from syncing ConfigMaps                                                        | `[]`    |
-| `syncConfigMaps.includeNamespaces` | Namespaces to include for syncing ConfigMaps. When non-empty, only these namespaces will be included | `[]`    |
-| `syncConfigMaps.items`             | List of ConfigMaps to sync across namespaces                                                         | `[]`    |
+| Name                               | Description                                                                                                                                                                                          | Value   |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `syncConfigMaps.enabled`           | Enable or disable syncing ConfigMaps across namespaces                                                                                                                                               | `false` |
+| `syncConfigMaps.useClusterPolicy`  | Use ClusterPolicy (kyverno.io/v1) instead of GeneratingPolicy (policies.kyverno.io/v1). ClusterPolicy has more mature generateExisting support and supports wildcard namespace patterns (e.g. tfy-*) | `true`  |
+| `syncConfigMaps.excludeNamespaces` | Namespaces to exclude from syncing ConfigMaps                                                                                                                                                        | `[]`    |
+| `syncConfigMaps.includeNamespaces` | Namespaces to include for syncing ConfigMaps. When non-empty, only these namespaces will be included. Supports wildcard patterns (e.g. tfy-*) when useClusterPolicy is true                          | `[]`    |
+| `syncConfigMaps.items`             | List of ConfigMaps to sync across namespaces                                                                                                                                                         | `[]`    |
 
 ### syncSecrets Configuration options for syncing Secrets across namespaces
 
-| Name                            | Description                                                                                       | Value   |
-| ------------------------------- | ------------------------------------------------------------------------------------------------- | ------- |
-| `syncSecrets.enabled`           | Enable or disable syncing Secrets across namespaces                                               | `false` |
-| `syncSecrets.excludeNamespaces` | Namespaces to exclude from syncing Secrets                                                        | `[]`    |
-| `syncSecrets.includeNamespaces` | Namespaces to include for syncing Secrets. When non-empty, only these namespaces will be included | `[]`    |
-| `syncSecrets.items`             | List of Secrets to sync across namespaces                                                         | `[]`    |
+| Name                            | Description                                                                                                                                                                                          | Value   |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `syncSecrets.enabled`           | Enable or disable syncing Secrets across namespaces                                                                                                                                                  | `false` |
+| `syncSecrets.useClusterPolicy`  | Use ClusterPolicy (kyverno.io/v1) instead of GeneratingPolicy (policies.kyverno.io/v1). ClusterPolicy has more mature generateExisting support and supports wildcard namespace patterns (e.g. tfy-*) | `true`  |
+| `syncSecrets.excludeNamespaces` | Namespaces to exclude from syncing Secrets                                                                                                                                                           | `[]`    |
+| `syncSecrets.includeNamespaces` | Namespaces to include for syncing Secrets. When non-empty, only these namespaces will be included. Supports wildcard patterns (e.g. tfy-*) when useClusterPolicy is true                             | `[]`    |
+| `syncSecrets.items`             | List of Secrets to sync across namespaces                                                                                                                                                            | `[]`    |
 
 ### podVolumeMounts Configuration options for adding volume mounts to pods
 

--- a/charts/tfy-kyverno-config/templates/sync-configmaps.yaml
+++ b/charts/tfy-kyverno-config/templates/sync-configmaps.yaml
@@ -1,4 +1,46 @@
 {{- if and .Values.syncConfigMaps.enabled .Values.syncConfigMaps.items -}}
+{{- if .Values.syncConfigMaps.useClusterPolicy }}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: {{ include "tfy-kyverno.fullname" . }}-sync-configmaps
+spec:
+  rules:
+    {{- range $i, $cm := .Values.syncConfigMaps.items }}
+    - name: sync-configmap-{{ $cm.name }}
+      skipBackgroundRequests: false
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+              {{- if $.Values.syncConfigMaps.includeNamespaces }}
+              names:
+                {{- range $.Values.syncConfigMaps.includeNamespaces }}
+                - {{ . | quote }}
+                {{- end }}
+              {{- end }}
+      {{- if $.Values.syncConfigMaps.excludeNamespaces }}
+      exclude:
+        any:
+          - resources:
+              names:
+                {{- range $.Values.syncConfigMaps.excludeNamespaces }}
+                - {{ . | quote }}
+                {{- end }}
+      {{- end }}
+      generate:
+        generateExisting: true
+        synchronize: true
+        apiVersion: v1
+        kind: ConfigMap
+        name: {{ $cm.name }}
+        namespace: "{{`{{request.object.metadata.name}}`}}"
+        clone:
+          namespace: {{ $cm.namespace }}
+          name: {{ $cm.name }}
+    {{- end }}
+{{- else }}
 apiVersion: policies.kyverno.io/v1
 kind: GeneratingPolicy
 metadata:
@@ -50,4 +92,5 @@ spec:
         {{- if $i }}, {{ end }}variables.source{{ $i }}
         {{- end }}
         ])
+{{- end }}
 {{- end -}}

--- a/charts/tfy-kyverno-config/templates/sync-configmaps.yaml
+++ b/charts/tfy-kyverno-config/templates/sync-configmaps.yaml
@@ -24,6 +24,8 @@ spec:
       exclude:
         any:
           - resources:
+              kinds:
+                - Namespace
               names:
                 {{- range $.Values.syncConfigMaps.excludeNamespaces }}
                 - {{ . | quote }}
@@ -34,11 +36,11 @@ spec:
         synchronize: true
         apiVersion: v1
         kind: ConfigMap
-        name: {{ $cm.name }}
+        name: {{ $cm.name | quote }}
         namespace: "{{`{{request.object.metadata.name}}`}}"
         clone:
-          namespace: {{ $cm.namespace }}
-          name: {{ $cm.name }}
+          namespace: {{ $cm.namespace | quote }}
+          name: {{ $cm.name | quote }}
     {{- end }}
 {{- else }}
 apiVersion: policies.kyverno.io/v1

--- a/charts/tfy-kyverno-config/templates/sync-secrets.yaml
+++ b/charts/tfy-kyverno-config/templates/sync-secrets.yaml
@@ -24,6 +24,8 @@ spec:
       exclude:
         any:
           - resources:
+              kinds:
+                - Namespace
               names:
                 {{- range $.Values.syncSecrets.excludeNamespaces }}
                 - {{ . | quote }}
@@ -34,11 +36,11 @@ spec:
         synchronize: true
         apiVersion: v1
         kind: Secret
-        name: {{ $secret.name }}
+        name: {{ $secret.name | quote }}
         namespace: "{{`{{request.object.metadata.name}}`}}"
         clone:
-          namespace: {{ $secret.namespace }}
-          name: {{ $secret.name }}
+          namespace: {{ $secret.namespace | quote }}
+          name: {{ $secret.name | quote }}
     {{- end }}
 {{- else }}
 apiVersion: policies.kyverno.io/v1

--- a/charts/tfy-kyverno-config/templates/sync-secrets.yaml
+++ b/charts/tfy-kyverno-config/templates/sync-secrets.yaml
@@ -1,4 +1,46 @@
 {{- if and .Values.syncSecrets.enabled .Values.syncSecrets.items -}}
+{{- if .Values.syncSecrets.useClusterPolicy }}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: {{ include "tfy-kyverno.fullname" . }}-sync-secrets
+spec:
+  rules:
+    {{- range $i, $secret := .Values.syncSecrets.items }}
+    - name: sync-secret-{{ $secret.name }}
+      skipBackgroundRequests: false
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+              {{- if $.Values.syncSecrets.includeNamespaces }}
+              names:
+                {{- range $.Values.syncSecrets.includeNamespaces }}
+                - {{ . | quote }}
+                {{- end }}
+              {{- end }}
+      {{- if $.Values.syncSecrets.excludeNamespaces }}
+      exclude:
+        any:
+          - resources:
+              names:
+                {{- range $.Values.syncSecrets.excludeNamespaces }}
+                - {{ . | quote }}
+                {{- end }}
+      {{- end }}
+      generate:
+        generateExisting: true
+        synchronize: true
+        apiVersion: v1
+        kind: Secret
+        name: {{ $secret.name }}
+        namespace: "{{`{{request.object.metadata.name}}`}}"
+        clone:
+          namespace: {{ $secret.namespace }}
+          name: {{ $secret.name }}
+    {{- end }}
+{{- else }}
 apiVersion: policies.kyverno.io/v1
 kind: GeneratingPolicy
 metadata:
@@ -6,6 +48,8 @@ metadata:
 spec:
   evaluation:
     synchronize:
+      enabled: true
+    generateExisting:
       enabled: true
   matchConstraints:
     {{- if or .Values.syncSecrets.excludeNamespaces .Values.syncSecrets.includeNamespaces }}
@@ -48,4 +92,5 @@ spec:
         {{- if $i }}, {{ end }}variables.source{{ $i }}
         {{- end }}
         ])
+{{- end }}
 {{- end -}}

--- a/charts/tfy-kyverno-config/values.yaml
+++ b/charts/tfy-kyverno-config/values.yaml
@@ -48,6 +48,9 @@ syncConfigMaps:
   items: []
 
 ## @section syncSecrets Configuration options for syncing Secrets across namespaces
+## Syncing secrets requires additional RBAC permissions for both the Kyverno admission
+## controller and the background controller to read source secrets and create/update/delete generated secrets for synchronization.
+## This must be configured in the Kyverno Helm chart values
 syncSecrets:
   ## @param syncSecrets.enabled Enable or disable syncing Secrets across namespaces
   enabled: false

--- a/charts/tfy-kyverno-config/values.yaml
+++ b/charts/tfy-kyverno-config/values.yaml
@@ -35,9 +35,11 @@ replaceArgoHelmRepo:
 syncConfigMaps:
   ## @param syncConfigMaps.enabled Enable or disable syncing ConfigMaps across namespaces
   enabled: false
+  ## @param syncConfigMaps.useClusterPolicy Use ClusterPolicy (kyverno.io/v1) instead of GeneratingPolicy (policies.kyverno.io/v1). ClusterPolicy has more mature generateExisting support and supports wildcard namespace patterns (e.g. tfy-*)
+  useClusterPolicy: true
   ## @param syncConfigMaps.excludeNamespaces Namespaces to exclude from syncing ConfigMaps
   excludeNamespaces: []
-  ## @param syncConfigMaps.includeNamespaces Namespaces to include for syncing ConfigMaps. When non-empty, only these namespaces will be included
+  ## @param syncConfigMaps.includeNamespaces Namespaces to include for syncing ConfigMaps. When non-empty, only these namespaces will be included. Supports wildcard patterns (e.g. tfy-*) when useClusterPolicy is true
   includeNamespaces: []
   ## @param syncConfigMaps.items List of ConfigMaps to sync across namespaces
   ## Example:
@@ -49,9 +51,11 @@ syncConfigMaps:
 syncSecrets:
   ## @param syncSecrets.enabled Enable or disable syncing Secrets across namespaces
   enabled: false
+  ## @param syncSecrets.useClusterPolicy Use ClusterPolicy (kyverno.io/v1) instead of GeneratingPolicy (policies.kyverno.io/v1). ClusterPolicy has more mature generateExisting support and supports wildcard namespace patterns (e.g. tfy-*)
+  useClusterPolicy: true
   ## @param syncSecrets.excludeNamespaces Namespaces to exclude from syncing Secrets
   excludeNamespaces: []
-  ## @param syncSecrets.includeNamespaces Namespaces to include for syncing Secrets. When non-empty, only these namespaces will be included
+  ## @param syncSecrets.includeNamespaces Namespaces to include for syncing Secrets. When non-empty, only these namespaces will be included. Supports wildcard patterns (e.g. tfy-*) when useClusterPolicy is true
   includeNamespaces: []
   ## @param syncSecrets.items List of Secrets to sync across namespaces
   ## Example:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes cluster-wide Kyverno policies and default behavior for sync; secret replication still depends on correct Kyverno RBAC and can affect many namespaces when enabled.
> 
> **Overview**
> Fixes **existing namespace ConfigMap and Secret sync** by defaulting to **Kyverno `ClusterPolicy`** (`kyverno.io/v1`) instead of **`GeneratingPolicy`**, with an opt-out via **`syncConfigMaps.useClusterPolicy`** / **`syncSecrets.useClusterPolicy`**.
> 
> When ClusterPolicy is enabled, the chart emits per-item **clone** generate rules on **Namespace** events with **`generateExisting`** and **`synchronize`**, and documents **wildcard include patterns** (e.g. `tfy-*`). The previous GeneratingPolicy templates remain behind `useClusterPolicy: false`; the secrets GeneratingPolicy branch also gains **`generateExisting`**.
> 
> Chart version is bumped to **0.1.9**; values/README note extra **Kyverno RBAC** needed for secret sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51d4ad4508214d8660a84dc0dc5042009a0b1fae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->