### PR TITLE
upgrade tfy-agent 0.2.95

### DIFF
--- a/charts/tfy-agent/Chart.yaml
+++ b/charts/tfy-agent/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.94
+version: 0.2.95
 
 maintainers:
   - name: truefoundry

--- a/charts/tfy-agent/README.md
+++ b/charts/tfy-agent/README.md
@@ -294,7 +294,13 @@ If your control plane URL is using self-signed CA certificate, follow these step
 
 ### eso (external-secrets operator) configuration parameters
 
-| Name                                               | Description                                                 | Value              |
-| -------------------------------------------------- | ----------------------------------------------------------- | ------------------ |
-| `external-secrets-operator.enabled`                | Bool value to deploy the external-secrets operator subchart | `true`             |
-| `external-secrets-operator.clusterSecretStoreName` | Name of the ClusterSecretStore resource                     | `tfy-secret-store` |
+| Name                                | Description                                                                                                                                                                        | Value  |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| `external-secrets-operator.enabled` | Bool value to deploy the external-secrets operator subchart. Disable this to use your own External Secrets Operator. Disabling it would still create a secret store for the agent. | `true` |
+
+### external-secrets-operator.clusterSecretStore ClusterSecretStore configuration
+
+| Name                                                  | Description                                    | Value              |
+| ----------------------------------------------------- | ---------------------------------------------- | ------------------ |
+| `external-secrets-operator.clusterSecretStore.create` | Bool value to create the cluster secret store. | `true`             |
+| `external-secrets-operator.clusterSecretStore.name`   | Name of the ClusterSecretStore resource        | `tfy-secret-store` |

--- a/charts/tfy-agent/templates/cluster-secret-store.yaml
+++ b/charts/tfy-agent/templates/cluster-secret-store.yaml
@@ -1,8 +1,8 @@
-{{- if index .Values "external-secrets-operator" "enabled" -}}
+{{- if index .Values "external-secrets-operator" "clusterSecretStore" "create" -}}
 apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
-  name: {{ index .Values "external-secrets-operator" "clusterSecretStoreName" }}
+  name: {{ index .Values "external-secrets-operator" "clusterSecretStore" "name" }}
   labels:
     {{- include "tfy-agent.commonLabels" . | nindent 4 }}
   annotations:

--- a/charts/tfy-agent/templates/secret.yaml
+++ b/charts/tfy-agent/templates/secret.yaml
@@ -4,10 +4,8 @@ kind: Secret
 metadata:
   name: {{ include "tfy-agent.secretName" . }}
   labels:
-    {{- include "tfy-agent.commonLabels" . | nindent 4 }}
-    {{- if index .Values "external-secrets-operator" "enabled" }}
     external-secrets.io/type: webhook
-    {{- end }}
+    {{- include "tfy-agent.commonLabels" . | nindent 4 }}
   annotations:
     {{- include "tfy-agent.commonAnnotations" . | nindent 4 }}
 stringData:

--- a/charts/tfy-agent/values.yaml
+++ b/charts/tfy-agent/values.yaml
@@ -795,6 +795,12 @@ external-secrets-operator:
   ## @param external-secrets-operator.enabled Bool value to deploy the external-secrets operator subchart
   ##
   enabled: true
-  ## @param external-secrets-operator.clusterSecretStoreName Name of the ClusterSecretStore resource
+  ## @param external-secrets-operator.clusterSecretStore ClusterSecretStore configuration
   ##
-  clusterSecretStoreName: "tfy-secret-store"
+  clusterSecretStore:
+    ## @param external-secrets-operator.clusterSecretStore.create Bool value to create the cluster secret store
+    ##
+    create: true
+    ## @param external-secrets-operator.clusterSecretStore.name Name of the ClusterSecretStore resource
+    ##
+    name: "tfy-secret-store"

--- a/charts/tfy-agent/values.yaml
+++ b/charts/tfy-agent/values.yaml
@@ -792,13 +792,13 @@ sdsServer:
 ## @section eso (external-secrets operator) configuration parameters
 ##
 external-secrets-operator:
-  ## @param external-secrets-operator.enabled Bool value to deploy the external-secrets operator subchart
+  ## @param external-secrets-operator.enabled Bool value to deploy the external-secrets operator subchart. Disable this to use your own External Secrets Operator. Disabling it would still create a secret store for the agent.
   ##
   enabled: true
-  ## @param external-secrets-operator.clusterSecretStore ClusterSecretStore configuration
+  ## @section external-secrets-operator.clusterSecretStore ClusterSecretStore configuration
   ##
   clusterSecretStore:
-    ## @param external-secrets-operator.clusterSecretStore.create Bool value to create the cluster secret store
+    ## @param external-secrets-operator.clusterSecretStore.create Bool value to create the cluster secret store.
     ##
     create: true
     ## @param external-secrets-operator.clusterSecretStore.name Name of the ClusterSecretStore resource


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Breaking Helm value rename and changed ClusterSecretStore render conditions can affect upgrades and clusters that already run their own External Secrets Operator or duplicate ClusterSecretStores.
> 
> **Overview**
> **tfy-agent 0.2.95** refactors how External Secrets and the agent’s **ClusterSecretStore** are configured.
> 
> **ClusterSecretStore** is now controlled by **`external-secrets-operator.clusterSecretStore.create`** (default `true`) instead of tying creation to **`external-secrets-operator.enabled`**. The store name moves from flat **`clusterSecretStoreName`** to **`clusterSecretStore.name`** (still default `tfy-secret-store`). That lets clusters **disable the bundled ESO subchart** while still rendering the webhook **ClusterSecretStore**, or skip creating the store via **`create: false`**.
> 
> The inline cluster token **Secret** always gets the **`external-secrets.io/type: webhook`** label (previously only when the subchart was enabled). README and values comments document the new knobs.
> 
> **Upgrade note:** Helm overrides must rename **`external-secrets-operator.clusterSecretStoreName`** → **`external-secrets-operator.clusterSecretStore.name`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d602476f7cf6d5c7ef39dc9354125c2a915bbe02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->