### PR TITLE
Update .gitignore to allow truefoundry subcharts (#2835)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ charts/tfy-gpu-operator/charts/
 **/venv
 __pycache__
 charts/tfy-agent/charts/
-charts/truefoundry/charts/


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single `.gitignore` line removal with no runtime or deployment logic changes.
> 
> **Overview**
> Removes the **`charts/truefoundry/charts/`** entry from **`.gitignore`**, so vendored Helm dependency output under the truefoundry chart can be tracked in git like the rest of the repo.
> 
> Other chart ignore rules (e.g. **`charts/tfy-agent/charts/`**, **`charts/tfy-gpu-operator/charts/`**) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd3d9bbdf8f12271fb8d4183a1621caf5d6ffea6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->