### PR TITLE
generate artifacts-manifest.json for tfy-llm-gateway chart

### DIFF
--- a/.github/workflows/update-artifacts.yml
+++ b/.github/workflows/update-artifacts.yml
@@ -12,6 +12,7 @@ on:
       - 'charts/tfy-k8s-gcp-gke-standard-inframold/**'
       - 'charts/tfy-k8s-generic-inframold/**'
       - 'charts/truefoundry/**'
+      - 'charts/tfy-llm-gateway/**'
       - 'scripts/generate-artifacts-manifest/**'
       - 'scripts/upload-artifacts/**'
       - 'scripts/get-release-notes/**'
@@ -85,12 +86,16 @@ jobs:
       # Generate artifacts manifest for inframold charts and truefoundry chart
       - name: Generate Artifacts Manifest for Each Chart
         run: |
-          charts_list=("tfy-k8s-aws-eks-inframold" "tfy-k8s-azure-aks-inframold" "tfy-k8s-gcp-gke-standard-inframold" "tfy-k8s-civo-talos-inframold" "tfy-k8s-generic-inframold" "truefoundry")
+          charts_list=("tfy-k8s-aws-eks-inframold" "tfy-k8s-azure-aks-inframold" "tfy-k8s-gcp-gke-standard-inframold" "tfy-k8s-civo-talos-inframold" "tfy-k8s-generic-inframold" "truefoundry" "tfy-llm-gateway")
           for chart in "${charts_list[@]}"; do
             version=$(grep '^version:' "charts/$chart/Chart.yaml" | awk '{print $2}')
             if [ "$chart" = "truefoundry" ]; then
               repo_url="oci://tfy.jfrog.io/tfy-helm"
               python scripts/generate-artifacts-manifest/artifacts_template_generator.py "$chart" "$repo_url" \
+                "$version" "charts/$chart/values-artifact-manifest.yaml" "charts/$chart/artifacts-manifest.json"
+            elif [ "$chart" = "tfy-llm-gateway" ]; then
+              # Standalone application chart (like truefoundry): only its own images, no platform extra.json
+              python scripts/generate-artifacts-manifest/artifacts_template_generator.py "$chart" "https://truefoundry.github.io/infra-charts/" \
                 "$version" "charts/$chart/values-artifact-manifest.yaml" "charts/$chart/artifacts-manifest.json"
             else
               python scripts/generate-artifacts-manifest/artifacts_template_generator.py "$chart" "https://truefoundry.github.io/infra-charts/" \
@@ -108,6 +113,9 @@ jobs:
           scripts/generate-artifacts-manifest/multi-arch-image-whitelist.json
           python scripts/generate-artifacts-manifest/check_chart_images_support_multiple_architectures.py \
           charts/truefoundry/artifacts-manifest.json \
+          scripts/generate-artifacts-manifest/multi-arch-image-whitelist.json
+          python scripts/generate-artifacts-manifest/check_chart_images_support_multiple_architectures.py \
+          charts/tfy-llm-gateway/artifacts-manifest.json \
           scripts/generate-artifacts-manifest/multi-arch-image-whitelist.json
 
       # Generate changelog step is run on only tfy-k8s-aws-eks-inframold chart

--- a/charts/tfy-llm-gateway/artifacts-manifest.json
+++ b/charts/tfy-llm-gateway/artifacts-manifest.json
@@ -1,0 +1,104 @@
+[
+    {
+        "type": "helm",
+        "details": {
+            "chart": "tfy-llm-gateway",
+            "repoURL": "https://truefoundry.github.io/infra-charts/",
+            "targetRevision": "0.148.0-rc.3",
+            "images": [
+                "tfy.jfrog.io/tfy-private-images/tfy-llm-gateway:v0.148.0-rc.3",
+                "tfy.jfrog.io/tfy-private-images/tfy-proxy:v0.148.0-rc.3",
+                "tfy.jfrog.io/tfy-mirror/alpine:3.21",
+                "tfy.jfrog.io/tfy-mirror/bitnamilegacy/redis:8.2.1-debian-12-r0"
+            ]
+        }
+    },
+    {
+        "type": "image",
+        "details": {
+            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-llm-gateway:v0.148.0-rc.3",
+            "platforms": [
+                {
+                    "os": "linux",
+                    "architecture": "arm64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "amd64"
+                }
+            ]
+        }
+    },
+    {
+        "type": "image",
+        "details": {
+            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-proxy:v0.148.0-rc.3",
+            "platforms": [
+                {
+                    "os": "linux",
+                    "architecture": "amd64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm64"
+                }
+            ]
+        }
+    },
+    {
+        "type": "image",
+        "details": {
+            "registryURL": "tfy.jfrog.io/tfy-mirror/alpine:3.21",
+            "platforms": [
+                {
+                    "os": "linux",
+                    "architecture": "amd64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "386"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "ppc64le"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "riscv64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "s390x"
+                }
+            ]
+        }
+    },
+    {
+        "type": "image",
+        "details": {
+            "registryURL": "tfy.jfrog.io/tfy-mirror/bitnamilegacy/redis:8.2.1-debian-12-r0",
+            "platforms": [
+                {
+                    "os": "linux",
+                    "architecture": "amd64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm64"
+                }
+            ]
+        }
+    }
+]

--- a/charts/tfy-llm-gateway/values-artifact-manifest.yaml
+++ b/charts/tfy-llm-gateway/values-artifact-manifest.yaml
@@ -1,0 +1,17 @@
+global:
+  tenantName: ""
+  controlPlaneURL: ""
+  customCA:
+    enabled: true
+    certificate: |
+      -----BEGIN CERTIFICATE-----
+      MIIBdummycertificatecontentusedonlyforartifactmanifestrendering==
+      -----END CERTIFICATE-----
+
+proxy:
+  tls:
+    enabled: true
+    secretName: tfy-llm-gateway-proxy-tls
+
+redis:
+  enabled: true

--- a/charts/tfy-llm-gateway/values-artifact-manifest.yaml
+++ b/charts/tfy-llm-gateway/values-artifact-manifest.yaml
@@ -3,11 +3,9 @@ global:
   controlPlaneURL: ""
   customCA:
     enabled: true
-    certificate: |
-      -----BEGIN CERTIFICATE-----
-      MIIBdummycertificatecontentusedonlyforartifactmanifestrendering==
-      -----END CERTIFICATE-----
-
+    existingConfigMap:
+      name: tfy-llm-gateway-custom-ca
+      overrideCAList: false
 proxy:
   tls:
     enabled: true

--- a/scripts/generate-artifacts-manifest/check_chart_images_support_multiple_architectures.py
+++ b/scripts/generate-artifacts-manifest/check_chart_images_support_multiple_architectures.py
@@ -7,7 +7,7 @@ from pathlib import Path
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
-truefoundry_charts = ["truefoundry", "tfy-agent", "elasti"]
+VALIDATED_CHARTS = ["truefoundry", "tfy-agent", "elasti", "tfy-llm-gateway"]
 
 def load_json_file(file_path: str):
     """Load and return the contents of a JSON file."""
@@ -42,23 +42,25 @@ def parse_args(args):
     return artifacts_manifest_path, whitelisted_images_path
 
 
-def get_truefoundry_chart_images(artifacts_manifest):
-    """Extract the list of images associated with the 'truefoundry' chart."""
+def get_validated_chart_images(artifacts_manifest):
+    """Extract images associated with charts that require multi-arch validation."""
     for artifact in artifacts_manifest:
-        if artifact.get("details", {}).get("chart") in truefoundry_charts:
-            return artifact["details"].get("images", [])
+        details = artifact.get("details", {})
+        if artifact.get("type") == "helm" and details.get("chart") in VALIDATED_CHARTS:
+            return details.get("images", [])
     return []
 
 
-def check_image_architectures(artifacts_manifest, truefoundry_chart_images, whitelisted_images):
+def check_image_architectures(artifacts_manifest, validated_chart_images, whitelisted_images):
+    validated_chart_image_set = set(validated_chart_images)
     whitelisted_set = set(whitelisted_images)
 
     for artifact_image in artifacts_manifest:
         if artifact_image.get("type") == "image":
             image_url = artifact_image.get("details", {}).get("registryURL")
 
-            # Skip images not in the truefoundry chart images list
-            if image_url not in truefoundry_chart_images:
+            # Skip images not in the validated chart images list
+            if image_url not in validated_chart_image_set:
                 continue
 
             platforms = artifact_image.get("details", {}).get("platforms", [])
@@ -87,10 +89,17 @@ def main():
     artifacts_manifest = load_json_file(artifacts_manifest_path)
     whitelisted_images = load_json_file(whitelisted_images_path)
 
-    truefoundry_chart_images = get_truefoundry_chart_images(artifacts_manifest)
-    check_image_architectures(artifacts_manifest, truefoundry_chart_images, whitelisted_images)
+    validated_chart_images = get_validated_chart_images(artifacts_manifest)
+    if not validated_chart_images:
+        logging.error(
+            "No images found for charts that require multi-arch validation. "
+            f"Supported charts: {', '.join(sorted(VALIDATED_CHARTS))}"
+        )
+        sys.exit(1)
 
-    logging.info("All images in the truefoundry chart support both arm64 and amd64 architectures.")
+    check_image_architectures(artifacts_manifest, validated_chart_images, whitelisted_images)
+
+    logging.info("All images in the validated charts support both arm64 and amd64 architectures.")
 
 
 if __name__ == "__main__":

--- a/scripts/generate-artifacts-manifest/test_check_chart_images_support_multiple_architectures.py
+++ b/scripts/generate-artifacts-manifest/test_check_chart_images_support_multiple_architectures.py
@@ -1,0 +1,74 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+SCRIPT_PATH = Path(__file__).with_name("check_chart_images_support_multiple_architectures.py")
+SPEC = importlib.util.spec_from_file_location("multi_arch_check", SCRIPT_PATH)
+multi_arch_check = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(multi_arch_check)
+
+
+class CheckChartImagesSupportMultipleArchitecturesTest(unittest.TestCase):
+    def test_collects_tfy_llm_gateway_images(self):
+        artifacts_manifest = [
+            {
+                "type": "helm",
+                "details": {
+                    "chart": "tfy-llm-gateway",
+                    "images": ["example.com/tfy-llm-gateway:v1"],
+                },
+            }
+        ]
+
+        chart_images = multi_arch_check.get_validated_chart_images(artifacts_manifest)
+
+        self.assertEqual(chart_images, ["example.com/tfy-llm-gateway:v1"])
+
+    def test_returns_first_validated_chart_images(self):
+        artifacts_manifest = [
+            {
+                "type": "helm",
+                "details": {"chart": "elasti", "images": ["example.com/elasti:v1"]},
+            },
+            {
+                "type": "helm",
+                "details": {"chart": "truefoundry", "images": ["example.com/truefoundry:v1"]},
+            },
+            {
+                "type": "helm",
+                "details": {"chart": "unsupported", "images": ["example.com/unsupported:v1"]},
+            },
+        ]
+
+        chart_images = multi_arch_check.get_validated_chart_images(artifacts_manifest)
+
+        self.assertEqual(chart_images, ["example.com/elasti:v1"])
+
+    def test_fails_when_gateway_image_missing_arm64(self):
+        artifacts_manifest = [
+            {
+                "type": "helm",
+                "details": {
+                    "chart": "tfy-llm-gateway",
+                    "images": ["example.com/tfy-llm-gateway:v1"],
+                },
+            },
+            {
+                "type": "image",
+                "details": {
+                    "registryURL": "example.com/tfy-llm-gateway:v1",
+                    "platforms": [{"os": "linux", "architecture": "amd64"}],
+                },
+            },
+        ]
+        chart_images = multi_arch_check.get_validated_chart_images(artifacts_manifest)
+
+        with self.assertRaises(SystemExit) as exit_context:
+            multi_arch_check.check_image_architectures(artifacts_manifest, chart_images, [])
+
+        self.assertEqual(exit_context.exception.code, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add artifacts-manifest.json for the tfy-llm-gateway helm chart following the same pattern as the truefoundry and inframold charts. As a cloud-agnostic application chart, a single manifest covers all cloud providers (AWS, GCP, Azure, Civo, generic) since the rendered image set is identical across clouds.

- Add charts/tfy-llm-gateway/values-artifact-manifest.yaml enabling all optional image-producing components (TLS proxy, custom CA, redis)
- Add generated charts/tfy-llm-gateway/artifacts-manifest.json with multi-arch platform data
- Wire tfy-llm-gateway into update-artifacts.yml (path triggers, generation loop, and multi-arch verification)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to artifact manifest generation, CI wiring, and validation scripts with no impact on runtime deployment or security-sensitive application logic.
> 
> **Overview**
> Adds **tfy-llm-gateway** to the artifacts pipeline so it gets the same generated manifest and CI checks as **truefoundry** and the inframold charts.
> 
> New **`values-artifact-manifest.yaml`** turns on optional image-producing pieces (TLS proxy, custom CA, Redis) so generation captures the full image set. The committed **`artifacts-manifest.json`** lists the chart revision, four container images, and per-image platform metadata.
> 
> **`update-artifacts.yml`** now triggers on `charts/tfy-llm-gateway/**`, includes the chart in the generation loop (GitHub Pages repo URL, no platform **`extra.json`**), and runs the multi-arch checker on its manifest.
> 
> The multi-arch script is generalized: **`VALIDATED_CHARTS`** includes **`tfy-llm-gateway`**, image collection only considers **`helm`** entries, and the job fails if no validated chart images are found. Unit tests cover gateway image collection and amd64/arm64 enforcement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 546927d9e19da39db768a7c81c96b90b44807bee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->