### PR TITLE
fix: guard karpenter node templates against YAML null in aws-eks inframold

### DIFF
--- a/charts/tfy-k8s-aws-eks-inframold/templates/tfy-aws/karpenter-config.yaml
+++ b/charts/tfy-k8s-aws-eks-inframold/templates/tfy-aws/karpenter-config.yaml
@@ -63,6 +63,7 @@ spec:
             zones: {{- range .Values.aws.karpenter.defaultZones }}
             - {{ . | quote }}
             {{- end }}
+          {{- if or .Values.aws.karpenter.kmsKeyID .Values.tags }}
           inferentiaDefaultNodeTemplate:
             {{- if .Values.aws.karpenter.kmsKeyID }}
             kmsKeyID: {{ .Values.aws.karpenter.kmsKeyID | default "" }}
@@ -73,6 +74,7 @@ spec:
               {{ $k }}: {{ $v | quote }}
               {{- end }}
             {{- end }}
+          {{- end }}
           critical:
             zones: {{- range .Values.aws.karpenter.defaultZones }}
             - {{ . | quote }}
@@ -91,6 +93,7 @@ spec:
             zones: {{- range .Values.aws.karpenter.defaultZones }}
             - {{ . | quote }}
             {{- end }}
+          {{- if or .Values.aws.karpenter.kmsKeyID .Values.tags }}
           controlPlaneNodeTemplate:
             {{- if .Values.aws.karpenter.kmsKeyID }}
             kmsKeyID: {{ .Values.aws.karpenter.kmsKeyID | default "" }}
@@ -101,6 +104,7 @@ spec:
               {{ $k }}: {{ $v | quote }}
               {{- end }}
             {{- end }}
+          {{- end }}
         {{- end }}
   project: tfy-apps
   syncPolicy:


### PR DESCRIPTION
## Summary

- `inferentiaDefaultNodeTemplate` and `controlPlaneNodeTemplate` in `charts/tfy-k8s-aws-eks-inframold/templates/tfy-aws/karpenter-config.yaml` only contain conditional sub-keys (`kmsKeyID`, `extraTags`). When neither `aws.karpenter.kmsKeyID` nor `tags` is set (as in `values-artifact-manifest.yaml`), these blocks render as bare YAML keys with no content — e.g. `inferentiaDefaultNodeTemplate:`.
- In YAML, a key with no value is parsed as **`null`**. A `null` value **overrides** the Helm chart's `values.yaml` defaults during merge, making `.Values.karpenter.inferentiaDefaultNodeTemplate` nil at template render time.
- This caused the CI nil pointer panic: `nil pointer evaluating interface {}.enabled` in `karpenter-inferentia-default-ec2nodeclass.yaml:1`.

## Fix

Wrap `inferentiaDefaultNodeTemplate` and `controlPlaneNodeTemplate` in `{{- if or .Values.aws.karpenter.kmsKeyID .Values.tags }}` so the key is only emitted when there is actual content. When neither is set, the key is omitted entirely and the chart's `values.yaml` defaults take over.

## Related

- Failing CI: https://github.com/truefoundry/infra-charts/actions/runs/28648704459/job/84962266097
- Same fix applied to the upstream source in ubermold-base: https://github.com/truefoundry/ubermold-base/pull/2576

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Helm templating change in inframold values generation; no runtime auth or data-path changes, only avoids invalid value merges for Karpenter config.
> 
> **Overview**
> Fixes CI nil-pointer failures when rendering **tfy-karpenter-config** from the AWS EKS inframold chart by only emitting **`inferentiaDefaultNodeTemplate`** and **`controlPlaneNodeTemplate`** when **`aws.karpenter.kmsKeyID`** or **`tags`** is set.
> 
> Previously those blocks could render as keys with no nested fields (e.g. in artifact manifest values), which YAML parses as **null** and overrides the child chart defaults—so **`karpenter.inferentiaDefaultNodeTemplate`** became nil and templates like **`karpenter-inferentia-default-ec2nodeclass.yaml`** panicked on **`.enabled`**. Omitting the keys when there is nothing to override lets **`values.yaml`** defaults apply unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f001102576e99a290575da735fce9f53154aecbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->