### PR TITLE
feat: emit truefoundry-managed + truefoundry-cluster-name default tags on all EC2NodeClass (INFRA-703)

### DIFF
--- a/charts/tfy-karpenter-config/Chart.yaml
+++ b/charts/tfy-karpenter-config/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: tfy-karpenter-config
 description: "Karpenter resources to manage workloads"
 type: application
-version: 0.1.56
+version: 0.1.57
 maintainers:
   - name: truefoundry

--- a/charts/tfy-karpenter-config/templates/controlplane/karpenter-control-plane-ec2nodeclass.yaml
+++ b/charts/tfy-karpenter-config/templates/controlplane/karpenter-control-plane-ec2nodeclass.yaml
@@ -27,6 +27,8 @@ spec:
     truefoundry.com/component_type: control-plane
     karpenter.sh/discovery: {{ .Values.cluster.name }}
     cluster-name: {{ .Values.cluster.name }}
+    truefoundry-cluster-name: {{ .Values.cluster.name }}
+    truefoundry-managed: "true"
   {{- range $key, $val := .Values.karpenter.controlPlaneNodeTemplate.extraTags }}
     {{ $key }}: {{ $val | quote }} 
   {{- end }}

--- a/charts/tfy-karpenter-config/templates/critical/karpenter-critical-ec2nodeclass.yaml
+++ b/charts/tfy-karpenter-config/templates/critical/karpenter-critical-ec2nodeclass.yaml
@@ -27,6 +27,8 @@ spec:
     truefoundry.com/component_type: critical
     karpenter.sh/discovery: {{ .Values.cluster.name }}
     cluster-name: {{ .Values.cluster.name }}
+    truefoundry-cluster-name: {{ .Values.cluster.name }}
+    truefoundry-managed: "true"
   {{- range $key, $val := .Values.karpenter.critical.nodeclass.extraTags }}
     {{ $key }}: {{ $val | quote }} 
   {{- end }}

--- a/charts/tfy-karpenter-config/templates/default/karpenter-default-ec2nodeclass.yaml
+++ b/charts/tfy-karpenter-config/templates/default/karpenter-default-ec2nodeclass.yaml
@@ -27,6 +27,8 @@ spec:
     truefoundry.com/component_type: default
     karpenter.sh/discovery: {{ .Values.cluster.name }}
     cluster-name: {{ .Values.cluster.name }}
+    truefoundry-cluster-name: {{ .Values.cluster.name }}
+    truefoundry-managed: "true"
   {{- range $key, $val := .Values.karpenter.defaultNodeTemplate.extraTags }}
     {{ $key }}: {{ $val | quote }} 
   {{- end }}

--- a/charts/tfy-karpenter-config/templates/gpu/karpenter-gpu-default-ec2nodeclass.yaml
+++ b/charts/tfy-karpenter-config/templates/gpu/karpenter-gpu-default-ec2nodeclass.yaml
@@ -26,6 +26,8 @@ spec:
     truefoundry.com/compute_type: gpu
     karpenter.sh/discovery: {{ .Values.cluster.name }}
     cluster-name: {{ .Values.cluster.name }}
+    truefoundry-cluster-name: {{ .Values.cluster.name }}
+    truefoundry-managed: "true"
   {{- range $key, $val := .Values.karpenter.gpuDefaultNodeTemplate.extraTags }}
     {{ $key }}: {{ $val | quote }} 
   {{- end }}

--- a/charts/tfy-karpenter-config/templates/inferentia/karpenter-inferentia-default-ec2nodeclass.yaml
+++ b/charts/tfy-karpenter-config/templates/inferentia/karpenter-inferentia-default-ec2nodeclass.yaml
@@ -25,6 +25,8 @@ spec:
   tags:
     karpenter.sh/discovery: {{ .Values.cluster.name }}
     cluster-name: {{ .Values.cluster.name }}
+    truefoundry-cluster-name: {{ .Values.cluster.name }}
+    truefoundry-managed: "true"
   {{- range $key, $val := .Values.karpenter.inferentiaDefaultNodeTemplate.extraTags }}
     {{ $key }}: {{ $val | quote }} 
   {{- end }}


### PR DESCRIPTION
## What & why

Part of [INFRA-703](https://linear.app/truefoundry/issue/INFRA-703) (unified AWS tagging). The standard TrueFoundry audit tags — `truefoundry-managed` and `truefoundry-cluster-name` — should **flow by default from this chart**, not be hardcoded into the inframold umbrella's Karpenter `extraTags` (which is reserved for customer tags passed from outside). This was [Vedant's review note on ubermold-base#2466](https://github.com/truefoundry/ubermold-base/pull/2466#discussion_r3400613401):

> These two tags should flow by default to the karpenter-config helm chart … Extra tags can be passed from outside

`tfy-karpenter-config` is a TrueFoundry-owned chart, so the defaults belong here alongside the existing `cluster-name`.

## Changes

- Add `truefoundry-cluster-name: {{ .Values.cluster.name }}` and `truefoundry-managed: "true"` to the `tags:` block of all 5 EC2NodeClass templates (default, gpu, controlplane, inferentia, critical), after `cluster-name` and before the customer `extraTags` range.
- Bump chart `version` `0.1.56 → 0.1.57`.

No `values.yaml`/README changes (defaults are hardcoded, not new params). Customer `extraTags` still append/override.

## Verification

- `helm lint` — 0 failures.
- `helm template … --set cluster.name=test-cluster`: both tags render on all 5 EC2NodeClass (4 by default + inferentia when enabled).
- Confirmed customer `extraTags` (e.g. `cost-center`) still append on top.

## Downstream follow-up (not in this PR)

Once this releases as `0.1.57`, re-pin ubermold-base `karpenter-config.yaml` `targetRevision: 0.1.54 → 0.1.57`. The two must ship together — ubermold-base#2466 already dropped the hardcoded tags, so until this lands Karpenter nodes get neither.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tag-only Helm template changes on node provisioning metadata; no auth, data, or runtime logic changes. Coordinate release with ubermold-base pin so nodes keep audit tags after umbrella hardcoding was removed.
> 
> **Overview**
> Adds **`truefoundry-cluster-name`** (from `cluster.name`) and **`truefoundry-managed: "true"`** to the default `tags` block on all five Karpenter **EC2NodeClass** templates (default, GPU, control plane, inferentia, critical), placed after `cluster-name` and before customer **`extraTags`**.
> 
> Bumps **`tfy-karpenter-config`** chart version **0.1.56 → 0.1.57** so unified AWS tagging comes from this chart instead of umbrella `extraTags`. Existing customer **`extraTags`** still merge on top and can override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0216ef7e6013cc5e03fd80d9b419d9651ea167c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->