### PR TITLE
feat: update sparknotebook chart image for ai support

### DIFF
--- a/charts/tfy-configs/files/workbench-images.yaml
+++ b/charts/tfy-configs/files/workbench-images.yaml
@@ -92,7 +92,7 @@ images:
     image:
       - match: []
         spec:
-          image_uri: "public.ecr.aws/truefoundrycloud/jupyter-spark:0.4.10-py3.12.3-sc2.13-spark4.0.2-delta4.0.1-sudo"
+          image_uri: "public.ecr.aws/truefoundrycloud/jupyter-spark:0.5.0-py3.12.3-sc2.13-spark4.0.2-delta4.0.1-sudo"
 
   - name: Jupyter Lab Spark 3.5.7 (Python 3.11) - Databricks 16.4 LTS
     type: spark-notebook
@@ -101,7 +101,7 @@ images:
     image:
       - match: []
         spec:
-          image_uri: "public.ecr.aws/truefoundrycloud/jupyter-spark:0.4.10-py3.11.14-sc2.12-spark3.5.7-delta3.3.2-sudo"
+          image_uri: "public.ecr.aws/truefoundrycloud/jupyter-spark:0.5.0-py3.11.14-sc2.12-spark3.5.7-delta3.3.2-sudo"
 
   - name: Jupyter Lab Spark 3.5.7 (Python 3.10) - Databricks 15.4 LTS
     type: spark-notebook
@@ -110,7 +110,7 @@ images:
     image:
       - match: []
         spec:
-          image_uri: "public.ecr.aws/truefoundrycloud/jupyter-spark:0.4.10-py3.10.16-sc2.12-spark3.5.7-delta3.3.2-sudo"
+          image_uri: "public.ecr.aws/truefoundrycloud/jupyter-spark:0.5.0-py3.10.16-sc2.12-spark3.5.7-delta3.3.2-sudo"
 
   - name: Jupyter Lab Spark 3.5.7 (Python 3.10, Delta 3.1.0) - Databricks 14.3 LTS
     type: spark-notebook
@@ -119,7 +119,7 @@ images:
     image:
       - match: []
         spec:
-          image_uri: "public.ecr.aws/truefoundrycloud/jupyter-spark:0.4.10-py3.10.16-sc2.12-spark3.5.7-delta3.1.0-sudo"
+          image_uri: "public.ecr.aws/truefoundrycloud/jupyter-spark:0.5.0-py3.10.16-sc2.12-spark3.5.7-delta3.1.0-sudo"
 
   - name: SSH Server Minimal Image
     type: ssh-server


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changing default runtime images affects new and reprovisioned Spark notebooks; behavior depends on what 0.5.0 adds (e.g. AI tooling) and should be validated before broad rollout.
> 
> **Overview**
> Updates all four **spark-notebook** entries in `workbench-images.yaml` so new Spark Jupyter workbenches pull **`jupyter-spark:0.5.0-*`** instead of **`0.4.10-*`**. Spark/Python/Delta/Scala tags in each URI are unchanged; only the image patch version moves to **0.5.0** (aligned with the PR goal of AI-capable Spark notebook images).
> 
> Affected variants: Spark 4.0.2 / Python 3.12 (Databricks 17.3 LTS), Spark 3.5.7 / Python 3.11 (16.4 LTS), and both Python 3.10 Spark 3.5.7 images (Delta 3.3.2 and 3.1.0 for 15.4 / 14.3 LTS). Non–spark-notebook images in the file are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a99f434512401986f416338203cf7951bfc6bd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->