### PR TITLE
ci: serialize Release Charts runs to stop gh-pages push races

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,17 @@ on:
       - "release/truefoundry-[0-9]*"
   workflow_dispatch:
 
+# Every run of this workflow ends by regenerating index.html on gh-pages and
+# pushing it (chart-releaser also pushes index.yaml there). Rapid consecutive
+# pushes — e.g. a release branch cut + chart copy + README regen landing
+# within a minute — used to run concurrently and race each other on gh-pages,
+# failing the loser with a non-fast-forward rejection. Queue them instead
+# (never cancel: each triggering commit may carry a different chart to
+# release).
+concurrency:
+  group: release-charts-gh-pages
+  cancel-in-progress: false
+
 jobs:
   release:
     permissions:


### PR DESCRIPTION
## Summary
- Fixes the failure in [run 28804922163](https://github.com/truefoundry/infra-charts/actions/runs/28804922163): three pushes landed on `release/truefoundry-0.157.0` within ~90s (gateway chart copy, truefoundry chart copy, README regen), their `Release Charts` runs executed concurrently, and the loser's `gh-pages` push was rejected as non-fast-forward.
- Adds a shared `concurrency` group (`cancel-in-progress: false`) so runs queue instead of racing. If pending runs collapse to the newest one, the newest checks out the later commit whose tree already contains the earlier charts, and `CR_SKIP_EXISTING` releases anything not yet released — nothing is dropped.

## Test plan
- [ ] Next release-branch propagation (multiple rapid pushes) completes with all `Release Charts` runs green

Made with [Cursor](https://cursor.com)