### PR TITLE
feat: release truefoundry/tfy-llm-gateway from their own branch, not main

### DIFF
--- a/.github/workflows/artifactory-helm-release.yaml
+++ b/.github/workflows/artifactory-helm-release.yaml
@@ -1,14 +1,14 @@
 # truefoundry and tfy-llm-gateway are released from their OWN
-# truefoundry-X.Y.Z branch (mirroring helm-charts' branching model), not
-# from main — see release.yaml in this repo for the matching
-# rationale/exclusion.
+# release/truefoundry-X.Y.Z branch (mirroring helm-charts' branching model;
+# the release/ prefix avoids chart-releaser's tag namespace), not from main
+# — see release.yaml in this repo for the matching rationale/exclusion.
 name: Release Charts to public artifactory
 
 on:
   push:
     branches:
       - main
-      - "truefoundry-[0-9]*"
+      - "release/truefoundry-[0-9]*"
 
 env:
   ARTIFACTORY_REGISTRY: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}

--- a/.github/workflows/artifactory-helm-release.yaml
+++ b/.github/workflows/artifactory-helm-release.yaml
@@ -1,9 +1,14 @@
+# truefoundry and tfy-llm-gateway are released from their OWN
+# truefoundry-X.Y.Z branch (mirroring helm-charts' branching model), not
+# from main — see release.yaml in this repo for the matching
+# rationale/exclusion.
 name: Release Charts to public artifactory
 
 on:
   push:
     branches:
       - main
+      - "truefoundry-[0-9]*"
 
 env:
   ARTIFACTORY_REGISTRY: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}
@@ -21,6 +26,14 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+
+    - name: Exclude branch-released charts from main
+      if: ${{ github.ref == 'refs/heads/main' }}
+      run: |
+        # main.py scans the working tree, not git history — removing these on
+        # disk (this ephemeral checkout is discarded after the job, nothing is
+        # pushed) is enough to keep it from ever publishing them off a main push.
+        rm -rf charts/truefoundry charts/tfy-llm-gateway
 
     - name: Set up Helm
       uses: azure/setup-helm@v4.3.0

--- a/.github/workflows/block-version-bump-on-main.yaml
+++ b/.github/workflows/block-version-bump-on-main.yaml
@@ -31,22 +31,36 @@ on:
 
 jobs:
   block-version-bump:
-    # The pipeline's own promote-to-main PRs use the release branch itself as
-    # the PR head (release/truefoundry-X.Y.Z -> main, see helm-charts'
-    # release-public-truefoundry.yaml) and are the ONE sanctioned way these
-    # chart versions reach main — skip those. Everything else stays blocked.
-    if: ${{ !startsWith(github.head_ref, 'release/truefoundry-') }}
+    # NOTE: the promote-PR exemption below is implemented as step-level
+    # conditions (job always runs, reports an explicit SUCCESS for exempt
+    # PRs) rather than a job-level `if` that skips the whole job. This job
+    # is wired as a REQUIRED status check; an explicit success removes any
+    # dependence on GitHub's "skipped check satisfies required checks"
+    # semantics, which differ between skip mechanisms and have changed
+    # historically.
     runs-on: ubuntu-latest
     steps:
+      # The pipeline's own promote-to-main PRs use the release branch itself
+      # as the PR head (release/truefoundry-X.Y.Z -> main, see helm-charts'
+      # release-public-truefoundry.yaml) and are the ONE sanctioned way these
+      # chart versions reach main — pass those explicitly. Everything else
+      # is checked below.
+      - name: Sanctioned promote PR — pass
+        if: ${{ startsWith(github.head_ref, 'release/truefoundry-') }}
+        run: echo "Head branch '${{ github.head_ref }}' is a release branch promote — version bumps are expected here."
+
       - name: Checkout
+        if: ${{ !startsWith(github.head_ref, 'release/truefoundry-') }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Fetch PR base commit
+        if: ${{ !startsWith(github.head_ref, 'release/truefoundry-') }}
         run: git fetch --depth=1 origin "${{ github.event.pull_request.base.sha }}"
 
       - name: Fail if Chart.yaml version changed
+        if: ${{ !startsWith(github.head_ref, 'release/truefoundry-') }}
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |

--- a/.github/workflows/block-version-bump-on-main.yaml
+++ b/.github/workflows/block-version-bump-on-main.yaml
@@ -19,13 +19,15 @@
 # failure; GitHub only prevents merging when a failing check is required.
 name: Block version bump on main
 
+# NOTE: no `paths:` filter, deliberately — this job is wired as a REQUIRED
+# status check on main, and a required check that never reports (because the
+# PR didn't touch the filtered paths) shows as "Expected" and blocks the
+# merge forever. Running on every PR is cheap: the version-diff below no-ops
+# when the Chart.yaml files didn't change.
 on:
   pull_request:
     branches:
       - main
-    paths:
-      - 'charts/truefoundry/Chart.yaml'
-      - 'charts/tfy-llm-gateway/Chart.yaml'
 
 jobs:
   block-version-bump:

--- a/.github/workflows/block-version-bump-on-main.yaml
+++ b/.github/workflows/block-version-bump-on-main.yaml
@@ -1,0 +1,58 @@
+# truefoundry / tfy-llm-gateway are ONLY ever supposed to reach this repo via
+# truefoundry/helm-charts' release-start.yml pipeline, landing on their own
+# truefoundry-X.Y.Z branch (see release.yaml's "Exclude branch-released
+# charts from main" step — main never publishes these two, on purpose).
+#
+# A manual version bump against THIS repo's main would otherwise merge
+# silently and just as silently never publish (release.yaml strips these
+# chart directories before chart-releaser runs on a main push). Worse, if
+# the exclusion were ever removed/bypassed, a manual bump could get
+# chart-releaser to publish a version helm-charts has no tag for — and if
+# the real orchestrated pipeline later tries to ship that SAME version
+# number, chart-releaser's skip-existing logic would silently skip the real
+# release in favor of the stray manual one. Block the mistake here, at PR
+# time, instead of relying on either failure mode.
+#
+# NOTE: for this to actually BLOCK a merge (not just show as a failing,
+# ignorable check), this job must be added as a required status check on
+# main via this repo's branch ruleset. The workflow alone only reports
+# failure; GitHub only prevents merging when a failing check is required.
+name: Block version bump on main
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'charts/truefoundry/Chart.yaml'
+      - 'charts/tfy-llm-gateway/Chart.yaml'
+
+jobs:
+  block-version-bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch PR base commit
+        run: git fetch --depth=1 origin "${{ github.event.pull_request.base.sha }}"
+
+      - name: Fail if Chart.yaml version changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          FAILED=0
+          for CHART in charts/truefoundry/Chart.yaml charts/tfy-llm-gateway/Chart.yaml; do
+            if ! git cat-file -e "${BASE_SHA}:${CHART}" 2>/dev/null; then
+              continue
+            fi
+            BASE_VERSION=$(git show "${BASE_SHA}:${CHART}" | yq e '.version' -)
+            HEAD_VERSION=$(yq e '.version' "$CHART")
+            if [ "$BASE_VERSION" != "$HEAD_VERSION" ]; then
+              echo "::error file=${CHART}::${CHART} version changed from ${BASE_VERSION} to ${HEAD_VERSION} in a PR targeting main. This chart is released exclusively through truefoundry/helm-charts' release-start.yml pipeline, which lands it on its own truefoundry-X.Y.Z branch here — a version bumped directly on main here is never published (and could silently block a future real release at the same version)."
+              FAILED=1
+            fi
+          done
+          exit $FAILED

--- a/.github/workflows/block-version-bump-on-main.yaml
+++ b/.github/workflows/block-version-bump-on-main.yaml
@@ -43,24 +43,38 @@ jobs:
       # The pipeline's own promote-to-main PRs use the release branch itself
       # as the PR head (release/truefoundry-X.Y.Z -> main, see helm-charts'
       # release-public-truefoundry.yaml) and are the ONE sanctioned way these
-      # chart versions reach main — pass those explicitly. Everything else
-      # is checked below.
-      - name: Sanctioned promote PR — pass
-        if: ${{ startsWith(github.head_ref, 'release/truefoundry-') }}
-        run: echo "Head branch '${{ github.head_ref }}' is a release branch promote — version bumps are expected here."
+      # chart versions reach main — pass those explicitly. The exemption is
+      # deliberately strict: the head must live in THIS repo (a fork branch
+      # named release/truefoundry-* is not a pipeline promote) and must match
+      # the exact release/truefoundry-X.Y.Z semver shape (a prefix-only match
+      # would also exempt e.g. release/truefoundry-experiment). GitHub
+      # expressions have no regex, so the match is done in shell here.
+      - name: Determine whether this is a sanctioned promote PR
+        id: promote
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        run: |
+          if [ "$HEAD_REPO" = "$GITHUB_REPOSITORY" ] \
+             && printf '%s' "$HEAD_REF" | grep -Eq '^release/truefoundry-[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "exempt=true" >> "$GITHUB_OUTPUT"
+            echo "Head branch '$HEAD_REF' is this repo's own release branch promote — version bumps are expected here."
+          else
+            echo "exempt=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Checkout
-        if: ${{ !startsWith(github.head_ref, 'release/truefoundry-') }}
+        if: ${{ steps.promote.outputs.exempt == 'false' }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Fetch PR base commit
-        if: ${{ !startsWith(github.head_ref, 'release/truefoundry-') }}
+        if: ${{ steps.promote.outputs.exempt == 'false' }}
         run: git fetch --depth=1 origin "${{ github.event.pull_request.base.sha }}"
 
       - name: Fail if Chart.yaml version changed
-        if: ${{ !startsWith(github.head_ref, 'release/truefoundry-') }}
+        if: ${{ steps.promote.outputs.exempt == 'false' }}
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |

--- a/.github/workflows/block-version-bump-on-main.yaml
+++ b/.github/workflows/block-version-bump-on-main.yaml
@@ -29,6 +29,11 @@ on:
 
 jobs:
   block-version-bump:
+    # The pipeline's own promote-to-main PRs use the release branch itself as
+    # the PR head (release/truefoundry-X.Y.Z -> main, see helm-charts'
+    # release-public-truefoundry.yaml) and are the ONE sanctioned way these
+    # chart versions reach main — skip those. Everything else stays blocked.
+    if: ${{ !startsWith(github.head_ref, 'release/truefoundry-') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,10 +1,11 @@
 # truefoundry and tfy-llm-gateway are released from their OWN
-# truefoundry-X.Y.Z branch (named after the same string as the tag this run
-# will create — see truefoundry/helm-charts' release-public-truefoundry.yaml),
-# not from main. That workflow only fast-forwards main for the current
-# latest shipped line. The "Exclude branch-released charts from main" step
-# below makes that exclusion robust on the main trigger regardless of what
-# main's Chart.yaml happens to contain; the truefoundry-* trigger relies on
+# release/truefoundry-X.Y.Z branch (the release/ prefix keeps the branch out
+# of chart-releaser's identically-named tag namespace — see
+# truefoundry/helm-charts' release-public-truefoundry.yaml), not from main.
+# That workflow only fast-forwards main for the current latest shipped line.
+# The "Exclude branch-released charts from main" step below makes that
+# exclusion robust on the main trigger regardless of what main's Chart.yaml
+# happens to contain; the release/truefoundry-* trigger relies on
 # chart-releaser's own CR_SKIP_EXISTING to no-op on any OTHER chart that
 # hasn't changed there.
 name: Release Charts
@@ -13,7 +14,7 @@ on:
   push:
     branches:
       - main
-      - "truefoundry-[0-9]*"
+      - "release/truefoundry-[0-9]*"
   workflow_dispatch:
 
 jobs:
@@ -47,6 +48,23 @@ jobs:
         with:
           version: v3.17.3
 
+      # Chart dependencies resolved from an OCI registry (e.g. truefoundry's
+      # tfy-llm-gateway dep) may live in a registry that doesn't allow
+      # anonymous pulls (fork/sandbox registries; prod's is public). Log in
+      # when creds are configured so chart-releaser's dependency resolution
+      # works either way.
+      - name: Helm registry login (for OCI chart dependencies)
+        env:
+          REGISTRY_HOST: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}
+          REGISTRY_USER: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_USERNAME }}
+          REGISTRY_PASS: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_PASSWORD }}
+        run: |
+          if [ -n "$REGISTRY_HOST" ] && [ -n "$REGISTRY_USER" ]; then
+            helm registry login "$REGISTRY_HOST" -u "$REGISTRY_USER" -p "$REGISTRY_PASS"
+          else
+            echo "Registry host/creds unset; relying on anonymous pulls."
+          fi
+
       - name: Add Helm dependencies
         run: |
           helm repo add grafana https://grafana.github.io/helm-charts
@@ -66,6 +84,29 @@ jobs:
         env:
           CR_TOKEN: '${{ secrets.TRUEFOUNDRY_HELM_TOKEN }}'
           CR_SKIP_EXISTING: true
+          # Never let a newly-created release take the repo's "Latest" badge
+          # implicitly — GitHub defaults it to the newest-CREATED release, so
+          # an older-line hotfix (e.g. truefoundry-0.140.6 shipped after
+          # 0.148.0) would steal the badge from the actual newest version.
+          # The step below re-asserts the correct one deterministically.
+          CR_MAKE_RELEASE_LATEST: false
+
+      # Deterministically point the repo's "Latest" badge at the
+      # highest-semver FINAL truefoundry release, regardless of creation
+      # order (chart-releaser above never sets it).
+      - name: Mark highest truefoundry release as Latest
+        env:
+          GH_TOKEN: '${{ secrets.TRUEFOUNDRY_HELM_TOKEN }}'
+        run: |
+          HIGHEST=$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate --jq '.[].tag_name' \
+            | grep -E '^truefoundry-[0-9]+\.[0-9]+\.[0-9]+$' \
+            | sed 's/truefoundry-//' | sort -V | tail -1)
+          if [ -z "$HIGHEST" ]; then
+            echo "No final truefoundry-X.Y.Z release found; leaving Latest untouched."
+            exit 0
+          fi
+          RID=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/truefoundry-${HIGHEST}" --jq .id)
+          gh api -X PATCH "repos/${GITHUB_REPOSITORY}/releases/${RID}" -f make_latest=true --jq '"Latest -> " + .tag_name'
 
       - name: Checkout to gh-pages
         uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -98,8 +98,13 @@ jobs:
         env:
           GH_TOKEN: '${{ secrets.TRUEFOUNDRY_HELM_TOKEN }}'
         run: |
+          # `|| true` on the grep: zero matching tags is a legitimate state
+          # (fresh repo, or only RC/other-chart releases exist) handled by the
+          # empty-HIGHEST branch below — without it, grep's non-zero exit
+          # would abort the whole step under `pipefail` before that handler
+          # runs, killing the rest of the job (including the gh-pages steps).
           HIGHEST=$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate --jq '.[].tag_name' \
-            | grep -E '^truefoundry-[0-9]+\.[0-9]+\.[0-9]+$' \
+            | { grep -E '^truefoundry-[0-9]+\.[0-9]+\.[0-9]+$' || true; } \
             | sed 's/truefoundry-//' | sort -V | tail -1)
           if [ -z "$HIGHEST" ]; then
             echo "No final truefoundry-X.Y.Z release found; leaving Latest untouched."

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,19 @@
+# truefoundry and tfy-llm-gateway are released from their OWN
+# truefoundry-X.Y.Z branch (named after the same string as the tag this run
+# will create — see truefoundry/helm-charts' release-public-truefoundry.yaml),
+# not from main. That workflow only fast-forwards main for the current
+# latest shipped line. The "Exclude branch-released charts from main" step
+# below makes that exclusion robust on the main trigger regardless of what
+# main's Chart.yaml happens to contain; the truefoundry-* trigger relies on
+# chart-releaser's own CR_SKIP_EXISTING to no-op on any OTHER chart that
+# hasn't changed there.
 name: Release Charts
 
 on:
   push:
     branches:
       - main
+      - "truefoundry-[0-9]*"
   workflow_dispatch:
 
 jobs:
@@ -22,6 +32,15 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Exclude branch-released charts from main
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          # chart-releaser scans the working tree, not git history — removing
+          # these on disk (this ephemeral checkout is discarded after the job,
+          # nothing is pushed) is enough to keep it from ever tagging/releasing
+          # them off a main push.
+          rm -rf charts/truefoundry charts/tfy-llm-gateway
 
       - name: Set up Helm
         uses: azure/setup-helm@v4.3.0

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Please visit the [GitHub Repo](https://github.com/truefoundry/infra-charts) for sources
 
+See [RELEASE.md](./RELEASE.md) for how `truefoundry` and `tfy-llm-gateway`
+specifically are released — they follow a different flow from every other
+chart in this repo.
+
 ## To enable scraping metrics for a particular service
 1. Create a service monitor object in `charts/tfy-prometheus-config/templates/serviceMonitors`
 2. Add an entry in `charts/tfy-prometheus-config/values.yaml`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,66 @@
+# Releasing `truefoundry` and `tfy-llm-gateway`
+
+Most charts in this repo are released the traditional way: bump the version
+in a PR, merge to `main`, and `release.yaml` (chart-releaser) tags +
+publishes it. **`truefoundry` and `tfy-llm-gateway` do not follow that
+path.** This doc explains how they actually get here and why.
+
+## Where these two charts actually come from
+
+They are copied into this repo by `truefoundry/helm-charts`' own release
+pipeline (`release-start.yml` there), not edited directly here. Do not open
+a PR against this repo to change either chart's `Chart.yaml` version, or to
+fix a template bug in `charts/truefoundry/` / `charts/tfy-llm-gateway/` —
+make the change in `truefoundry/helm-charts` instead and run its release
+pipeline. See `.github/workflows/block-version-bump-on-main.yaml`, which
+rejects a PR into `main` here that changes either chart's version, for
+exactly this reason.
+
+## The branch model
+
+Whenever helm-charts ships a **final** release (a bare `truefoundry-X.Y.Z`
+git tag there — RCs never reach this repo at all), its
+`release-public-truefoundry.yaml` workflow:
+
+1. Ensures a branch here named `truefoundry-<VERSION>` exists (cut from this
+   repo's `main` if it doesn't) — e.g. `truefoundry-0.156.0`. This is the
+   SAME string as the git tag on the helm-charts side, not helm-charts' own
+   internal `release-v<VERSION>` branch name.
+2. Copies `truefoundry` + `tfy-llm-gateway` into that branch via a PR, then
+   auto-merges it (only after that PR's own checks pass).
+3. That push triggers `release.yaml` (gh-pages) and
+   `artifactory-helm-release.yaml` (public + inframold OCI) here — both now
+   trigger on `truefoundry-[0-9]*` branch pushes, not just `main`.
+4. **Only if this was the current latest shipped line**, that branch is ALSO
+   fast-forwarded into this repo's `main` (same "latest-line-only" rule
+   helm-charts applies to its own `main`). An older-line hotfix final still
+   completes steps 1–3 — it publishes — it just never touches `main` here.
+
+`tfy-llm-gateway` is versioned independently of `truefoundry` (they can ship
+different patch numbers in the same release) and separately gets its own
+`tfy-llm-gateway-<its own version>` branch as a pure reference snapshot, so
+its version history is browsable on its own even when it diverges from the
+umbrella's version. That branch is inert — it never merges anywhere and
+can't trigger a publish (its name doesn't match either publish trigger).
+
+## Why `main` doesn't publish these two charts
+
+`release.yaml` / `artifactory-helm-release.yaml` both explicitly strip
+`charts/truefoundry` and `charts/tfy-llm-gateway` from the working tree
+before running, when triggered from `main`. This is deliberate: RCs and
+older-line hotfixes structurally cannot reach `main` (main only advances for
+the latest line), so if these charts' publish were gated on a `main` merge,
+those cases could never publish at all. Publishing off the branch push
+instead — decoupled from whether `main` ever advances — is what makes an
+RC deployable for QA and an older-line hotfix shippable to its own customer
+cluster.
+
+## If something looks wrong
+
+- **A manual PR bumping one of these charts' versions against `main` gets
+  rejected** — this is `block-version-bump-on-main.yaml` working as
+  intended. Make the fix in `truefoundry/helm-charts` instead.
+- **A version seems to be "stuck" on an old value on `main`** — check
+  whether it's actually an older-line release: `main` here only ever
+  reflects the *latest* line, by design, not everything that's ever shipped.
+  Check the `truefoundry-<VERSION>` branch and the git tag directly.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -22,15 +22,20 @@ Whenever helm-charts ships a **final** release (a bare `truefoundry-X.Y.Z`
 git tag there — RCs never reach this repo at all), its
 `release-public-truefoundry.yaml` workflow:
 
-1. Ensures a branch here named `truefoundry-<VERSION>` exists (cut from this
-   repo's `main` if it doesn't) — e.g. `truefoundry-0.156.0`. This is the
-   SAME string as the git tag on the helm-charts side, not helm-charts' own
-   internal `release-v<VERSION>` branch name.
+1. Ensures a branch here named `release/truefoundry-<VERSION>` exists (cut
+   from this repo's `main` if it doesn't) — e.g.
+   `release/truefoundry-0.156.0`. It carries the same `truefoundry-X.Y.Z`
+   string as the git tag on the helm-charts side, under a `release/` prefix.
+   The prefix is load-bearing, not cosmetic: a branch named EXACTLY
+   `truefoundry-<VERSION>` collides with the identically-named git tag
+   chart-releaser mints in this repo, and git short-ref resolution
+   (`actions/checkout`, `create-pull-request`) breaks on the ambiguity for
+   every run after the tag exists.
 2. Copies `truefoundry` + `tfy-llm-gateway` into that branch via a PR, then
    auto-merges it (only after that PR's own checks pass).
 3. That push triggers `release.yaml` (gh-pages) and
-   `artifactory-helm-release.yaml` (public + inframold OCI) here — both now
-   trigger on `truefoundry-[0-9]*` branch pushes, not just `main`.
+   `artifactory-helm-release.yaml` (public + inframold OCI) here — both
+   trigger on `release/truefoundry-[0-9]*` branch pushes, not just `main`.
 4. **Only if this was the current latest shipped line**, that branch is ALSO
    fast-forwarded into this repo's `main` (same "latest-line-only" rule
    helm-charts applies to its own `main`). An older-line hotfix final still
@@ -38,10 +43,21 @@ git tag there — RCs never reach this repo at all), its
 
 `tfy-llm-gateway` is versioned independently of `truefoundry` (they can ship
 different patch numbers in the same release) and separately gets its own
-`tfy-llm-gateway-<its own version>` branch as a pure reference snapshot, so
-its version history is browsable on its own even when it diverges from the
-umbrella's version. That branch is inert — it never merges anywhere and
-can't trigger a publish (its name doesn't match either publish trigger).
+`release/tfy-llm-gateway-<its own version>` branch as a pure reference
+snapshot, so its version history is browsable on its own even when it
+diverges from the umbrella's version. That branch is inert — it never merges
+anywhere and can't trigger a publish (its name doesn't match either publish
+trigger).
+
+## The "Latest" release badge
+
+chart-releaser is configured to never implicitly mark a newly-created
+release as the repo's Latest (`CR_MAKE_RELEASE_LATEST: false`) — GitHub
+defaults the badge to the newest-CREATED release, so an older-line hotfix
+(e.g. `truefoundry-0.140.6` shipped after `0.148.0`) would otherwise steal
+it from the actual newest version. A step in `release.yaml` deterministically
+re-asserts the highest-semver final `truefoundry-X.Y.Z` release as Latest
+after every run.
 
 ## Why `main` doesn't publish these two charts
 
@@ -63,4 +79,4 @@ cluster.
 - **A version seems to be "stuck" on an old value on `main`** — check
   whether it's actually an older-line release: `main` here only ever
   reflects the *latest* line, by design, not everything that's ever shipped.
-  Check the `truefoundry-<VERSION>` branch and the git tag directly.
+  Check the `release/truefoundry-<VERSION>` branch and the git tag directly.


### PR DESCRIPTION
## Summary
- `release.yaml` / `artifactory-helm-release.yaml`: added a `truefoundry-[0-9]*` branch trigger alongside `main`, and an explicit exclusion step stripping `charts/truefoundry` / `charts/tfy-llm-gateway` from the working tree when triggered from `main`. These two charts are now released exclusively via `truefoundry/helm-charts`' `release-start.yml` pipeline (companion PR: truefoundry/helm-charts#5881), which lands them on a `truefoundry-<VERSION>` branch here instead of directly on `main`.
- New `block-version-bump-on-main.yaml`: rejects a PR into `main` that changes either chart's `Chart.yaml` version, since that should only ever happen through the helm-charts pipeline. Not yet wired as a required check.
- New `RELEASE.md` documenting this flow, linked from the root `README.md`.

## Why
RCs and older-line hotfixes structurally never reach `main` (it only advances for the latest shipped line) — gating these two charts' publish on a `main` merge would mean those could never publish at all. Publishing off the branch push instead, decoupled from whether `main` ever advances, is what makes an RC deployable for QA and an older-line hotfix shippable to its own customer cluster.

## Test plan
- [ ] Merge the helm-charts companion PR first, then trigger a real release (`rc` or `hotfix`) there and confirm a `truefoundry-X.Y.Z` branch appears here, publishes to gh-pages/OCI, and (for the latest line) fast-forwards `main`.
- [ ] Confirm a manual PR bumping `charts/truefoundry/Chart.yaml`'s version against `main` here is rejected by `block-version-bump-on-main.yaml`.

Made with [Cursor](https://cursor.com)