### PR TITLE
feat: add permission to delete spark connect services

### DIFF
--- a/charts/tfy-agent/templates/tfy-agent-proxy-clusterrole-ns.yaml
+++ b/charts/tfy-agent/templates/tfy-agent-proxy-clusterrole-ns.yaml
@@ -100,9 +100,9 @@ rules:
     resources: ["virtualservices"]
     verbs: ["create", "patch"]
 
-  {{/* This allows us to apply/delete SparkApplication (Spark Job Run) */}}
+  {{/* This allows us to apply/delete SparkApplication (Spark Job Run) and SparkConnect (Spark Notebook) */}}
   - apiGroups: ["sparkoperator.k8s.io"]
-    resources: ["sparkapplications"]
+    resources: ["sparkapplications", "sparkconnects"]
     verbs: ["create", "get", "delete"]
 {{- end }}
 {{- end }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Narrow RBAC chart change that mirrors existing SparkApplication permissions for SparkConnect; no auth or data-path logic changes.
> 
> **Overview**
> Extends the **tfy-agent-proxy** namespace **ClusterRole** so the agent can manage **SparkConnect** resources (`sparkconnects` on `sparkoperator.k8s.io`), not only **SparkApplication** job runs.
> 
> The existing rule verbs (`create`, `get`, `delete`) now apply to both resource types; the inline comment is updated to call out Spark Notebook / SparkConnect. A small Helm template comment formatting fix is included on the same block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c05afff36172d866263ea39cf5ebed527fc9e17c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->