### PR TITLE
feat: thread tags to Karpenter nodes + EBS PVC volumes (INFRA-703)

### DIFF
--- a/charts/tfy-k8s-aws-eks-inframold/Chart.yaml
+++ b/charts/tfy-k8s-aws-eks-inframold/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: tfy-k8s-aws-eks-inframold
-version: 0.1.286
+version: 0.1.287
 description: "Inframold, the superchart that configure your cluster on aws for truefoundry."
 maintainers:
   - name: truefoundry

--- a/charts/tfy-k8s-aws-eks-inframold/Chart.yaml
+++ b/charts/tfy-k8s-aws-eks-inframold/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: tfy-k8s-aws-eks-inframold
-version: 0.1.287
+version: 0.1.288
 description: "Inframold, the superchart that configure your cluster on aws for truefoundry."
 maintainers:
   - name: truefoundry

--- a/charts/tfy-k8s-aws-eks-inframold/README.md
+++ b/charts/tfy-k8s-aws-eks-inframold/README.md
@@ -5,16 +5,17 @@ Inframold, the superchart that configure your cluster on aws for truefoundry.
 
 ### Global Parameters
 
-| Name               | Description                                                | Value |
-| ------------------ | ---------------------------------------------------------- | ----- |
-| `global.repoURL`   | Override chart repository URL for all Argo CD Applications | `""`  |
-| `tenantName`       | Parameters for tenantName                                  | `""`  |
-| `controlPlaneURL`  | Parameters for controlPlaneURL                             | `""`  |
-| `clusterName`      | Name of the cluster                                        | `""`  |
-| `registry`         | registry to override in the chart components               | `""`  |
-| `imagePullSecrets` | imagePullSecrets to override in the chart components       | `[]`  |
-| `tolerations`      | Tolerations for the all chart components                   | `[]`  |
-| `affinity`         | Affinity for the all chart components                      | `{}`  |
+| Name               | Description                                                                                           | Value |
+| ------------------ | ----------------------------------------------------------------------------------------------------- | ----- |
+| `global.repoURL`   | Override chart repository URL for all Argo CD Applications                                            | `""`  |
+| `tenantName`       | Parameters for tenantName                                                                             | `""`  |
+| `controlPlaneURL`  | Parameters for controlPlaneURL                                                                        | `""`  |
+| `clusterName`      | Name of the cluster                                                                                   | `""`  |
+| `tags`             | AWS resource tags applied to Karpenter-launched EC2 nodes and dynamically-provisioned EBS PVC volumes | `{}`  |
+| `registry`         | registry to override in the chart components                                                          | `""`  |
+| `imagePullSecrets` | imagePullSecrets to override in the chart components                                                  | `[]`  |
+| `tolerations`      | Tolerations for the all chart components                                                              | `[]`  |
+| `affinity`         | Affinity for the all chart components                                                                 | `{}`  |
 
 ### argocd parameters
 

--- a/charts/tfy-k8s-aws-eks-inframold/templates/tfy-aws/aws-ebs-csi-driver.yaml
+++ b/charts/tfy-k8s-aws-eks-inframold/templates/tfy-aws/aws-ebs-csi-driver.yaml
@@ -104,6 +104,9 @@ spec:
             cluster-name: "{{ .Values.clusterName }}"
             volume-type: csi-ebs
             truefoundry.com/managed: "true"
+            {{- range $k, $v := .Values.tags }}
+            {{ $k }}: {{ $v | quote }}
+            {{- end }}
           {{- if $mergedTolerations }}
           tolerations:
             {{- toYaml $mergedTolerations | nindent 14 }}

--- a/charts/tfy-k8s-aws-eks-inframold/templates/tfy-aws/aws-ebs-csi-driver.yaml
+++ b/charts/tfy-k8s-aws-eks-inframold/templates/tfy-aws/aws-ebs-csi-driver.yaml
@@ -104,6 +104,8 @@ spec:
             cluster-name: "{{ .Values.clusterName }}"
             volume-type: csi-ebs
             truefoundry.com/managed: "true"
+            truefoundry-cluster-name: "{{ .Values.clusterName }}"
+            truefoundry-managed: "true"
             {{- range $k, $v := .Values.tags }}
             {{ $k }}: {{ $v | quote }}
             {{- end }}

--- a/charts/tfy-k8s-aws-eks-inframold/templates/tfy-aws/karpenter-config.yaml
+++ b/charts/tfy-k8s-aws-eks-inframold/templates/tfy-aws/karpenter-config.yaml
@@ -59,6 +59,7 @@ spec:
             zones: {{- range .Values.aws.karpenter.defaultZones }}
             - {{ . | quote }}
             {{- end }}
+          {{- if or .Values.aws.karpenter.kmsKeyID .Values.tags }}
           inferentiaDefaultNodeTemplate:
             {{- if .Values.aws.karpenter.kmsKeyID }}
             kmsKeyID: {{ .Values.aws.karpenter.kmsKeyID | default "" }}
@@ -67,6 +68,7 @@ spec:
             extraTags:
               {{- .Values.tags | toYaml | nindent 14 }}
             {{- end }}
+          {{- end }}
           critical:
             zones: {{- range .Values.aws.karpenter.defaultZones }}
             - {{ . | quote }}
@@ -85,6 +87,7 @@ spec:
             zones: {{- range .Values.aws.karpenter.defaultZones }}
             - {{ . | quote }}
             {{- end }}
+          {{- if or .Values.aws.karpenter.kmsKeyID .Values.tags }}
           controlPlaneNodeTemplate:
             {{- if .Values.aws.karpenter.kmsKeyID }}
             kmsKeyID: {{ .Values.aws.karpenter.kmsKeyID | default "" }}
@@ -93,6 +96,7 @@ spec:
             extraTags:
               {{- .Values.tags | toYaml | nindent 14 }}
             {{- end }}
+          {{- end }}
         {{- end }}
   project: tfy-apps
   syncPolicy:

--- a/charts/tfy-k8s-aws-eks-inframold/templates/tfy-aws/karpenter-config.yaml
+++ b/charts/tfy-k8s-aws-eks-inframold/templates/tfy-aws/karpenter-config.yaml
@@ -36,6 +36,10 @@ spec:
             {{- if .Values.aws.karpenter.kmsKeyID }}
             kmsKeyID: {{ .Values.aws.karpenter.kmsKeyID | default "" }}
             {{- end }}
+            {{- if .Values.tags }}
+            extraTags:
+              {{- .Values.tags | toYaml | nindent 14 }}
+            {{- end }}
           {{- if .Values.gpu.enabled }}
           gpuNodePool:
             zones: {{- range .Values.aws.karpenter.defaultZones }}
@@ -46,31 +50,49 @@ spec:
             {{- if .Values.aws.karpenter.kmsKeyID }}
             kmsKeyID: {{ .Values.aws.karpenter.kmsKeyID | default "" }}
             {{- end }}
+            {{- if .Values.tags }}
+            extraTags:
+              {{- .Values.tags | toYaml | nindent 14 }}
+            {{- end }}
           {{- end }}
           inferentiaNodePool:
             zones: {{- range .Values.aws.karpenter.defaultZones }}
             - {{ . | quote }}
             {{- end }}
-          {{- if .Values.aws.karpenter.kmsKeyID }}
           inferentiaDefaultNodeTemplate:
+            {{- if .Values.aws.karpenter.kmsKeyID }}
             kmsKeyID: {{ .Values.aws.karpenter.kmsKeyID | default "" }}
-          {{- end }}
+            {{- end }}
+            {{- if .Values.tags }}
+            extraTags:
+              {{- .Values.tags | toYaml | nindent 14 }}
+            {{- end }}
           critical:
             zones: {{- range .Values.aws.karpenter.defaultZones }}
             - {{ . | quote }}
             {{- end }}
-            {{- if .Values.aws.karpenter.kmsKeyID }}
+            {{- if or .Values.aws.karpenter.kmsKeyID .Values.tags }}
             nodeclass:
+              {{- if .Values.aws.karpenter.kmsKeyID }}
               kmsKeyID: {{ .Values.aws.karpenter.kmsKeyID | default "" }}
+              {{- end }}
+              {{- if .Values.tags }}
+              extraTags:
+                {{- .Values.tags | toYaml | nindent 16 }}
+              {{- end }}
             {{- end }}
           controlPlaneNodePool:
             zones: {{- range .Values.aws.karpenter.defaultZones }}
             - {{ . | quote }}
             {{- end }}
-          {{- if .Values.aws.karpenter.kmsKeyID }}
           controlPlaneNodeTemplate:
+            {{- if .Values.aws.karpenter.kmsKeyID }}
             kmsKeyID: {{ .Values.aws.karpenter.kmsKeyID | default "" }}
-          {{- end }}
+            {{- end }}
+            {{- if .Values.tags }}
+            extraTags:
+              {{- .Values.tags | toYaml | nindent 14 }}
+            {{- end }}
         {{- end }}
   project: tfy-apps
   syncPolicy:

--- a/charts/tfy-k8s-aws-eks-inframold/templates/tfy-aws/karpenter-config.yaml
+++ b/charts/tfy-k8s-aws-eks-inframold/templates/tfy-aws/karpenter-config.yaml
@@ -36,10 +36,12 @@ spec:
             {{- if .Values.aws.karpenter.kmsKeyID }}
             kmsKeyID: {{ .Values.aws.karpenter.kmsKeyID | default "" }}
             {{- end }}
-            {{- if .Values.tags }}
             extraTags:
-              {{- .Values.tags | toYaml | nindent 14 }}
-            {{- end }}
+              truefoundry-cluster-name: {{ .Values.clusterName | quote }}
+              truefoundry-managed: "true"
+              {{- range $k, $v := .Values.tags }}
+              {{ $k }}: {{ $v | quote }}
+              {{- end }}
           {{- if .Values.gpu.enabled }}
           gpuNodePool:
             zones: {{- range .Values.aws.karpenter.defaultZones }}
@@ -50,53 +52,55 @@ spec:
             {{- if .Values.aws.karpenter.kmsKeyID }}
             kmsKeyID: {{ .Values.aws.karpenter.kmsKeyID | default "" }}
             {{- end }}
-            {{- if .Values.tags }}
             extraTags:
-              {{- .Values.tags | toYaml | nindent 14 }}
-            {{- end }}
+              truefoundry-cluster-name: {{ .Values.clusterName | quote }}
+              truefoundry-managed: "true"
+              {{- range $k, $v := .Values.tags }}
+              {{ $k }}: {{ $v | quote }}
+              {{- end }}
           {{- end }}
           inferentiaNodePool:
             zones: {{- range .Values.aws.karpenter.defaultZones }}
             - {{ . | quote }}
             {{- end }}
-          {{- if or .Values.aws.karpenter.kmsKeyID .Values.tags }}
           inferentiaDefaultNodeTemplate:
             {{- if .Values.aws.karpenter.kmsKeyID }}
             kmsKeyID: {{ .Values.aws.karpenter.kmsKeyID | default "" }}
             {{- end }}
-            {{- if .Values.tags }}
             extraTags:
-              {{- .Values.tags | toYaml | nindent 14 }}
-            {{- end }}
-          {{- end }}
+              truefoundry-cluster-name: {{ .Values.clusterName | quote }}
+              truefoundry-managed: "true"
+              {{- range $k, $v := .Values.tags }}
+              {{ $k }}: {{ $v | quote }}
+              {{- end }}
           critical:
             zones: {{- range .Values.aws.karpenter.defaultZones }}
             - {{ . | quote }}
             {{- end }}
-            {{- if or .Values.aws.karpenter.kmsKeyID .Values.tags }}
             nodeclass:
               {{- if .Values.aws.karpenter.kmsKeyID }}
               kmsKeyID: {{ .Values.aws.karpenter.kmsKeyID | default "" }}
               {{- end }}
-              {{- if .Values.tags }}
               extraTags:
-                {{- .Values.tags | toYaml | nindent 16 }}
-              {{- end }}
-            {{- end }}
+                truefoundry-cluster-name: {{ .Values.clusterName | quote }}
+                truefoundry-managed: "true"
+                {{- range $k, $v := .Values.tags }}
+                {{ $k }}: {{ $v | quote }}
+                {{- end }}
           controlPlaneNodePool:
             zones: {{- range .Values.aws.karpenter.defaultZones }}
             - {{ . | quote }}
             {{- end }}
-          {{- if or .Values.aws.karpenter.kmsKeyID .Values.tags }}
           controlPlaneNodeTemplate:
             {{- if .Values.aws.karpenter.kmsKeyID }}
             kmsKeyID: {{ .Values.aws.karpenter.kmsKeyID | default "" }}
             {{- end }}
-            {{- if .Values.tags }}
             extraTags:
-              {{- .Values.tags | toYaml | nindent 14 }}
-            {{- end }}
-          {{- end }}
+              truefoundry-cluster-name: {{ .Values.clusterName | quote }}
+              truefoundry-managed: "true"
+              {{- range $k, $v := .Values.tags }}
+              {{ $k }}: {{ $v | quote }}
+              {{- end }}
         {{- end }}
   project: tfy-apps
   syncPolicy:

--- a/charts/tfy-k8s-aws-eks-inframold/values.yaml
+++ b/charts/tfy-k8s-aws-eks-inframold/values.yaml
@@ -35,6 +35,16 @@ controlPlaneURL: ""
 ##
 clusterName: ""
 
+## @param tags [object] AWS resource tags applied to Karpenter-launched EC2 nodes and dynamically-provisioned EBS PVC volumes
+## Key/value pairs are threaded into tfy-karpenter-config extraTags (EC2NodeClass spec.tags)
+## and into the EBS CSI driver controller.extraVolumeTags for all new PVC volumes.
+## Example:
+##   tags:
+##     cost-center: "platform"
+##     environment: "production"
+##
+tags: {}
+
 ## @param registry registry to override in the chart components
 ##
 registry: ""


### PR DESCRIPTION
## Summary

- Add top-level `tags: {}` map to `tfy-k8s-aws-eks-inframold/values.yaml` (mirrors `clusterName` with `@param` doc comment)
- Thread `.Values.tags` into `extraTags` under all five Karpenter node template blocks in `karpenter-config.yaml`: `defaultNodeTemplate`, `gpuDefaultNodeTemplate`, `inferentiaDefaultNodeTemplate`, `critical.nodeclass`, `controlPlaneNodeTemplate`
- Append caller tags via `range $k,$v := .Values.tags` to EBS CSI driver `controller.extraVolumeTags` in `aws-ebs-csi-driver.yaml`
- Bump chart version `0.1.286 → 0.1.287`

Part of INFRA-703 uniform AWS tagging initiative (Part B, Task #7).

## Test plan

- [x] `helm lint charts/tfy-k8s-aws-eks-inframold` — 0 failures
- [x] `helm template` with `--set 'tags.cost-center=test-123'` — `cost-center: test-123` appears in all 5 Karpenter `extraTags` blocks and in EBS CSI `extraVolumeTags`
- [x] `valuesOverride` short-circuit respected (tags only emitted in the `else` branch)
- [x] Empty `tags: {}` (default) produces no extra keys — guarded by `{{- if .Values.tags }}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tag changes apply to newly launched Karpenter nodes and dynamically provisioned EBS volumes; wrong tags can break cost or compliance policies but defaults are unchanged and overrides still bypass the built-in templates.
> 
> **Overview**
> Adds a top-level **`tags`** map on `tfy-k8s-aws-eks-inframold` so clusters can apply uniform AWS tags from one place (INFRA-703).
> 
> **`values.yaml`** documents `tags: {}` and threads it into Argo-rendered Helm values for Karpenter config and the EBS CSI driver (only when the default value paths are used, not `valuesOverride`).
> 
> **Karpenter** (`karpenter-config.yaml`): each node template / nodeclass block now sets **`extraTags`** with `truefoundry-cluster-name`, `truefoundry-managed`, plus every key in **`tags`**. The **`kmsKeyID`** conditionals are moved so they sit under the right template keys without changing behavior.
> 
> **EBS CSI** (`aws-ebs-csi-driver.yaml`): **`controller.extraVolumeTags`** gains the same Truefoundry tag keys and merges **`tags`** into tags applied to newly provisioned volumes.
> 
> Chart version is bumped (**0.1.286 → 0.1.288**); README global params table documents **`tags`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 313e2587292fa097f73e53cb4a1ac7ddc5562a26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->