### PR TITLE
PLA-1623: Added github action to validate pr title to check whether it includes linear ticket or not

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,13 @@
+name: PR Checks
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+jobs:
+  validate-pr-title:
+    uses: truefoundry/workflows/.github/workflows/pr-title-check.yml@main


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only change with no runtime or deployment impact; validation logic lives in the external reusable workflow pinned to `@main`.
> 
> **Overview**
> Adds a **PR Checks** GitHub Actions workflow that runs on pull request **opened**, **edited**, **synchronize**, and **reopened** events.
> 
> The only job, `validate-pr-title`, delegates to the shared **`truefoundry/workflows`** reusable workflow at `@main`, enforcing that PR titles include a Linear ticket reference (per PLA-1623).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc69ce1f8edacb5533f02f0fcadf1d18bf189d2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->