### PR TITLE
Update .gitignore to allow truefoundry subcharts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ charts/tfy-gpu-operator/charts/
 **/venv
 __pycache__
 charts/tfy-agent/charts/
-charts/truefoundry/charts/


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Git ignore-only change with no runtime or deployment behavior impact.
> 
> **Overview**
> Removes **`charts/truefoundry/charts/`** from **`.gitignore`** so Helm dependency output for the truefoundry umbrella chart can be tracked in git, consistent with **`charts/tfy-agent/charts/`** and **`charts/tfy-gpu-operator/charts/`** already being ignored while truefoundry was excluded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db03d244f49dc94ad43a2e47acdd19f332f9f30d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->