### PR TITLE
move path filter to job level in update-artifacts workflow

### DIFF
--- a/.github/workflows/update-artifacts.yml
+++ b/.github/workflows/update-artifacts.yml
@@ -4,21 +4,34 @@ on:
   pull_request:
     branches:
       - 'main'
-    paths:
-      - '.github/workflows/update-artifacts.yml'
-      - 'charts/tfy-k8s-aws-eks-inframold/**'
-      - 'charts/tfy-k8s-azure-aks-inframold/**'
-      - 'charts/tfy-k8s-civo-talos-inframold/**'
-      - 'charts/tfy-k8s-gcp-gke-standard-inframold/**'
-      - 'charts/tfy-k8s-generic-inframold/**'
-      - 'charts/truefoundry/**'
-      - 'charts/tfy-llm-gateway/**'
-      - 'scripts/generate-artifacts-manifest/**'
-      - 'scripts/upload-artifacts/**'
-      - 'scripts/get-release-notes/**'
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - name: Detect Relevant Path Changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - '.github/workflows/update-artifacts.yml'
+              - 'charts/tfy-k8s-aws-eks-inframold/**'
+              - 'charts/tfy-k8s-azure-aks-inframold/**'
+              - 'charts/tfy-k8s-civo-talos-inframold/**'
+              - 'charts/tfy-k8s-gcp-gke-standard-inframold/**'
+              - 'charts/tfy-k8s-generic-inframold/**'
+              - 'charts/truefoundry/**'
+              - 'charts/tfy-llm-gateway/**'
+              - 'scripts/generate-artifacts-manifest/**'
+              - 'scripts/upload-artifacts/**'
+              - 'scripts/get-release-notes/**'
+
   update-artifacts:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/update-artifacts.yml
+++ b/.github/workflows/update-artifacts.yml
@@ -12,7 +12,7 @@ jobs:
       relevant: ${{ steps.filter.outputs.relevant }}
     steps:
       - name: Detect Relevant Path Changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |


### PR DESCRIPTION
Convert the workflow-level paths filter into a job-level conditional so the required update-artifacts check always reports a status (Success when skipped), unblocking PRs that don't touch the filtered paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change; artifact generation logic is unchanged and still gated on the same path set.
> 
> **Overview**
> **Removes the workflow-level `pull_request.paths` filter** so the Generate Inframold Charts Artifacts Manifest workflow runs on every PR to `main`, instead of being omitted entirely when unrelated files change.
> 
> **Adds a `changes` job** that uses `dorny/paths-filter@v4` with the same path list as before (workflow file, inframold/truefoundry/llm-gateway charts, and artifact scripts). **`update-artifacts` now `needs: changes` and runs only when `relevant` is true**, preserving the old scope of work while ensuring CI always posts a job outcome for PRs that don’t touch those paths—avoiding stuck/pending required checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d46d20d0238b7deaf3996fc6bfa00a50eb1d980. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->