### PR TITLE
Use PAT for PR workflow pushes to avoid manual approval

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
+          token: ${{ secrets.TFY_GITHUB_TOKEN }}
       - name: Execute readme-generator-for-helm
         env:
           DIFF_URL: '${{github.event.pull_request.diff_url}}'

--- a/.github/workflows/update-artifacts.yml
+++ b/.github/workflows/update-artifacts.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
+          token: ${{ secrets.TFY_GITHUB_TOKEN }}
 
       - name: Setup Kubectl
         uses: azure/setup-kubectl@v3


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two PR workflows push generated changes back to the PR branch. When those pushes use the default `GITHUB_TOKEN`, GitHub treats the resulting `pull_request` synchronize event as approval-required, which blocks follow-up CI runs until someone manually approves them.

This change passes the existing `TFY_GITHUB_TOKEN` secret to `actions/checkout` in both workflows, so `git push` authenticates with a PAT instead. Follow-up PR workflows should then run automatically after bot commits are pushed.

## Changes

- Add `token: ${{ secrets.TFY_GITHUB_TOKEN }}` to checkout in `.github/workflows/docs.yml`
- Add `token: ${{ secrets.TFY_GITHUB_TOKEN }}` to checkout in `.github/workflows/update-artifacts.yml`

## Test plan

- [ ] Open or update a PR that changes `charts/**` and confirm the README metadata workflow pushes without requiring approval on the follow-up synchronize event
- [ ] Open or update a PR that changes inframold chart paths and confirm the artifacts manifest workflow pushes without requiring approval on the follow-up synchronize event
- [ ] Confirm dependent PR checks (`Validate Chart Template`, etc.) run automatically after bot pushes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e333858-5bd3-45bf-a09c-d7b448d18eea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e333858-5bd3-45bf-a09c-d7b448d18eea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

