### PR TITLE
Add podSecurityContext and containerSecurityContext to proxy helm chart

### DIFF
--- a/charts/tfy-squid-proxy/README.md
+++ b/charts/tfy-squid-proxy/README.md
@@ -48,4 +48,6 @@ Tfy-squid-proxy is a Helm chart that facilitates the deployment and management o
 | `tolerations`                                | Tolerations                                                    | `[]`                      |
 | `affinity`                                   | Affinity                                                       | `{}`                      |
 | `nodeSelector`                               | Node selector                                                  | `{}`                      |
+| `containerSecurityContext`                   | Container Security Context                                     | `{}`                      |
+| `podSecurityContext`                         | Pod Security Context                                           | `{}`                      |
 

--- a/charts/tfy-squid-proxy/templates/_helpers.tpl
+++ b/charts/tfy-squid-proxy/templates/_helpers.tpl
@@ -245,3 +245,25 @@ Node Selector for tfy-squid-proxy deployment
 []
 {{- end }}
 {{- end }}
+
+{{/*
+Container Security Context for tfy-squid-proxy deployment
+*/}}
+{{- define "tfy-squid-proxy.containerSecurityContext" -}}
+{{- if .Values.containerSecurityContext -}}
+{{- toYaml .Values.containerSecurityContext }}
+{{- else -}}
+{}
+{{- end }}
+{{- end }}
+
+{{/*
+Pod Security Context for tfy-squid-proxy deployment
+*/}}
+{{- define "tfy-squid-proxy.podSecurityContext" -}}
+{{- if .Values.podSecurityContext -}}
+{{- toYaml .Values.podSecurityContext }}
+{{- else -}}
+{}
+{{- end }}
+{{- end }}

--- a/charts/tfy-squid-proxy/templates/deployment.yaml
+++ b/charts/tfy-squid-proxy/templates/deployment.yaml
@@ -44,8 +44,11 @@ spec:
               subPath: squid.conf
           resources:
             {{- include "tfy-squid-proxy.resources" . | nindent 12 }}
+          securityContext:
+            {{- include "tfy-squid-proxy.containerSecurityContext" . | nindent 12 }}
       volumes:
         - name: squid-config
           configMap:
             name: {{ include "tfy-squid-proxy.fullname" . }}-squid-proxy-config
-
+      securityContext:
+        {{- include "tfy-squid-proxy.podSecurityContext" . | nindent 8 }}

--- a/charts/tfy-squid-proxy/templates/deployment.yaml
+++ b/charts/tfy-squid-proxy/templates/deployment.yaml
@@ -42,6 +42,8 @@ spec:
             - name: squid-config
               mountPath: /etc/squid/squid.conf
               subPath: squid.conf
+            - name: squid-tmp
+              mountPath: /tmp
           resources:
             {{- include "tfy-squid-proxy.resources" . | nindent 12 }}
           securityContext:
@@ -50,5 +52,7 @@ spec:
         - name: squid-config
           configMap:
             name: {{ include "tfy-squid-proxy.fullname" . }}-squid-proxy-config
+        - name: squid-tmp
+          emptyDir: {}
       securityContext:
         {{- include "tfy-squid-proxy.podSecurityContext" . | nindent 8 }}

--- a/charts/tfy-squid-proxy/values.yaml
+++ b/charts/tfy-squid-proxy/values.yaml
@@ -115,3 +115,9 @@ affinity: {}
 
 ## @param nodeSelector [object] Node selector
 nodeSelector: {}
+
+## @param containerSecurityContext [object] Container Security Context
+containerSecurityContext: {}
+
+## @param podSecurityContext [object] Pod Security Context
+podSecurityContext: {}


### PR DESCRIPTION
This PR extends the try-squid-proxy chart to expose the different security contexts in values.yml.

It is the same as PR #2412 (closed for inactivity) but adds a /tmp emptyDir to support readOnlyRootFilesystem:true in the container security context.

Feedback welcome.

Here is how I use it to run as non-root and log directly to /dev/stdout.

```
# https://github.com/truefoundry/infra-charts/tree/main/charts/tfy-squid-proxy
---
fullnameOverride: 'outgoing'

global:
  resourceTier: small

config: |
  # ------------------------
  # Listens on 3128
  # ------------------------
  http_port 3128

  # Write pid to a location writable by the proxy user
  pid_filename /tmp/squid.pid

  # No caching
  cache deny all

  # Allow all by default
  http_access allow all

  # Log to stdout in custom format
  logformat custom %ts.%03tu %6tr %>A %Ss/%03>Hs %<st %rm %ru %[un %Sh/%<a %mt
  access_log stdio:/dev/stdout custom

containerSecurityContext:
  allowPrivilegeEscalation: false
  capabilities:
    drop:
      - ALL
  readOnlyRootFilesystem: true

podSecurityContext:
  runAsGroup: 0
  runAsNonRoot: true
  runAsUser: 13 # pid of 'proxy' user in the image
  seccompProfile:
    type: RuntimeDefault
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional Helm values with empty defaults; the always-on /tmp emptyDir is a small behavioral addition but does not change proxy networking or auth.
> 
> **Overview**
> The **tfy-squid-proxy** chart now accepts **`containerSecurityContext`** and **`podSecurityContext`** in `values.yaml` (both default to `{}`), with helpers wiring them onto the container and pod spec in the Deployment. Defaults leave behavior unchanged until operators set these values.
> 
> A writable **`/tmp` `emptyDir`** volume is always mounted so Squid can write pid/temp files when operators enable **`readOnlyRootFilesystem`** and non-root **`runAsUser`** via the new knobs. README documents the new parameters.
> 
> The **`imagePullSecrets`** helper template is also corrected (stray closing `{{- end }}` removed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a6fb4dd9cb038f38824d34bd54519e6b005adb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->