### PR TITLE
runAsNonRoot set as default for podSecurityContext: false

### DIFF
--- a/charts/tfy-llm-gateway/templates/_helpers.tpl
+++ b/charts/tfy-llm-gateway/templates/_helpers.tpl
@@ -635,3 +635,20 @@ false
 {{- end }}
 {{- end }}
 {{- end -}}
+
+{{/*
+  Pod securityContext
+  Renders the pod-level securityContext. When enabled, emits the provided
+  fields (minus "enabled"). When disabled, the securityContext is NOT removed
+  entirely; instead only runAsNonRoot: true is enforced.
+  Usage: {{- include "tfy-llm-gateway.podSecurityContext" .Values.podSecurityContext | nindent <n> }}
+*/}}
+{{- define "tfy-llm-gateway.podSecurityContext" -}}
+securityContext:
+{{- if .enabled }}
+  {{- toYaml (omit . "enabled") | nindent 2 }}
+{{- else }}
+  runAsNonRoot: true
+{{- end }}
+{{- end -}}
+

--- a/charts/tfy-llm-gateway/templates/deployment.yaml
+++ b/charts/tfy-llm-gateway/templates/deployment.yaml
@@ -38,10 +38,7 @@ spec:
         {{- toYaml .Values.dnsConfig | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "tfy-llm-gateway.serviceAccountName" . }}
-      {{- if .Values.podSecurityContext.enabled }}
-      securityContext:
-        {{- toYaml (omit .Values.podSecurityContext "enabled") | nindent 8 }}
-      {{- end }}
+      {{- include "tfy-llm-gateway.podSecurityContext" .Values.podSecurityContext | nindent 6 }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 30 }}
       {{- if or .Values.initContainers (and .Values.global.customCA.enabled (eq (include "tfy-llm-gateway.customCA.useDirectMount" .) "false")) }}
       initContainers:

--- a/charts/tfy-otel-collector/templates/_helpers.tpl
+++ b/charts/tfy-otel-collector/templates/_helpers.tpl
@@ -544,3 +544,20 @@ false
 {{- end }}
 {{- end }}
 {{- end -}}
+
+{{/*
+  Pod securityContext
+  Renders the pod-level securityContext. When enabled, emits the provided
+  fields (minus "enabled"). When disabled, the securityContext is NOT removed
+  entirely; instead only runAsNonRoot: true is enforced.
+  Usage: {{- include "tfy-otel-collector.podSecurityContext" .Values.podSecurityContext | nindent <n> }}
+*/}}
+{{- define "tfy-otel-collector.podSecurityContext" -}}
+securityContext:
+{{- if .enabled }}
+  {{- toYaml (omit . "enabled") | nindent 2 }}
+{{- else }}
+  runAsNonRoot: true
+{{- end }}
+{{- end -}}
+

--- a/charts/tfy-otel-collector/templates/deployment.yaml
+++ b/charts/tfy-otel-collector/templates/deployment.yaml
@@ -29,10 +29,7 @@ spec:
         {{- include "tfy-otel-collector.podLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "tfy-otel-collector.serviceAccountName" . }}
-      {{- if .Values.podSecurityContext.enabled }}
-      securityContext:
-        {{- toYaml (omit .Values.podSecurityContext "enabled") | nindent 8 }}
-      {{- end }}
+      {{- include "tfy-otel-collector.podSecurityContext" .Values.podSecurityContext | nindent 6 }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 30 }}
       {{- $initContainers := include "tfy-otel-collector.customCA.initContainer" . | trim }}
       {{- if $initContainers }}

--- a/charts/true-ai/templates/_helpers.tpl
+++ b/charts/true-ai/templates/_helpers.tpl
@@ -475,3 +475,20 @@ limits:
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+  Pod securityContext
+  Renders the pod-level securityContext. When enabled, emits the provided
+  fields (minus "enabled"). When disabled, the securityContext is NOT removed
+  entirely; instead only runAsNonRoot: true is enforced.
+  Usage: {{- include "true-ai.podSecurityContext" .Values.podSecurityContext | nindent <n> }}
+*/}}
+{{- define "true-ai.podSecurityContext" -}}
+securityContext:
+{{- if .enabled }}
+  {{- toYaml (omit . "enabled") | nindent 2 }}
+{{- else }}
+  runAsNonRoot: true
+{{- end }}
+{{- end -}}
+

--- a/charts/true-ai/templates/deployment.yaml
+++ b/charts/true-ai/templates/deployment.yaml
@@ -37,10 +37,7 @@ spec:
         {{- toYaml .Values.dnsConfig | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "true-ai.serviceAccountName" . }}
-      {{- if .Values.podSecurityContext.enabled }}
-      securityContext:
-        {{- toYaml (omit .Values.podSecurityContext "enabled") | nindent 8 }}
-      {{- end }}
+      {{- include "true-ai.podSecurityContext" .Values.podSecurityContext | nindent 6 }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 30 }}
       {{- if or .Values.initContainers (and .Values.global.customCA.enabled (eq (include "true-ai.customCA.useDirectMount" .) "false")) }}
       initContainers:

--- a/charts/truefoundry/templates/_helpers.tpl
+++ b/charts/truefoundry/templates/_helpers.tpl
@@ -499,3 +499,19 @@ Usage: include "truefoundry.networkPolicyName" (dict "context" . "suffix" "intra
 {{- toYaml . }}
 {{- end }}
 {{- end -}}
+
+{{/*
+  Pod securityContext
+  Renders the pod-level securityContext. When enabled, emits the provided
+  fields (minus "enabled"). When disabled, the securityContext is NOT removed
+  entirely; instead only runAsNonRoot: true is enforced.
+  Usage: {{- include "truefoundry.podSecurityContext" .Values.<component>.podSecurityContext | nindent <n> }}
+*/}}
+{{- define "truefoundry.podSecurityContext" -}}
+securityContext:
+{{- if .enabled }}
+  {{- toYaml (omit . "enabled") | nindent 2 }}
+{{- else }}
+  runAsNonRoot: true
+{{- end }}
+{{- end -}}

--- a/charts/truefoundry/templates/bootstrap/job.yaml
+++ b/charts/truefoundry/templates/bootstrap/job.yaml
@@ -18,12 +18,7 @@ spec:
       labels:
         {{- include "bootstrap.podlabels" . | nindent 8 }}
     spec:
-      {{- if .Values.truefoundryBootstrap.podSecurityContext.enabled }}
-      {{- with .Values.truefoundryBootstrap.podSecurityContext }}
-      securityContext:
-        {{- toYaml (omit . "enabled") | nindent 8 }}
-      {{- end }}
-      {{- end }}
+      {{- include "truefoundry.podSecurityContext" .Values.truefoundryBootstrap.podSecurityContext | nindent 6 }}
       serviceAccountName: {{ include "bootstrap.serviceAccountName" . }}
       containers:
       - name: truefoundry-bootstrap-job

--- a/charts/truefoundry/templates/deltafusion-ingestor/cronjob.yaml
+++ b/charts/truefoundry/templates/deltafusion-ingestor/cronjob.yaml
@@ -36,12 +36,7 @@ spec:
           imagePullSecrets:
             {{- include "deltafusion-compaction.imagePullSecrets" . | nindent 12 }}
           serviceAccountName: {{ include "deltafusion-compaction.serviceAccountName" . }}
-          {{- if .Values.deltaFusionCompaction.podSecurityContext.enabled }}
-          {{- with .Values.deltaFusionCompaction.podSecurityContext }}
-          securityContext:
-            {{- toYaml (omit . "enabled") | nindent 12 }}
-          {{- end }}
-          {{- end }}
+          {{- include "truefoundry.podSecurityContext" .Values.deltaFusionCompaction.podSecurityContext | nindent 10 }}
           {{- if and .Values.global.customCA.enabled (eq (include "truefoundry.customCA.useDirectMount" .) "false") }}
           initContainers:
             {{- include "truefoundry.customCA.initContainer" . | nindent 12 }}

--- a/charts/truefoundry/templates/deltafusion-ingestor/statefulset.yaml
+++ b/charts/truefoundry/templates/deltafusion-ingestor/statefulset.yaml
@@ -28,6 +28,7 @@ spec:
       {{- if .Values.deltaFusionIngestor.podSecurityContext.enabled }}
         {{- toYaml (omit .Values.deltaFusionIngestor.podSecurityContext "enabled") | nindent 8 }}
       {{- else }}
+        runAsNonRoot: true
         fsGroup: {{ .Values.deltaFusionIngestor.podSecurityContext.fsGroup | default 100 }}
       {{- end }}
       {{- if and .Values.global.customCA.enabled (eq (include "truefoundry.customCA.useDirectMount" .) "false") }}

--- a/charts/truefoundry/templates/deltafusion-query-server/deployment.yaml
+++ b/charts/truefoundry/templates/deltafusion-query-server/deployment.yaml
@@ -23,12 +23,7 @@ spec:
         {{- include "deltafusion-query-server.podLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "deltafusion-query-server.serviceAccountName" . }}
-      {{- if .Values.deltaFusionQueryServer.podSecurityContext.enabled }}
-      {{- with .Values.deltaFusionQueryServer.podSecurityContext }}
-      securityContext:
-        {{- toYaml (omit . "enabled") | nindent 8 }}
-      {{- end }}
-      {{- end }}
+      {{- include "truefoundry.podSecurityContext" .Values.deltaFusionQueryServer.podSecurityContext | nindent 6 }}
       {{- if and .Values.global.customCA.enabled (eq (include "truefoundry.customCA.useDirectMount" .) "false") }}
       initContainers:
         {{- include "truefoundry.customCA.initContainer" . | nindent 8 }}

--- a/charts/truefoundry/templates/mlfoundry-server/deployment.yaml
+++ b/charts/truefoundry/templates/mlfoundry-server/deployment.yaml
@@ -21,12 +21,7 @@ spec:
         {{- include "mlfoundry-server.podLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "mlfoundry-server.serviceAccountName" . }}
-      {{- if .Values.mlfoundryServer.podSecurityContext.enabled }}
-      {{- with .Values.mlfoundryServer.podSecurityContext }}
-      securityContext:
-        {{- toYaml (omit . "enabled") | nindent 8 }}
-      {{- end }}
-      {{- end }}
+      {{- include "truefoundry.podSecurityContext" .Values.mlfoundryServer.podSecurityContext | nindent 6 }}
       {{- if and .Values.global.customCA.enabled (eq (include "truefoundry.customCA.useDirectMount" .) "false") }}
       initContainers:
         {{- include "truefoundry.customCA.initContainer" . | nindent 8 }}

--- a/charts/truefoundry/templates/s3proxy/deployment.yaml
+++ b/charts/truefoundry/templates/s3proxy/deployment.yaml
@@ -21,12 +21,7 @@ spec:
         {{- include "s3proxy.podLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "s3proxy.serviceAccountName" . }}
-      {{- if .Values.s3proxy.podSecurityContext.enabled }}
-      {{- with .Values.s3proxy.podSecurityContext }}
-      securityContext:
-        {{- toYaml (omit . "enabled") | nindent 8 }}
-      {{- end }}
-      {{- end }}
+      {{- include "truefoundry.podSecurityContext" .Values.s3proxy.podSecurityContext | nindent 6 }}
       {{- if and .Values.global.customCA.enabled (eq (include "truefoundry.customCA.useDirectMount" .) "false") }}
       initContainers:
         {{- include "truefoundry.customCA.initContainer" . | nindent 8 }}

--- a/charts/truefoundry/templates/servicefoundry-server/deployment.yaml
+++ b/charts/truefoundry/templates/servicefoundry-server/deployment.yaml
@@ -21,12 +21,7 @@ spec:
         {{- include "servicefoundry-server.podLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "servicefoundry-server.serviceAccountName" . }}
-      {{- if .Values.servicefoundryServer.podSecurityContext.enabled }}
-      {{- with .Values.servicefoundryServer.podSecurityContext }}
-      securityContext:
-        {{- toYaml (omit . "enabled") | nindent 8 }}
-      {{- end }}
-      {{- end }}
+      {{- include "truefoundry.podSecurityContext" .Values.servicefoundryServer.podSecurityContext | nindent 6 }}
       {{- if and .Values.global.customCA.enabled (eq (include "truefoundry.customCA.useDirectMount" .) "false") }}
       initContainers:
         {{- include "truefoundry.customCA.initContainer" . | nindent 8 }}

--- a/charts/truefoundry/templates/sfy-manifest-service/deployment.yaml
+++ b/charts/truefoundry/templates/sfy-manifest-service/deployment.yaml
@@ -21,12 +21,7 @@ spec:
         {{- include "sfy-manifest-service.podLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "sfy-manifest-service.serviceAccountName" . }}
-      {{- if .Values.sfyManifestService.podSecurityContext.enabled }}
-      {{- with .Values.sfyManifestService.podSecurityContext }}
-      securityContext:
-        {{- toYaml (omit . "enabled") | nindent 8 }}
-      {{- end }}
-      {{- end }}
+      {{- include "truefoundry.podSecurityContext" .Values.sfyManifestService.podSecurityContext | nindent 6 }}
       {{- if and .Values.global.customCA.enabled (eq (include "truefoundry.customCA.useDirectMount" .) "false") }}
       initContainers:
         {{- include "truefoundry.customCA.initContainer" . | nindent 8 }}

--- a/charts/truefoundry/templates/spark-history-server/deployment.yaml
+++ b/charts/truefoundry/templates/spark-history-server/deployment.yaml
@@ -21,12 +21,7 @@ spec:
         {{- include "spark-history-server.podLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "spark-history-server.serviceAccountName" . }}
-      {{- if .Values.sparkHistoryServer.podSecurityContext.enabled }}
-      {{- with .Values.sparkHistoryServer.podSecurityContext }}
-      securityContext:
-        {{- toYaml (omit . "enabled") | nindent 8 }}
-      {{- end }}
-      {{- end }}
+      {{- include "truefoundry.podSecurityContext" .Values.sparkHistoryServer.podSecurityContext | nindent 6 }}
       {{- if and .Values.global.customCA.enabled (eq (include "truefoundry.customCA.useDirectMount" .) "false") }}
       initContainers:
         {{- include "truefoundry.customCA.initContainer" . | nindent 8 }}

--- a/charts/truefoundry/templates/stdio-mcp-proxy/deployment.yaml
+++ b/charts/truefoundry/templates/stdio-mcp-proxy/deployment.yaml
@@ -21,12 +21,7 @@ spec:
         {{- include "stdio-mcp-proxy.podLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "stdio-mcp-proxy.serviceAccountName" . }}
-      {{- if .Values.stdioMcpProxy.podSecurityContext.enabled }}
-      {{- with .Values.stdioMcpProxy.podSecurityContext }}
-      securityContext:
-        {{- toYaml (omit . "enabled") | nindent 8 }}
-      {{- end }}
-      {{- end }}
+      {{- include "truefoundry.podSecurityContext" .Values.stdioMcpProxy.podSecurityContext | nindent 6 }}
       {{- if and .Values.global.customCA.enabled (eq (include "truefoundry.customCA.useDirectMount" .) "false") }}
       initContainers:
         {{- include "truefoundry.customCA.initContainer" . | nindent 8 }}

--- a/charts/truefoundry/templates/tfy-buildkitd-service/statefulset.yaml
+++ b/charts/truefoundry/templates/tfy-buildkitd-service/statefulset.yaml
@@ -24,10 +24,7 @@ spec:
       imagePullSecrets:
         {{- include "tfy-buildkitd-service.imagePullSecrets" . | nindent 8 }}
       serviceAccountName: {{ include "tfy-buildkitd-service.serviceAccountName" . }}
-      {{- if .Values.tfyBuildkitdService.podSecurityContext.enabled }}
-      securityContext:
-        {{- toYaml (omit .Values.tfyBuildkitdService.podSecurityContext "enabled") | nindent 8 }}
-      {{- end }}
+      {{- include "truefoundry.podSecurityContext" .Values.tfyBuildkitdService.podSecurityContext | nindent 6 }}
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: "kubernetes.io/hostname"

--- a/charts/truefoundry/templates/tfy-controller/deployment.yaml
+++ b/charts/truefoundry/templates/tfy-controller/deployment.yaml
@@ -21,12 +21,7 @@ spec:
         {{- include "tfy-controller.podLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "tfy-controller.serviceAccountName" . }}
-      {{- if .Values.tfyController.podSecurityContext.enabled }}
-      {{- with .Values.tfyController.podSecurityContext }}
-      securityContext:
-        {{- toYaml (omit . "enabled") | nindent 8 }}
-      {{- end }}
-      {{- end }}
+      {{- include "truefoundry.podSecurityContext" .Values.tfyController.podSecurityContext | nindent 6 }}
       {{- if and .Values.global.customCA.enabled (eq (include "truefoundry.customCA.useDirectMount" .) "false") }}
       initContainers:
         {{- include "truefoundry.customCA.initContainer" . | nindent 8 }}

--- a/charts/truefoundry/templates/tfy-k8s-controller/deployment.yaml
+++ b/charts/truefoundry/templates/tfy-k8s-controller/deployment.yaml
@@ -21,12 +21,7 @@ spec:
         {{- include "tfy-k8s-controller.podLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "tfy-k8s-controller.serviceAccountName" . }}
-      {{- if .Values.tfyK8sController.podSecurityContext.enabled }}
-      {{- with .Values.tfyK8sController.podSecurityContext }}
-      securityContext:
-        {{- toYaml (omit . "enabled") | nindent 8 }}
-      {{- end }}
-      {{- end }}
+      {{- include "truefoundry.podSecurityContext" .Values.tfyK8sController.podSecurityContext | nindent 6 }}
       {{- if and .Values.global.customCA.enabled (eq (include "truefoundry.customCA.useDirectMount" .) "false") }}
       initContainers:
         {{- include "truefoundry.customCA.initContainer" . | nindent 8 }}

--- a/charts/truefoundry/templates/tfy-proxy/deployment.yaml
+++ b/charts/truefoundry/templates/tfy-proxy/deployment.yaml
@@ -30,12 +30,7 @@ spec:
         {{- include "tfy-proxy.podLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "tfy-proxy.serviceAccountName" . }}
-      {{- if .Values.tfyProxy.podSecurityContext.enabled }}
-      {{- with .Values.tfyProxy.podSecurityContext }}
-      securityContext:
-        {{- toYaml (omit . "enabled") | nindent 8 }}
-      {{- end }}
-      {{- end }}
+      {{- include "truefoundry.podSecurityContext" .Values.tfyProxy.podSecurityContext | nindent 6 }}
       terminationGracePeriodSeconds: {{ .Values.tfyProxy.terminationGracePeriodSeconds | default 300 }}
       {{- if and .Values.global.customCA.enabled (eq (include "truefoundry.customCA.useDirectMount" .) "false") }}
       initContainers:

--- a/charts/truefoundry/templates/tfy-workflow-admin/deployment.yaml
+++ b/charts/truefoundry/templates/tfy-workflow-admin/deployment.yaml
@@ -22,12 +22,7 @@ spec:
         {{- include "tfy-workflow-admin.server.podLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "tfy-workflow-admin.serviceAccountName" . }}
-      {{- if .Values.tfyWorkflowAdmin.podSecurityContext.enabled }}
-      {{- with .Values.tfyWorkflowAdmin.podSecurityContext }}
-      securityContext:
-        {{- toYaml (omit . "enabled") | nindent 8 }}
-      {{- end }}
-      {{- end }}
+      {{- include "truefoundry.podSecurityContext" .Values.tfyWorkflowAdmin.podSecurityContext | nindent 6 }}
       {{- if and .Values.global.customCA.enabled (eq (include "truefoundry.customCA.useDirectMount" .) "false") }}
       initContainers:
         {{- include "truefoundry.customCA.initContainer" . | nindent 8 }}
@@ -149,12 +144,7 @@ spec:
         {{- include "tfy-workflow-admin.scheduler.podLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "tfy-workflow-admin.serviceAccountName" . }}
-      {{- if .Values.tfyWorkflowAdmin.podSecurityContext.enabled }}
-      {{- with .Values.tfyWorkflowAdmin.podSecurityContext }}
-      securityContext:
-        {{- toYaml (omit . "enabled") | nindent 8 }}
-      {{- end }}
-      {{- end }}
+      {{- include "truefoundry.podSecurityContext" .Values.tfyWorkflowAdmin.podSecurityContext | nindent 6 }}
       {{- if and .Values.global.customCA.enabled (eq (include "truefoundry.customCA.useDirectMount" .) "false") }}
       initContainers:
         {{- include "truefoundry.customCA.initContainer" . | nindent 8 }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Wide rollout across many workloads changes pod spec when users had podSecurityContext disabled (previously no pod securityContext). Pods or images that require root may fail scheduling or startup until values are adjusted.
> 
> **Overview**
> Helm charts now **always** render a pod-level `securityContext` instead of omitting it when `podSecurityContext.enabled` is false.
> 
> Shared helpers (`tfy-llm-gateway`, `tfy-otel-collector`, `true-ai`, and `truefoundry.podSecurityContext`) emit the full values block when enabled, and **`runAsNonRoot: true` only** when disabled. Deployments, Jobs, CronJobs, and most StatefulSets switch from conditional inline blocks to these includes.
> 
> **deltafusion-ingestor** keeps its custom disabled branch (still sets `fsGroup`) but **adds** `runAsNonRoot: true` when pod security context is off—previously the disabled path had no `runAsNonRoot`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dc13d4860de3594775424271c7dca4228a18a70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->