### PR TITLE
Fix kyverno vol mount

### DIFF
--- a/charts/tfy-kyverno-config/Chart.yaml
+++ b/charts/tfy-kyverno-config/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: tfy-kyverno-config
 description: A Helm chart for kyverno configuration
 type: application
-version: 0.1.9
+version: 0.1.10
 maintainers:
   - name: truefoundry

--- a/charts/tfy-kyverno-config/README.md
+++ b/charts/tfy-kyverno-config/README.md
@@ -29,162 +29,54 @@ Chart defaults for the pod volume mount policy live in `files/default-pod-volume
 
 ### replaceImageRegistry Configuration options for replacing the image registry
 
-| Name                                          | Description                                                                                                                                                        | Value   |
-| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- |
-| `replaceImageRegistry.enabled`                | Enable or disable replacing the image registry                                                                                                                     | `false` |
-| `replaceImageRegistry.excludeNamespaces`      | Namespaces to exclude from replacing the image registry                                                                                                            | `[]`    |
-| `replaceImageRegistry.includeNamespaces`      | Namespaces to include from replacing the image registry. When non-empty, only these namespaces will be included                                                    | `[]`    |
-| `replaceImageRegistry.registryReplacementMap` | Map of source registry prefixes to target registries. Use `"*"` as wildcard default (strips source registry, keeps image path). Per-source overrides take priority | `{}`    |
+| Name                                          | Description                                                                                                     | Value   |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ------- |
+| `replaceImageRegistry.enabled`                | Enable or disable replacing the image registry                                                                  | `false` |
+| `replaceImageRegistry.excludeNamespaces`      | Namespaces to exclude from replacing the image registry                                                         | `[]`    |
+| `replaceImageRegistry.includeNamespaces`      | Namespaces to include from replacing the image registry. When non-empty, only these namespaces will be included | `[]`    |
+| `replaceImageRegistry.registryReplacementMap` | Map of source registry prefixes to target registries.                                                           | `{}`    |
 
 ### replaceArgoHelmRepo Configuration options for replacing the Argo Helm repository
 
-| Name                                         | Description                                                                                                                                                      | Value   |
-| -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `replaceArgoHelmRepo.enabled`                | Enable or disable replacing the Argo Helm repository                                                                                                             | `false` |
-| `replaceArgoHelmRepo.excludeNamespaces`      | Namespaces to exclude from replacing the argo helm repo                                                                                                          | `[]`    |
-| `replaceArgoHelmRepo.includeNamespaces`      | Namespaces to include for replacing the argo helm repo. When non-empty, only these namespaces will be included                                                  | `[]`    |
-| `replaceArgoHelmRepo.registryReplacementMap` | Map of source repoURL prefixes to target registries. Use `"*"` as wildcard default (strips host, keeps path). Per-source overrides take priority                | `{}`    |
+| Name                                         | Description                                                                                                    | Value   |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ------- |
+| `replaceArgoHelmRepo.enabled`                | Enable or disable replacing the Argo Helm repository                                                           | `false` |
+| `replaceArgoHelmRepo.excludeNamespaces`      | Namespaces to exclude from replacing the argo helm repo                                                        | `[]`    |
+| `replaceArgoHelmRepo.includeNamespaces`      | Namespaces to include for replacing the argo helm repo. When non-empty, only these namespaces will be included | `[]`    |
+| `replaceArgoHelmRepo.registryReplacementMap` | Map of source repoURL prefixes to target registries.                                                           | `{}`    |
 
 ### syncConfigMaps Configuration options for syncing ConfigMaps across namespaces
 
-| Name                               | Description                                                                                                                                                                                                | Value   |
-| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `syncConfigMaps.enabled`           | Enable or disable syncing ConfigMaps across namespaces                                                                                                                                                     | `false` |
-| `syncConfigMaps.useClusterPolicy`  | Use ClusterPolicy (`kyverno.io/v1`) instead of GeneratingPolicy (`policies.kyverno.io/v1`). ClusterPolicy supports wildcard namespace patterns (for example `tfy-*`) and mature `generateExisting` support | `true`  |
-| `syncConfigMaps.excludeNamespaces` | Namespaces to exclude from syncing ConfigMaps. Supports wildcard patterns when `useClusterPolicy` is `true`                                                                                                | `[]`    |
-| `syncConfigMaps.includeNamespaces` | Namespaces to include for syncing ConfigMaps. When non-empty, only these namespaces will be included. Supports wildcard patterns (for example `tfy-*`) when `useClusterPolicy` is `true`                      | `[]`    |
-| `syncConfigMaps.items`             | List of ConfigMaps to sync. Each entry requires `namespace` (source) and `name`                                                                                                                            | `[]`    |
-
-Example:
-
-```yaml
-syncConfigMaps:
-  enabled: true
-  includeNamespaces:
-    - tfy-*
-  items:
-    - namespace: truefoundry
-      name: ca-cert-bundle
-```
+| Name                               | Description                                                                                                                                                                                          | Value   |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `syncConfigMaps.enabled`           | Enable or disable syncing ConfigMaps across namespaces                                                                                                                                               | `false` |
+| `syncConfigMaps.useClusterPolicy`  | Use ClusterPolicy (kyverno.io/v1) instead of GeneratingPolicy (policies.kyverno.io/v1). ClusterPolicy has more mature generateExisting support and supports wildcard namespace patterns (e.g. tfy-*) | `true`  |
+| `syncConfigMaps.excludeNamespaces` | Namespaces to exclude from syncing ConfigMaps                                                                                                                                                        | `[]`    |
+| `syncConfigMaps.includeNamespaces` | Namespaces to include for syncing ConfigMaps. When non-empty, only these namespaces will be included. Supports wildcard patterns (e.g. tfy-*) when useClusterPolicy is true                          | `[]`    |
+| `syncConfigMaps.items`             | List of ConfigMaps to sync across namespaces                                                                                                                                                         | `[]`    |
 
 ### syncSecrets Configuration options for syncing Secrets across namespaces
 
-Syncing secrets requires additional RBAC permissions for the Kyverno admission and background controllers. Configure those permissions in the Kyverno Helm chart values.
-
-| Name                            | Description                                                                                                                                                                                                | Value   |
-| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `syncSecrets.enabled`           | Enable or disable syncing Secrets across namespaces                                                                                                                                                        | `false` |
-| `syncSecrets.useClusterPolicy`  | Use ClusterPolicy (`kyverno.io/v1`) instead of GeneratingPolicy (`policies.kyverno.io/v1`). ClusterPolicy supports wildcard namespace patterns (for example `tfy-*`) and mature `generateExisting` support | `true`  |
-| `syncSecrets.excludeNamespaces` | Namespaces to exclude from syncing Secrets. Supports wildcard patterns when `useClusterPolicy` is `true`                                                                                                   | `[]`    |
-| `syncSecrets.includeNamespaces` | Namespaces to include for syncing Secrets. When non-empty, only these namespaces will be included. Supports wildcard patterns (for example `tfy-*`) when `useClusterPolicy` is `true`                     | `[]`    |
-| `syncSecrets.items`             | List of Secrets to sync. Each entry requires `namespace` (source) and `name`                                                                                                                               | `[]`    |
-
-Example:
-
-```yaml
-syncSecrets:
-  enabled: true
-  includeNamespaces:
-    - tfy-*
-  items:
-    - namespace: truefoundry
-      name: my-tls-secret
-```
+| Name                            | Description                                                                                                                                                                                          | Value   |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `syncSecrets.enabled`           | Enable or disable syncing Secrets across namespaces                                                                                                                                                  | `false` |
+| `syncSecrets.useClusterPolicy`  | Use ClusterPolicy (kyverno.io/v1) instead of GeneratingPolicy (policies.kyverno.io/v1). ClusterPolicy has more mature generateExisting support and supports wildcard namespace patterns (e.g. tfy-*) | `true`  |
+| `syncSecrets.excludeNamespaces` | Namespaces to exclude from syncing Secrets                                                                                                                                                           | `[]`    |
+| `syncSecrets.includeNamespaces` | Namespaces to include for syncing Secrets. When non-empty, only these namespaces will be included. Supports wildcard patterns (e.g. tfy-*) when useClusterPolicy is true                             | `[]`    |
+| `syncSecrets.items`             | List of Secrets to sync across namespaces                                                                                                                                                            | `[]`    |
 
 ### podVolumeMounts Configuration options for adding volume mounts to pods
 
-Supports mounting **ConfigMaps** and **Secrets**. When `useClusterPolicy` is `true` (default), the chart renders a `ClusterPolicy` with wildcard namespace support, optional env vars, `readOnly` mounts, and ConfigMap `items`. Set `useClusterPolicy: false` to use a `MutatingPolicy` instead (simpler volume-only mounts, no wildcards).
-
-| Name                                       | Description                                                                                                                                                            | Value   |
-| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `podVolumeMounts.enabled`                  | Enable or disable adding volume mounts to pods                                                                                                                         | `false` |
-| `podVolumeMounts.useClusterPolicy`         | Use ClusterPolicy (`kyverno.io/v1`) instead of MutatingPolicy (`policies.kyverno.io/v1`)                                                                             | `true`  |
-| `podVolumeMounts.policyName`               | Name of the ClusterPolicy when `useClusterPolicy` is `true`. Defaults to `<release-name>-pod-volume-mounts`                                                            | `""`    |
-| `podVolumeMounts.configMapName`            | ConfigMap name for the built-in default CA mount from `files/default-pod-volume-mounts.yaml`. Used when `mountDetails` is not overridden. Defaults to `ca-cert-bundle` | `""`    |
-| `podVolumeMounts.mountInitContainers`      | Also mount volumes into init containers                                                                                                                                | `false` |
-| `podVolumeMounts.excludeNamespaces`        | Namespaces to exclude. Supports wildcard patterns when `useClusterPolicy` is `true`                                                                                    | `[]`    |
-| `podVolumeMounts.includeNamespaces`        | Namespaces to include. When non-empty, only these namespaces are matched. Supports wildcard patterns (for example `tfy-*`) when `useClusterPolicy` is `true`           | `[]`    |
-| `podVolumeMounts.objectSelector`           | Label selector to match specific pods                                                                                                                                  | `{}`    |
-| `podVolumeMounts.mountDetails`             | Override chart default volume mounts from `files/default-pod-volume-mounts.yaml`. When empty, chart defaults are used                                                  | `[]`    |
-| `podVolumeMounts.additionalMountDetails`   | Additional volume mounts appended to the effective mount list                                                                                                          | `[]`    |
-
-#### Mount entry fields
-
-Each item in `mountDetails` or `additionalMountDetails` supports:
-
-| Field            | Required      | Description                                                         |
-| ---------------- | ------------- | ------------------------------------------------------------------- |
-| `type`           | Yes           | `configMap` or `secret`                                             |
-| `configMapName`  | For ConfigMap | Name of the ConfigMap to mount                                      |
-| `secretName`     | For Secret    | Name of the Secret to mount                                         |
-| `volumeName`     | No            | Kubernetes volume name. Defaults to `configMapName` or `secretName` |
-| `mountPath`      | Yes           | Container mount path                                                |
-| `subPath`        | No            | Sub-path within the volume                                          |
-| `readOnly`       | No            | Mount as read-only                                                  |
-| `configMapItems` | No            | ConfigMap key/path mapping (ConfigMap only)                         |
-| `envVars`        | No            | Environment variables to inject (map of name to value)              |
-
-#### Examples
-
-Use chart defaults (CA bundle ConfigMap mount):
-
-```yaml
-podVolumeMounts:
-  enabled: true
-  includeNamespaces:
-    - tfy-*
-  configMapName: ca-cert-bundle
-```
-
-Override the default ConfigMap name only:
-
-```yaml
-podVolumeMounts:
-  enabled: true
-  configMapName: my-company-ca-bundle
-```
-
-Append a Secret mount alongside the default CA mount:
-
-```yaml
-podVolumeMounts:
-  enabled: true
-  includeNamespaces:
-    - tfy-*
-  additionalMountDetails:
-    - type: secret
-      secretName: my-tls-secret
-      mountPath: /etc/tls
-      readOnly: true
-```
-
-Replace defaults with a custom mount list:
-
-```yaml
-podVolumeMounts:
-  enabled: true
-  mountDetails:
-    - type: secret
-      secretName: my-secret
-      mountPath: /var/run/secrets/my-secret
-      subPath: token
-      readOnly: true
-```
-
-Full custom CA + init container mounts:
-
-```yaml
-podVolumeMounts:
-  enabled: true
-  policyName: custom-ca-cert-policy
-  configMapName: ca-cert-bundle
-  mountInitContainers: true
-  includeNamespaces:
-    - tfy-*
-```
-
-### additionalKyvernoPolicies
-
-| Name                          | Description                                               | Value |
-| ----------------------------- | --------------------------------------------------------- | ----- |
-| `additionalKyvernoPolicies`   | Additional raw Kyverno ClusterPolicy manifests to apply   | `[]`  |
+| Name                                     | Description                                                                                                                                                                                                            | Value   |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `podVolumeMounts.enabled`                | Enable or disable adding volume mounts to pods                                                                                                                                                                         | `false` |
+| `podVolumeMounts.useClusterPolicy`       | Use ClusterPolicy (kyverno.io/v1) instead of MutatingPolicy (policies.kyverno.io/v1). ClusterPolicy supports wildcard namespace patterns (e.g. tfy-*), configMap items, env vars, and readOnly volume mounts           | `true`  |
+| `podVolumeMounts.policyName`             | Name of the ClusterPolicy when useClusterPolicy is true. Defaults to `<release-name>-pod-volume-mounts`                                                                                                                | `""`    |
+| `podVolumeMounts.configMapName`          | Default ConfigMap name for the built-in CA volume mount. Used when mountDetails is not overridden                                                                                                                      | `""`    |
+| `podVolumeMounts.mountInitContainers`    | Mount volumes into init containers when enabled                                                                                                                                                                        | `false` |
+| `podVolumeMounts.excludeNamespaces`      | Namespaces to exclude from adding volume mounts to pods. Supports wildcard patterns (e.g. tfy-*) when useClusterPolicy is true                                                                                         | `[]`    |
+| `podVolumeMounts.includeNamespaces`      | Namespaces to include for adding volume mounts to pods. When non-empty, only these namespaces will be included. Supports wildcard patterns (e.g. tfy-*) when useClusterPolicy is true                                  | `[]`    |
+| `podVolumeMounts.objectSelector`         | Label selector to match specific pods. When set, only pods matching these labels will be mutated                                                                                                                       | `{}`    |
+| `podVolumeMounts.mountDetails`           | Override the chart default volume mounts from files/default-pod-volume-mounts.yaml. When empty, chart defaults are used. Set configMapName on each entry or use podVolumeMounts.configMapName for the built-in default | `[]`    |
+| `podVolumeMounts.additionalMountDetails` | Additional volume mounts appended to the effective mount list                                                                                                                                                          | `[]`    |
+| `additionalKyvernoPolicies`              | Additional Kyverno clusterpolicies to apply                                                                                                                                                                            | `[]`    |

--- a/charts/tfy-kyverno-config/README.md
+++ b/charts/tfy-kyverno-config/README.md
@@ -6,14 +6,14 @@ A Helm chart for Kyverno cluster policies used in TrueFoundry deployments.
 
 This chart can deploy the following Kyverno policies:
 
-| Policy | Values key | Description |
-| ------ | ---------- | ----------- |
-| Image registry replacement | `replaceImageRegistry` | Rewrites container image registries on workloads |
-| Argo Helm repo replacement | `replaceArgoHelmRepo` | Rewrites Argo CD `repoURL` values |
-| ConfigMap sync | `syncConfigMaps` | Clones ConfigMaps from a source namespace into matching target namespaces |
-| Secret sync | `syncSecrets` | Clones Secrets from a source namespace into matching target namespaces |
-| Pod volume mounts | `podVolumeMounts` | Injects volumes and volume mounts (ConfigMap or Secret) into pods |
-| Custom policies | `additionalKyvernoPolicies` | Renders additional raw Kyverno `ClusterPolicy` manifests |
+| Policy                       | Values key                   | Description                                                               |
+| ---------------------------- | ---------------------------- | ------------------------------------------------------------------------- |
+| Image registry replacement   | `replaceImageRegistry`       | Rewrites container image registries on workloads                          |
+| Argo Helm repo replacement   | `replaceArgoHelmRepo`        | Rewrites Argo CD `repoURL` values                                         |
+| ConfigMap sync               | `syncConfigMaps`             | Clones ConfigMaps from a source namespace into matching target namespaces |
+| Secret sync                  | `syncSecrets`                | Clones Secrets from a source namespace into matching target namespaces    |
+| Pod volume mounts            | `podVolumeMounts`            | Injects volumes and volume mounts (ConfigMap or Secret) into pods         |
+| Custom policies              | `additionalKyvernoPolicies`  | Renders additional raw Kyverno `ClusterPolicy` manifests                  |
 
 ### Custom CA certificate workflow
 
@@ -29,31 +29,31 @@ Chart defaults for the pod volume mount policy live in `files/default-pod-volume
 
 ### replaceImageRegistry Configuration options for replacing the image registry
 
-| Name | Description | Value |
-| ---- | ----------- | ----- |
-| `replaceImageRegistry.enabled` | Enable or disable replacing the image registry | `false` |
-| `replaceImageRegistry.excludeNamespaces` | Namespaces to exclude from replacing the image registry | `[]` |
-| `replaceImageRegistry.includeNamespaces` | Namespaces to include from replacing the image registry. When non-empty, only these namespaces will be included | `[]` |
-| `replaceImageRegistry.registryReplacementMap` | Map of source registry prefixes to target registries. Use `"*"` as wildcard default (strips source registry, keeps image path). Per-source overrides take priority | `{}` |
+| Name                                          | Description                                                                                                                                                        | Value   |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| `replaceImageRegistry.enabled`                | Enable or disable replacing the image registry                                                                                                                     | `false` |
+| `replaceImageRegistry.excludeNamespaces`      | Namespaces to exclude from replacing the image registry                                                                                                            | `[]`    |
+| `replaceImageRegistry.includeNamespaces`      | Namespaces to include from replacing the image registry. When non-empty, only these namespaces will be included                                                    | `[]`    |
+| `replaceImageRegistry.registryReplacementMap` | Map of source registry prefixes to target registries. Use `"*"` as wildcard default (strips source registry, keeps image path). Per-source overrides take priority | `{}`    |
 
 ### replaceArgoHelmRepo Configuration options for replacing the Argo Helm repository
 
-| Name | Description | Value |
-| ---- | ----------- | ----- |
-| `replaceArgoHelmRepo.enabled` | Enable or disable replacing the Argo Helm repository | `false` |
-| `replaceArgoHelmRepo.excludeNamespaces` | Namespaces to exclude from replacing the argo helm repo | `[]` |
-| `replaceArgoHelmRepo.includeNamespaces` | Namespaces to include for replacing the argo helm repo. When non-empty, only these namespaces will be included | `[]` |
-| `replaceArgoHelmRepo.registryReplacementMap` | Map of source repoURL prefixes to target registries. Use `"*"` as wildcard default (strips host, keeps path). Per-source overrides take priority | `{}` |
+| Name                                         | Description                                                                                                                                                      | Value   |
+| -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `replaceArgoHelmRepo.enabled`                | Enable or disable replacing the Argo Helm repository                                                                                                             | `false` |
+| `replaceArgoHelmRepo.excludeNamespaces`      | Namespaces to exclude from replacing the argo helm repo                                                                                                          | `[]`    |
+| `replaceArgoHelmRepo.includeNamespaces`      | Namespaces to include for replacing the argo helm repo. When non-empty, only these namespaces will be included                                                  | `[]`    |
+| `replaceArgoHelmRepo.registryReplacementMap` | Map of source repoURL prefixes to target registries. Use `"*"` as wildcard default (strips host, keeps path). Per-source overrides take priority                | `{}`    |
 
 ### syncConfigMaps Configuration options for syncing ConfigMaps across namespaces
 
-| Name | Description | Value |
-| ---- | ----------- | ----- |
-| `syncConfigMaps.enabled` | Enable or disable syncing ConfigMaps across namespaces | `false` |
-| `syncConfigMaps.useClusterPolicy` | Use ClusterPolicy (`kyverno.io/v1`) instead of GeneratingPolicy (`policies.kyverno.io/v1`). ClusterPolicy supports wildcard namespace patterns (for example `tfy-*`) and mature `generateExisting` support | `true` |
-| `syncConfigMaps.excludeNamespaces` | Namespaces to exclude from syncing ConfigMaps. Supports wildcard patterns when `useClusterPolicy` is `true` | `[]` |
-| `syncConfigMaps.includeNamespaces` | Namespaces to include for syncing ConfigMaps. When non-empty, only these namespaces will be included. Supports wildcard patterns (for example `tfy-*`) when `useClusterPolicy` is `true` | `[]` |
-| `syncConfigMaps.items` | List of ConfigMaps to sync. Each entry requires `namespace` (source) and `name` | `[]` |
+| Name                               | Description                                                                                                                                                                                                | Value   |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `syncConfigMaps.enabled`           | Enable or disable syncing ConfigMaps across namespaces                                                                                                                                                     | `false` |
+| `syncConfigMaps.useClusterPolicy`  | Use ClusterPolicy (`kyverno.io/v1`) instead of GeneratingPolicy (`policies.kyverno.io/v1`). ClusterPolicy supports wildcard namespace patterns (for example `tfy-*`) and mature `generateExisting` support | `true`  |
+| `syncConfigMaps.excludeNamespaces` | Namespaces to exclude from syncing ConfigMaps. Supports wildcard patterns when `useClusterPolicy` is `true`                                                                                                | `[]`    |
+| `syncConfigMaps.includeNamespaces` | Namespaces to include for syncing ConfigMaps. When non-empty, only these namespaces will be included. Supports wildcard patterns (for example `tfy-*`) when `useClusterPolicy` is `true`                      | `[]`    |
+| `syncConfigMaps.items`             | List of ConfigMaps to sync. Each entry requires `namespace` (source) and `name`                                                                                                                            | `[]`    |
 
 Example:
 
@@ -71,13 +71,13 @@ syncConfigMaps:
 
 Syncing secrets requires additional RBAC permissions for the Kyverno admission and background controllers. Configure those permissions in the Kyverno Helm chart values.
 
-| Name | Description | Value |
-| ---- | ----------- | ----- |
-| `syncSecrets.enabled` | Enable or disable syncing Secrets across namespaces | `false` |
-| `syncSecrets.useClusterPolicy` | Use ClusterPolicy (`kyverno.io/v1`) instead of GeneratingPolicy (`policies.kyverno.io/v1`). ClusterPolicy supports wildcard namespace patterns (for example `tfy-*`) and mature `generateExisting` support | `true` |
-| `syncSecrets.excludeNamespaces` | Namespaces to exclude from syncing Secrets. Supports wildcard patterns when `useClusterPolicy` is `true` | `[]` |
-| `syncSecrets.includeNamespaces` | Namespaces to include for syncing Secrets. When non-empty, only these namespaces will be included. Supports wildcard patterns (for example `tfy-*`) when `useClusterPolicy` is `true` | `[]` |
-| `syncSecrets.items` | List of Secrets to sync. Each entry requires `namespace` (source) and `name` | `[]` |
+| Name                            | Description                                                                                                                                                                                                | Value   |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `syncSecrets.enabled`           | Enable or disable syncing Secrets across namespaces                                                                                                                                                        | `false` |
+| `syncSecrets.useClusterPolicy`  | Use ClusterPolicy (`kyverno.io/v1`) instead of GeneratingPolicy (`policies.kyverno.io/v1`). ClusterPolicy supports wildcard namespace patterns (for example `tfy-*`) and mature `generateExisting` support | `true`  |
+| `syncSecrets.excludeNamespaces` | Namespaces to exclude from syncing Secrets. Supports wildcard patterns when `useClusterPolicy` is `true`                                                                                                   | `[]`    |
+| `syncSecrets.includeNamespaces` | Namespaces to include for syncing Secrets. When non-empty, only these namespaces will be included. Supports wildcard patterns (for example `tfy-*`) when `useClusterPolicy` is `true`                     | `[]`    |
+| `syncSecrets.items`             | List of Secrets to sync. Each entry requires `namespace` (source) and `name`                                                                                                                               | `[]`    |
 
 Example:
 
@@ -95,34 +95,34 @@ syncSecrets:
 
 Supports mounting **ConfigMaps** and **Secrets**. When `useClusterPolicy` is `true` (default), the chart renders a `ClusterPolicy` with wildcard namespace support, optional env vars, `readOnly` mounts, and ConfigMap `items`. Set `useClusterPolicy: false` to use a `MutatingPolicy` instead (simpler volume-only mounts, no wildcards).
 
-| Name | Description | Value |
-| ---- | ----------- | ----- |
-| `podVolumeMounts.enabled` | Enable or disable adding volume mounts to pods | `false` |
-| `podVolumeMounts.useClusterPolicy` | Use ClusterPolicy (`kyverno.io/v1`) instead of MutatingPolicy (`policies.kyverno.io/v1`) | `true` |
-| `podVolumeMounts.policyName` | Name of the ClusterPolicy when `useClusterPolicy` is `true`. Defaults to `<release-name>-pod-volume-mounts` | `""` |
-| `podVolumeMounts.configMapName` | ConfigMap name for the built-in default CA mount from `files/default-pod-volume-mounts.yaml`. Used when `mountDetails` is not overridden. Defaults to `ca-cert-bundle` | `""` |
-| `podVolumeMounts.mountInitContainers` | Also mount volumes into init containers | `false` |
-| `podVolumeMounts.excludeNamespaces` | Namespaces to exclude. Supports wildcard patterns when `useClusterPolicy` is `true` | `[]` |
-| `podVolumeMounts.includeNamespaces` | Namespaces to include. When non-empty, only these namespaces are matched. Supports wildcard patterns (for example `tfy-*`) when `useClusterPolicy` is `true` | `[]` |
-| `podVolumeMounts.objectSelector` | Label selector to match specific pods | `{}` |
-| `podVolumeMounts.mountDetails` | Override chart default volume mounts from `files/default-pod-volume-mounts.yaml`. When empty, chart defaults are used | `[]` |
-| `podVolumeMounts.additionalMountDetails` | Additional volume mounts appended to the effective mount list | `[]` |
+| Name                                       | Description                                                                                                                                                            | Value   |
+| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `podVolumeMounts.enabled`                  | Enable or disable adding volume mounts to pods                                                                                                                         | `false` |
+| `podVolumeMounts.useClusterPolicy`         | Use ClusterPolicy (`kyverno.io/v1`) instead of MutatingPolicy (`policies.kyverno.io/v1`)                                                                             | `true`  |
+| `podVolumeMounts.policyName`               | Name of the ClusterPolicy when `useClusterPolicy` is `true`. Defaults to `<release-name>-pod-volume-mounts`                                                            | `""`    |
+| `podVolumeMounts.configMapName`            | ConfigMap name for the built-in default CA mount from `files/default-pod-volume-mounts.yaml`. Used when `mountDetails` is not overridden. Defaults to `ca-cert-bundle` | `""`    |
+| `podVolumeMounts.mountInitContainers`      | Also mount volumes into init containers                                                                                                                                | `false` |
+| `podVolumeMounts.excludeNamespaces`        | Namespaces to exclude. Supports wildcard patterns when `useClusterPolicy` is `true`                                                                                    | `[]`    |
+| `podVolumeMounts.includeNamespaces`        | Namespaces to include. When non-empty, only these namespaces are matched. Supports wildcard patterns (for example `tfy-*`) when `useClusterPolicy` is `true`           | `[]`    |
+| `podVolumeMounts.objectSelector`           | Label selector to match specific pods                                                                                                                                  | `{}`    |
+| `podVolumeMounts.mountDetails`             | Override chart default volume mounts from `files/default-pod-volume-mounts.yaml`. When empty, chart defaults are used                                                  | `[]`    |
+| `podVolumeMounts.additionalMountDetails`   | Additional volume mounts appended to the effective mount list                                                                                                          | `[]`    |
 
 #### Mount entry fields
 
 Each item in `mountDetails` or `additionalMountDetails` supports:
 
-| Field | Required | Description |
-| ----- | -------- | ----------- |
-| `type` | Yes | `configMap` or `secret` |
-| `configMapName` | For ConfigMap | Name of the ConfigMap to mount |
-| `secretName` | For Secret | Name of the Secret to mount |
-| `volumeName` | No | Kubernetes volume name. Defaults to `configMapName` or `secretName` |
-| `mountPath` | Yes | Container mount path |
-| `subPath` | No | Sub-path within the volume |
-| `readOnly` | No | Mount as read-only |
-| `configMapItems` | No | ConfigMap key/path mapping (ConfigMap only) |
-| `envVars` | No | Environment variables to inject (map of name to value) |
+| Field            | Required      | Description                                                         |
+| ---------------- | ------------- | ------------------------------------------------------------------- |
+| `type`           | Yes           | `configMap` or `secret`                                             |
+| `configMapName`  | For ConfigMap | Name of the ConfigMap to mount                                      |
+| `secretName`     | For Secret    | Name of the Secret to mount                                         |
+| `volumeName`     | No            | Kubernetes volume name. Defaults to `configMapName` or `secretName` |
+| `mountPath`      | Yes           | Container mount path                                                |
+| `subPath`        | No            | Sub-path within the volume                                          |
+| `readOnly`       | No            | Mount as read-only                                                  |
+| `configMapItems` | No            | ConfigMap key/path mapping (ConfigMap only)                         |
+| `envVars`        | No            | Environment variables to inject (map of name to value)              |
 
 #### Examples
 
@@ -185,6 +185,6 @@ podVolumeMounts:
 
 ### additionalKyvernoPolicies
 
-| Name | Description | Value |
-| ---- | ----------- | ----- |
-| `additionalKyvernoPolicies` | Additional raw Kyverno ClusterPolicy manifests to apply | `[]` |
+| Name                          | Description                                               | Value |
+| ----------------------------- | --------------------------------------------------------- | ----- |
+| `additionalKyvernoPolicies`   | Additional raw Kyverno ClusterPolicy manifests to apply   | `[]`  |

--- a/charts/tfy-kyverno-config/README.md
+++ b/charts/tfy-kyverno-config/README.md
@@ -1,53 +1,190 @@
 # tfy-kyverno-config helm chart packaged by TrueFoundry
-A Helm chart for kyverno configurations
+
+A Helm chart for Kyverno cluster policies used in TrueFoundry deployments.
+
+## Overview
+
+This chart can deploy the following Kyverno policies:
+
+| Policy | Values key | Description |
+| ------ | ---------- | ----------- |
+| Image registry replacement | `replaceImageRegistry` | Rewrites container image registries on workloads |
+| Argo Helm repo replacement | `replaceArgoHelmRepo` | Rewrites Argo CD `repoURL` values |
+| ConfigMap sync | `syncConfigMaps` | Clones ConfigMaps from a source namespace into matching target namespaces |
+| Secret sync | `syncSecrets` | Clones Secrets from a source namespace into matching target namespaces |
+| Pod volume mounts | `podVolumeMounts` | Injects volumes and volume mounts (ConfigMap or Secret) into pods |
+| Custom policies | `additionalKyvernoPolicies` | Renders additional raw Kyverno `ClusterPolicy` manifests |
+
+### Custom CA certificate workflow
+
+A common setup is to sync a CA bundle ConfigMap and mount it into application pods:
+
+1. Create `ca-cert-bundle` in a source namespace (for example `truefoundry`).
+2. Enable `syncConfigMaps` to clone it into target namespaces (for example `tfy-*`).
+3. Enable `podVolumeMounts` to mount the synced ConfigMap and set SSL-related environment variables.
+
+Chart defaults for the pod volume mount policy live in `files/default-pod-volume-mounts.yaml`. When `podVolumeMounts.mountDetails` is empty, those defaults are used. Override the ConfigMap name with `podVolumeMounts.configMapName` (defaults to `ca-cert-bundle`).
 
 ## Parameters
 
 ### replaceImageRegistry Configuration options for replacing the image registry
 
-| Name                                          | Description                                                                                                     | Value   |
-| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ------- |
-| `replaceImageRegistry.enabled`                | Enable or disable replacing the image registry                                                                  | `false` |
-| `replaceImageRegistry.excludeNamespaces`      | Namespaces to exclude from replacing the image registry                                                         | `[]`    |
-| `replaceImageRegistry.includeNamespaces`      | Namespaces to include from replacing the image registry. When non-empty, only these namespaces will be included | `[]`    |
-| `replaceImageRegistry.registryReplacementMap` | Map of source registry prefixes to target registries.                                                           | `{}`    |
+| Name | Description | Value |
+| ---- | ----------- | ----- |
+| `replaceImageRegistry.enabled` | Enable or disable replacing the image registry | `false` |
+| `replaceImageRegistry.excludeNamespaces` | Namespaces to exclude from replacing the image registry | `[]` |
+| `replaceImageRegistry.includeNamespaces` | Namespaces to include from replacing the image registry. When non-empty, only these namespaces will be included | `[]` |
+| `replaceImageRegistry.registryReplacementMap` | Map of source registry prefixes to target registries. Use `"*"` as wildcard default (strips source registry, keeps image path). Per-source overrides take priority | `{}` |
 
 ### replaceArgoHelmRepo Configuration options for replacing the Argo Helm repository
 
-| Name                                         | Description                                                                                                    | Value   |
-| -------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ------- |
-| `replaceArgoHelmRepo.enabled`                | Enable or disable replacing the Argo Helm repository                                                           | `false` |
-| `replaceArgoHelmRepo.excludeNamespaces`      | Namespaces to exclude from replacing the argo helm repo                                                        | `[]`    |
-| `replaceArgoHelmRepo.includeNamespaces`      | Namespaces to include for replacing the argo helm repo. When non-empty, only these namespaces will be included | `[]`    |
-| `replaceArgoHelmRepo.registryReplacementMap` | Map of source repoURL prefixes to target registries.                                                           | `{}`    |
+| Name | Description | Value |
+| ---- | ----------- | ----- |
+| `replaceArgoHelmRepo.enabled` | Enable or disable replacing the Argo Helm repository | `false` |
+| `replaceArgoHelmRepo.excludeNamespaces` | Namespaces to exclude from replacing the argo helm repo | `[]` |
+| `replaceArgoHelmRepo.includeNamespaces` | Namespaces to include for replacing the argo helm repo. When non-empty, only these namespaces will be included | `[]` |
+| `replaceArgoHelmRepo.registryReplacementMap` | Map of source repoURL prefixes to target registries. Use `"*"` as wildcard default (strips host, keeps path). Per-source overrides take priority | `{}` |
 
 ### syncConfigMaps Configuration options for syncing ConfigMaps across namespaces
 
-| Name                               | Description                                                                                                                                                                                          | Value   |
-| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `syncConfigMaps.enabled`           | Enable or disable syncing ConfigMaps across namespaces                                                                                                                                               | `false` |
-| `syncConfigMaps.useClusterPolicy`  | Use ClusterPolicy (kyverno.io/v1) instead of GeneratingPolicy (policies.kyverno.io/v1). ClusterPolicy has more mature generateExisting support and supports wildcard namespace patterns (e.g. tfy-*) | `true`  |
-| `syncConfigMaps.excludeNamespaces` | Namespaces to exclude from syncing ConfigMaps                                                                                                                                                        | `[]`    |
-| `syncConfigMaps.includeNamespaces` | Namespaces to include for syncing ConfigMaps. When non-empty, only these namespaces will be included. Supports wildcard patterns (e.g. tfy-*) when useClusterPolicy is true                          | `[]`    |
-| `syncConfigMaps.items`             | List of ConfigMaps to sync across namespaces                                                                                                                                                         | `[]`    |
+| Name | Description | Value |
+| ---- | ----------- | ----- |
+| `syncConfigMaps.enabled` | Enable or disable syncing ConfigMaps across namespaces | `false` |
+| `syncConfigMaps.useClusterPolicy` | Use ClusterPolicy (`kyverno.io/v1`) instead of GeneratingPolicy (`policies.kyverno.io/v1`). ClusterPolicy supports wildcard namespace patterns (for example `tfy-*`) and mature `generateExisting` support | `true` |
+| `syncConfigMaps.excludeNamespaces` | Namespaces to exclude from syncing ConfigMaps. Supports wildcard patterns when `useClusterPolicy` is `true` | `[]` |
+| `syncConfigMaps.includeNamespaces` | Namespaces to include for syncing ConfigMaps. When non-empty, only these namespaces will be included. Supports wildcard patterns (for example `tfy-*`) when `useClusterPolicy` is `true` | `[]` |
+| `syncConfigMaps.items` | List of ConfigMaps to sync. Each entry requires `namespace` (source) and `name` | `[]` |
+
+Example:
+
+```yaml
+syncConfigMaps:
+  enabled: true
+  includeNamespaces:
+    - tfy-*
+  items:
+    - namespace: truefoundry
+      name: ca-cert-bundle
+```
 
 ### syncSecrets Configuration options for syncing Secrets across namespaces
 
-| Name                            | Description                                                                                                                                                                                          | Value   |
-| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `syncSecrets.enabled`           | Enable or disable syncing Secrets across namespaces                                                                                                                                                  | `false` |
-| `syncSecrets.useClusterPolicy`  | Use ClusterPolicy (kyverno.io/v1) instead of GeneratingPolicy (policies.kyverno.io/v1). ClusterPolicy has more mature generateExisting support and supports wildcard namespace patterns (e.g. tfy-*) | `true`  |
-| `syncSecrets.excludeNamespaces` | Namespaces to exclude from syncing Secrets                                                                                                                                                           | `[]`    |
-| `syncSecrets.includeNamespaces` | Namespaces to include for syncing Secrets. When non-empty, only these namespaces will be included. Supports wildcard patterns (e.g. tfy-*) when useClusterPolicy is true                             | `[]`    |
-| `syncSecrets.items`             | List of Secrets to sync across namespaces                                                                                                                                                            | `[]`    |
+Syncing secrets requires additional RBAC permissions for the Kyverno admission and background controllers. Configure those permissions in the Kyverno Helm chart values.
+
+| Name | Description | Value |
+| ---- | ----------- | ----- |
+| `syncSecrets.enabled` | Enable or disable syncing Secrets across namespaces | `false` |
+| `syncSecrets.useClusterPolicy` | Use ClusterPolicy (`kyverno.io/v1`) instead of GeneratingPolicy (`policies.kyverno.io/v1`). ClusterPolicy supports wildcard namespace patterns (for example `tfy-*`) and mature `generateExisting` support | `true` |
+| `syncSecrets.excludeNamespaces` | Namespaces to exclude from syncing Secrets. Supports wildcard patterns when `useClusterPolicy` is `true` | `[]` |
+| `syncSecrets.includeNamespaces` | Namespaces to include for syncing Secrets. When non-empty, only these namespaces will be included. Supports wildcard patterns (for example `tfy-*`) when `useClusterPolicy` is `true` | `[]` |
+| `syncSecrets.items` | List of Secrets to sync. Each entry requires `namespace` (source) and `name` | `[]` |
+
+Example:
+
+```yaml
+syncSecrets:
+  enabled: true
+  includeNamespaces:
+    - tfy-*
+  items:
+    - namespace: truefoundry
+      name: my-tls-secret
+```
 
 ### podVolumeMounts Configuration options for adding volume mounts to pods
 
-| Name                                | Description                                                                                                    | Value   |
-| ----------------------------------- | -------------------------------------------------------------------------------------------------------------- | ------- |
-| `podVolumeMounts.enabled`           | Enable or disable adding volume mounts to pods                                                                 | `false` |
-| `podVolumeMounts.excludeNamespaces` | Namespaces to exclude from adding volume mounts to pods                                                        | `[]`    |
-| `podVolumeMounts.includeNamespaces` | Namespaces to include for adding volume mounts to pods. When non-empty, only these namespaces will be included | `[]`    |
-| `podVolumeMounts.objectSelector`    | Label selector to match specific pods. When set, only pods matching these labels will be mutated               | `{}`    |
-| `podVolumeMounts.mountDetails`      | The details of the volume mounts to add                                                                        | `[]`    |
-| `additionalKyvernoPolicies`         | Additional Kyverno clusterpolicies to apply                                                                    | `[]`    |
+Supports mounting **ConfigMaps** and **Secrets**. When `useClusterPolicy` is `true` (default), the chart renders a `ClusterPolicy` with wildcard namespace support, optional env vars, `readOnly` mounts, and ConfigMap `items`. Set `useClusterPolicy: false` to use a `MutatingPolicy` instead (simpler volume-only mounts, no wildcards).
+
+| Name | Description | Value |
+| ---- | ----------- | ----- |
+| `podVolumeMounts.enabled` | Enable or disable adding volume mounts to pods | `false` |
+| `podVolumeMounts.useClusterPolicy` | Use ClusterPolicy (`kyverno.io/v1`) instead of MutatingPolicy (`policies.kyverno.io/v1`) | `true` |
+| `podVolumeMounts.policyName` | Name of the ClusterPolicy when `useClusterPolicy` is `true`. Defaults to `<release-name>-pod-volume-mounts` | `""` |
+| `podVolumeMounts.configMapName` | ConfigMap name for the built-in default CA mount from `files/default-pod-volume-mounts.yaml`. Used when `mountDetails` is not overridden. Defaults to `ca-cert-bundle` | `""` |
+| `podVolumeMounts.mountInitContainers` | Also mount volumes into init containers | `false` |
+| `podVolumeMounts.excludeNamespaces` | Namespaces to exclude. Supports wildcard patterns when `useClusterPolicy` is `true` | `[]` |
+| `podVolumeMounts.includeNamespaces` | Namespaces to include. When non-empty, only these namespaces are matched. Supports wildcard patterns (for example `tfy-*`) when `useClusterPolicy` is `true` | `[]` |
+| `podVolumeMounts.objectSelector` | Label selector to match specific pods | `{}` |
+| `podVolumeMounts.mountDetails` | Override chart default volume mounts from `files/default-pod-volume-mounts.yaml`. When empty, chart defaults are used | `[]` |
+| `podVolumeMounts.additionalMountDetails` | Additional volume mounts appended to the effective mount list | `[]` |
+
+#### Mount entry fields
+
+Each item in `mountDetails` or `additionalMountDetails` supports:
+
+| Field | Required | Description |
+| ----- | -------- | ----------- |
+| `type` | Yes | `configMap` or `secret` |
+| `configMapName` | For ConfigMap | Name of the ConfigMap to mount |
+| `secretName` | For Secret | Name of the Secret to mount |
+| `volumeName` | No | Kubernetes volume name. Defaults to `configMapName` or `secretName` |
+| `mountPath` | Yes | Container mount path |
+| `subPath` | No | Sub-path within the volume |
+| `readOnly` | No | Mount as read-only |
+| `configMapItems` | No | ConfigMap key/path mapping (ConfigMap only) |
+| `envVars` | No | Environment variables to inject (map of name to value) |
+
+#### Examples
+
+Use chart defaults (CA bundle ConfigMap mount):
+
+```yaml
+podVolumeMounts:
+  enabled: true
+  includeNamespaces:
+    - tfy-*
+  configMapName: ca-cert-bundle
+```
+
+Override the default ConfigMap name only:
+
+```yaml
+podVolumeMounts:
+  enabled: true
+  configMapName: my-company-ca-bundle
+```
+
+Append a Secret mount alongside the default CA mount:
+
+```yaml
+podVolumeMounts:
+  enabled: true
+  includeNamespaces:
+    - tfy-*
+  additionalMountDetails:
+    - type: secret
+      secretName: my-tls-secret
+      mountPath: /etc/tls
+      readOnly: true
+```
+
+Replace defaults with a custom mount list:
+
+```yaml
+podVolumeMounts:
+  enabled: true
+  mountDetails:
+    - type: secret
+      secretName: my-secret
+      mountPath: /var/run/secrets/my-secret
+      subPath: token
+      readOnly: true
+```
+
+Full custom CA + init container mounts:
+
+```yaml
+podVolumeMounts:
+  enabled: true
+  policyName: custom-ca-cert-policy
+  configMapName: ca-cert-bundle
+  mountInitContainers: true
+  includeNamespaces:
+    - tfy-*
+```
+
+### additionalKyvernoPolicies
+
+| Name | Description | Value |
+| ---- | ----------- | ----- |
+| `additionalKyvernoPolicies` | Additional raw Kyverno ClusterPolicy manifests to apply | `[]` |

--- a/charts/tfy-kyverno-config/files/default-pod-volume-mounts.yaml
+++ b/charts/tfy-kyverno-config/files/default-pod-volume-mounts.yaml
@@ -1,0 +1,14 @@
+mountDetails:
+  - type: configMap
+    volumeName: custom-ca-cert
+    configMapName: ca-cert-bundle
+    configMapItems:
+      - key: ca-certificates.crt
+        path: ca-certificates.crt
+    mountPath: /etc/ssl/certs/ca-certificates.crt
+    subPath: ca-certificates.crt
+    readOnly: true
+    envVars:
+      SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+      REQUESTS_CA_BUNDLE: /etc/ssl/certs/ca-certificates.crt
+      SSL_CERT_DIR: /etc/ssl/certs

--- a/charts/tfy-kyverno-config/templates/_helpers.tpl
+++ b/charts/tfy-kyverno-config/templates/_helpers.tpl
@@ -60,3 +60,28 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Resolve the Kubernetes volume name for a podVolumeMounts mountDetail entry.
+*/}}
+{{- define "tfy-kyverno.podVolumeMountName" -}}
+{{- if .volumeName -}}
+{{- .volumeName -}}
+{{- else if eq .type "secret" -}}
+{{- .secretName -}}
+{{- else if eq .type "configMap" -}}
+{{- .configMapName -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Render env vars for podVolumeMounts ClusterPolicy rules.
+*/}}
+{{- define "tfy-kyverno.podVolumeMountEnvVars" -}}
+{{- range $m := .mountDetails }}
+{{- range $name, $value := $m.envVars }}
+- name: {{ $name | quote }}
+  value: {{ $value | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/tfy-kyverno-config/templates/pod-volume-mounts.yaml
+++ b/charts/tfy-kyverno-config/templates/pod-volume-mounts.yaml
@@ -1,4 +1,192 @@
-{{- if and .Values.podVolumeMounts.enabled .Values.podVolumeMounts.mountDetails -}}
+{{- if .Values.podVolumeMounts.enabled -}}
+{{- $defaultMountDetails := (.Files.Get "files/default-pod-volume-mounts.yaml" | fromYaml).mountDetails -}}
+{{- $configMapName := .Values.podVolumeMounts.configMapName | default "ca-cert-bundle" -}}
+{{- range $m := $defaultMountDetails -}}
+{{- if eq $m.type "configMap" -}}
+{{- $_ := set $m "configMapName" $configMapName -}}
+{{- end -}}
+{{- end -}}
+{{- $baseMountDetails := ternary .Values.podVolumeMounts.mountDetails $defaultMountDetails (gt (len .Values.podVolumeMounts.mountDetails) 0) -}}
+{{- $mountDetails := concat $baseMountDetails (.Values.podVolumeMounts.additionalMountDetails | default list) -}}
+{{- if gt (len $mountDetails) 0 -}}
+{{- if .Values.podVolumeMounts.useClusterPolicy }}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: {{ .Values.podVolumeMounts.policyName | default (printf "%s-pod-volume-mounts" (include "tfy-kyverno.fullname" .)) }}
+spec:
+  background: false
+  rules:
+    - name: add-volumes
+      match:
+        resources:
+          kinds:
+            - Pod
+          {{- if .Values.podVolumeMounts.includeNamespaces }}
+          namespaces:
+            {{- range .Values.podVolumeMounts.includeNamespaces }}
+            - {{ . | quote }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.podVolumeMounts.objectSelector }}
+          selector:
+            {{- with .Values.podVolumeMounts.objectSelector.matchLabels }}
+            matchLabels:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+            {{- with .Values.podVolumeMounts.objectSelector.matchExpressions }}
+            matchExpressions:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+          {{- end }}
+      {{- if .Values.podVolumeMounts.excludeNamespaces }}
+      exclude:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              namespaces:
+                {{- range .Values.podVolumeMounts.excludeNamespaces }}
+                - {{ . | quote }}
+                {{- end }}
+      {{- end }}
+      mutate:
+        patchStrategicMerge:
+          spec:
+            volumes:
+              {{- range $m := $mountDetails }}
+              - name: {{ include "tfy-kyverno.podVolumeMountName" $m | quote }}
+                {{- if eq $m.type "secret" }}
+                secret:
+                  secretName: {{ $m.secretName | quote }}
+                {{- else if eq $m.type "configMap" }}
+                configMap:
+                  name: {{ $m.configMapName | quote }}
+                  {{- with $m.configMapItems }}
+                  items:
+                    {{- toYaml . | nindent 20 }}
+                  {{- end }}
+                {{- end }}
+              {{- end }}
+    - name: patch-all-containers
+      match:
+        resources:
+          kinds:
+            - Pod
+          {{- if .Values.podVolumeMounts.includeNamespaces }}
+          namespaces:
+            {{- range .Values.podVolumeMounts.includeNamespaces }}
+            - {{ . | quote }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.podVolumeMounts.objectSelector }}
+          selector:
+            {{- with .Values.podVolumeMounts.objectSelector.matchLabels }}
+            matchLabels:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+            {{- with .Values.podVolumeMounts.objectSelector.matchExpressions }}
+            matchExpressions:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+          {{- end }}
+      {{- if .Values.podVolumeMounts.excludeNamespaces }}
+      exclude:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              namespaces:
+                {{- range .Values.podVolumeMounts.excludeNamespaces }}
+                - {{ . | quote }}
+                {{- end }}
+      {{- end }}
+      mutate:
+        foreach:
+          - list: request.object.spec.containers
+            patchStrategicMerge:
+              spec:
+                containers:
+                  - name: "{{`{{ element.name }}`}}"
+                    {{- if include "tfy-kyverno.podVolumeMountEnvVars" (dict "mountDetails" $mountDetails) }}
+                    env:
+                      {{- include "tfy-kyverno.podVolumeMountEnvVars" (dict "mountDetails" $mountDetails) | nindent 22 }}
+                    {{- end }}
+                    volumeMounts:
+                      {{- range $m := $mountDetails }}
+                      - name: {{ include "tfy-kyverno.podVolumeMountName" $m | quote }}
+                        mountPath: {{ $m.mountPath | quote }}
+                        {{- if $m.subPath }}
+                        subPath: {{ $m.subPath | quote }}
+                        {{- end }}
+                        {{- if $m.readOnly }}
+                        readOnly: true
+                        {{- end }}
+                      {{- end }}
+    {{- if .Values.podVolumeMounts.mountInitContainers }}
+    - name: patch-all-initcontainers
+      match:
+        resources:
+          kinds:
+            - Pod
+          {{- if .Values.podVolumeMounts.includeNamespaces }}
+          namespaces:
+            {{- range .Values.podVolumeMounts.includeNamespaces }}
+            - {{ . | quote }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.podVolumeMounts.objectSelector }}
+          selector:
+            {{- with .Values.podVolumeMounts.objectSelector.matchLabels }}
+            matchLabels:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+            {{- with .Values.podVolumeMounts.objectSelector.matchExpressions }}
+            matchExpressions:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+          {{- end }}
+      {{- if .Values.podVolumeMounts.excludeNamespaces }}
+      exclude:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              namespaces:
+                {{- range .Values.podVolumeMounts.excludeNamespaces }}
+                - {{ . | quote }}
+                {{- end }}
+      {{- end }}
+      preconditions:
+        all:
+          {{- $initContainersPrecondition := "{{ request.object.spec.initContainers || `[]` | length(@) }}" }}
+          - key: {{ $initContainersPrecondition | quote }}
+            operator: GreaterThan
+            value: 0
+      mutate:
+        foreach:
+          - list: request.object.spec.initContainers
+            patchStrategicMerge:
+              spec:
+                initContainers:
+                  - name: "{{`{{ element.name }}`}}"
+                    {{- if include "tfy-kyverno.podVolumeMountEnvVars" (dict "mountDetails" $mountDetails) }}
+                    env:
+                      {{- include "tfy-kyverno.podVolumeMountEnvVars" (dict "mountDetails" $mountDetails) | nindent 22 }}
+                    {{- end }}
+                    volumeMounts:
+                      {{- range $m := $mountDetails }}
+                      - name: {{ include "tfy-kyverno.podVolumeMountName" $m | quote }}
+                        mountPath: {{ $m.mountPath | quote }}
+                        {{- if $m.subPath }}
+                        subPath: {{ $m.subPath | quote }}
+                        {{- end }}
+                        {{- if $m.readOnly }}
+                        readOnly: true
+                        {{- end }}
+                      {{- end }}
+    {{- end }}
+{{- else }}
 apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
@@ -46,15 +234,13 @@ spec:
     - name: has-new-volumes
       expression: >-
         !has(object.spec.volumes) ||
-        {{- range $i, $m := .Values.podVolumeMounts.mountDetails }}
-        {{- $volName := "" }}
-        {{- if eq $m.type "secret" }}{{ $volName = $m.secretName }}{{ else if eq $m.type "configMap" }}{{ $volName = $m.configMapName }}{{ end }}
+        {{- range $i, $m := $mountDetails }}
+        {{- $volName := include "tfy-kyverno.podVolumeMountName" $m }}
         {{ if $i }}||{{ end }} !object.spec.volumes.exists(v, v.name == "{{ $volName }}")
         {{- end }}
   mutations:
-    {{- range $m := .Values.podVolumeMounts.mountDetails }}
-    {{- $volName := "" }}
-    {{- if eq $m.type "secret" }}{{ $volName = $m.secretName }}{{ else if eq $m.type "configMap" }}{{ $volName = $m.configMapName }}{{ end }}
+    {{- range $m := $mountDetails }}
+    {{- $volName := include "tfy-kyverno.podVolumeMountName" $m }}
     - patchType: ApplyConfiguration
       applyConfiguration:
         expression: |
@@ -64,14 +250,14 @@ spec:
               volumes: [
                 {{- if eq $m.type "secret" }}
                 Object.spec.volumes{
-                  name: "{{ $m.secretName }}",
+                  name: "{{ $volName }}",
                   secret: Object.spec.volumes.secret{
                     secretName: "{{ $m.secretName }}"
                   }
                 }
                 {{- else if eq $m.type "configMap" }}
                 Object.spec.volumes{
-                  name: "{{ $m.configMapName }}",
+                  name: "{{ $volName }}",
                   configMap: Object.spec.volumes.configMap{
                     name: "{{ $m.configMapName }}",
                     defaultMode: 420
@@ -92,7 +278,7 @@ spec:
                     }
                   ]
                 }
-              ),
+              ){{- if $.Values.podVolumeMounts.mountInitContainers }},
               initContainers: has(object.spec.initContainers) ?
                 object.spec.initContainers.map(c,
                   Object.spec.initContainers{
@@ -107,7 +293,7 @@ spec:
                       }
                     ]
                   }
-                ) : []
+                ) : []{{- end }}
             }
           } : Object{}
     {{- end }}
@@ -116,4 +302,6 @@ spec:
       enabled: true
   webhookConfiguration:
     timeoutSeconds: 10
+{{- end }}
+{{- end }}
 {{- end -}}

--- a/charts/tfy-kyverno-config/values.yaml
+++ b/charts/tfy-kyverno-config/values.yaml
@@ -40,13 +40,15 @@ syncConfigMaps:
   ## @param syncConfigMaps.excludeNamespaces Namespaces to exclude from syncing ConfigMaps
   excludeNamespaces: []
   ## @param syncConfigMaps.includeNamespaces Namespaces to include for syncing ConfigMaps. When non-empty, only these namespaces will be included. Supports wildcard patterns (e.g. tfy-*) when useClusterPolicy is true
+  ## example
+  ## includeNamespaces: [tfy-*]
   includeNamespaces: []
+
   ## @param syncConfigMaps.items List of ConfigMaps to sync across namespaces
   ## Example:
   ##   - namespace: truefoundry
   ##     name: ca-cert-bundle
   items: []
-
 ## @section syncSecrets Configuration options for syncing Secrets across namespaces
 ## Syncing secrets requires additional RBAC permissions for both the Kyverno admission
 ## controller and the background controller to read source secrets and create/update/delete generated secrets for synchronization.
@@ -70,12 +72,20 @@ syncSecrets:
 podVolumeMounts:
   ## @param podVolumeMounts.enabled Enable or disable adding volume mounts to pods
   enabled: false
-  ## @param podVolumeMounts.excludeNamespaces Namespaces to exclude from adding volume mounts to pods
+  ## @param podVolumeMounts.useClusterPolicy Use ClusterPolicy (kyverno.io/v1) instead of MutatingPolicy (policies.kyverno.io/v1). ClusterPolicy supports wildcard namespace patterns (e.g. tfy-*), configMap items, env vars, and readOnly volume mounts
+  useClusterPolicy: true
+  ## @param podVolumeMounts.policyName Name of the ClusterPolicy when useClusterPolicy is true. Defaults to `<release-name>-pod-volume-mounts`
+  policyName: "" #Example: custom-ca-cert-policy
+  ## @param podVolumeMounts.configMapName Default ConfigMap name for the built-in CA volume mount. Used when mountDetails is not overridden
+  configMapName: "" #Example: ca-cert-bundle
+  ## @param podVolumeMounts.mountInitContainers Mount volumes into init containers when enabled
+  mountInitContainers: false
+  ## @param podVolumeMounts.excludeNamespaces Namespaces to exclude from adding volume mounts to pods. Supports wildcard patterns (e.g. tfy-*) when useClusterPolicy is true
   excludeNamespaces: []
-
-  ## @param podVolumeMounts.includeNamespaces Namespaces to include for adding volume mounts to pods. When non-empty, only these namespaces will be included
+  ## @param podVolumeMounts.includeNamespaces Namespaces to include for adding volume mounts to pods. When non-empty, only these namespaces will be included. Supports wildcard patterns (e.g. tfy-*) when useClusterPolicy is true
+  ## example
+  ## includeNamespaces: [tfy-*]
   includeNamespaces: []
-
   ## @param podVolumeMounts.objectSelector Label selector to match specific pods. When set, only pods matching these labels will be mutated
   ## Example:
   ##   matchLabels:
@@ -85,18 +95,14 @@ podVolumeMounts:
   ##       operator: In
   ##       values: ["truefoundry", "my-app"]
   objectSelector: {}
-
-  ## @param podVolumeMounts.mountDetails The details of the volume mounts to add
+  ## @param podVolumeMounts.mountDetails Override the chart default volume mounts from files/default-pod-volume-mounts.yaml. When empty, chart defaults are used. Set configMapName on each entry or use podVolumeMounts.configMapName for the built-in default
+  mountDetails: []
+  ## @param podVolumeMounts.additionalMountDetails Additional volume mounts appended to the effective mount list
   ## Example:
   ##   - type: secret
   ##     secretName: my-secret
   ##     mountPath: /var/run/secrets/my-secret
-  ##     subPath: my-subPath
-  ##   - type: configMap
-  ##     configMapName: my-configmap
-  ##     mountPath: /my/configmap/path
-  ##     subPath: my-subPath
-  mountDetails: []
+  additionalMountDetails: []
 
 ## @param additionalKyvernoPolicies Additional Kyverno clusterpolicies to apply
 additionalKyvernoPolicies: []


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes cluster admission mutations for pods when enabled; misconfigured namespaces or mounts could break workloads or TLS, though the feature stays off by default.
> 
> **Overview**
> **tfy-kyverno-config 0.1.10** overhauls **pod volume mounts** so enabling the feature no longer requires hand-written `mountDetails`. Chart defaults in `files/default-pod-volume-mounts.yaml` mount a synced **`ca-cert-bundle`** ConfigMap, set SSL env vars, and support **readOnly** / **subPath** mounts.
> 
> When **`podVolumeMounts.useClusterPolicy`** is true (new default), the chart renders a **Kyverno `ClusterPolicy`** with wildcard-friendly include/exclude namespaces, optional **init container** patching, **`additionalMountDetails`**, and configurable **`policyName`** / **`configMapName`**. The legacy **MutatingPolicy** path remains but now uses the same merged mount list and optional init-container mounts.
> 
> Docs and **`values.yaml`** are updated to describe the sync ConfigMap → mount CA workflow and the new knobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c2f62e263aaf45c8324380e5b93dd5f85b080a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->