### PR TITLE
Inframold 0.1.309

### DIFF
--- a/charts/tfy-k8s-aws-eks-inframold/Chart.yaml
+++ b/charts/tfy-k8s-aws-eks-inframold/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: tfy-k8s-aws-eks-inframold
-version: 0.1.308
+version: 0.1.309
 description: "Inframold, the superchart that configure your cluster on aws for truefoundry."
 maintainers:
   - name: truefoundry

--- a/charts/tfy-k8s-aws-eks-inframold/README.md
+++ b/charts/tfy-k8s-aws-eks-inframold/README.md
@@ -2,3 +2,291 @@
 Inframold, the superchart that configure your cluster on aws for truefoundry.
 
 ## Parameters
+
+### Global Parameters
+
+| Name               | Description                                                                                           | Value |
+| ------------------ | ----------------------------------------------------------------------------------------------------- | ----- |
+| `global.repoURL`   | Override chart repository URL for all Argo CD Applications                                            | `""`  |
+| `tenantName`       | Parameters for tenantName                                                                             | `""`  |
+| `controlPlaneURL`  | Parameters for controlPlaneURL                                                                        | `""`  |
+| `clusterName`      | Name of the cluster                                                                                   | `""`  |
+| `tags`             | AWS resource tags applied to Karpenter-launched EC2 nodes and dynamically-provisioned EBS PVC volumes | `{}`  |
+| `registry`         | registry to override in the chart components                                                          | `""`  |
+| `imagePullSecrets` | imagePullSecrets to override in the chart components                                                  | `[]`  |
+| `tolerations`      | Tolerations for the all chart components                                                              | `[]`  |
+| `affinity`         | Affinity for the all chart components                                                                 | `{}`  |
+
+### argocd parameters
+
+| Name                    | Description                                | Value  |
+| ----------------------- | ------------------------------------------ | ------ |
+| `argocd.enabled`        | Flag to enable ArgoCD                      | `true` |
+| `argocd.tolerations`    | Tolerations for ArgoCD                     | `[]`   |
+| `argocd.affinity`       | Affinity for ArgoCD                        | `{}`   |
+| `argocd.valuesOverride` | Config override from default config values | `{}`   |
+
+### argoWorkflows parameters
+
+| Name                           | Description                                | Value  |
+| ------------------------------ | ------------------------------------------ | ------ |
+| `argoWorkflows.enabled`        | Flag to enable Argo Workflows              | `true` |
+| `argoWorkflows.tolerations`    | Tolerations for Argo Workflows             | `[]`   |
+| `argoWorkflows.affinity`       | Affinity for Argo Workflows                | `{}`   |
+| `argoWorkflows.valuesOverride` | Config override from default config values | `{}`   |
+
+### argoRollouts parameters
+
+| Name                          | Description                                | Value  |
+| ----------------------------- | ------------------------------------------ | ------ |
+| `argoRollouts.enabled`        | Flag to enable Argo Rollouts               | `true` |
+| `argoRollouts.tolerations`    | Tolerations for Argo Rollouts              | `[]`   |
+| `argoRollouts.affinity`       | Affinity for Argo Rollouts                 | `{}`   |
+| `argoRollouts.valuesOverride` | Config override from default config values | `{}`   |
+
+### certManager parameters
+
+| Name                                     | Description                                                                       | Value   |
+| ---------------------------------------- | --------------------------------------------------------------------------------- | ------- |
+| `certManager.enabled`                    | Flag to enable Cert Manager                                                       | `false` |
+| `certManager.tolerations`                | Tolerations for Cert Manager                                                      | `[]`    |
+| `certManager.podLabels`                  | Pod labels for Cert Manager. For Azure will be applied to serviceaccount as well. | `{}`    |
+| `certManager.serviceAccount.annotations` | Service account annotations for Cert Manager.                                     | `{}`    |
+| `certManager.affinity`                   | Affinity for Cert Manager                                                         | `{}`    |
+| `certManager.valuesOverride`             | Config override from default config values                                        | `{}`    |
+
+### certManager issuers parameters
+
+| Name                                | Description                                        | Value  |
+| ----------------------------------- | -------------------------------------------------- | ------ |
+| `certManager.config.enabled`        | Flag to enable certManager config                  | `true` |
+| `certManager.config.issuers`        | Map of issuers and their certificate configuration | `{}`   |
+| `certManager.config.valuesOverride` | Config override from default config values         | `{}`   |
+
+### metricsServer parameters
+
+| Name                           | Description                                | Value  |
+| ------------------------------ | ------------------------------------------ | ------ |
+| `metricsServer.enabled`        | Flag to enable Metrics Server              | `true` |
+| `metricsServer.enabled`        | Flag to enable Metrics Server              | `true` |
+| `metricsServer.tolerations`    | Tolerations for Metrics Server             | `[]`   |
+| `metricsServer.affinity`       | Affinity for Metrics Server                | `{}`   |
+| `metricsServer.valuesOverride` | Config override from default config values | `{}`   |
+
+### AWS parameters
+
+| Name                                           | Description                                 | Value   |
+| ---------------------------------------------- | ------------------------------------------- | ------- |
+| `aws.awsLoadBalancerController.enabled`        | Flag to enable AWS Load Balancer Controller | `true`  |
+| `aws.awsLoadBalancerController.roleArn`        | Role ARN for AWS Load Balancer Controller   | `""`    |
+| `aws.awsLoadBalancerController.vpcId`          | VPC ID of AWS EKS cluster                   | `""`    |
+| `aws.awsLoadBalancerController.region`         | region of AWS EKS cluster                   | `""`    |
+| `aws.awsLoadBalancerController.affinity`       | Affinity for AWS LoadBalancer               | `{}`    |
+| `aws.awsLoadBalancerController.tolerations`    | Tolerations for AWS LoadBalancer            | `[]`    |
+| `aws.awsLoadBalancerController.valuesOverride` | Config override from default config values  | `{}`    |
+| `aws.karpenter.enabled`                        | Flag to enable Karpenter                    | `true`  |
+| `aws.karpenter.clusterEndpoint`                | Cluster endpoint for Karpenter              | `""`    |
+| `aws.karpenter.roleArn`                        | Role ARN for Karpenter                      | `""`    |
+| `aws.karpenter.instanceProfile`                | Instance profile for Karpenter              | `""`    |
+| `aws.karpenter.defaultZones`                   | Default zones list for Karpenter            | `[]`    |
+| `aws.karpenter.affinity`                       | Affinity for Karpenter                      | `{}`    |
+| `aws.karpenter.tolerations`                    | Tolerations for Karpenter                   | `[]`    |
+| `aws.karpenter.kmsKeyID`                       | KMS Key ID for Karpenter                    | `""`    |
+| `aws.karpenter.interruptionQueue`              | Interruption queue name for Karpenter       | `""`    |
+| `aws.karpenter.valuesOverride`                 | Config override from default config values  | `{}`    |
+| `aws.karpenter.config.enabled`                 | Flag to enable karpenter config             | `true`  |
+| `aws.karpenter.config.valuesOverride`          | Config override for karpenter config        | `{}`    |
+| `aws.awsEbsCsiDriver.enabled`                  | Flag to enable AWS EBS CSI Driver           | `true`  |
+| `aws.awsEbsCsiDriver.roleArn`                  | Role ARN for AWS EBS CSI Driver             | `""`    |
+| `aws.awsEbsCsiDriver.affinity`                 | Affinity for AWS EBS CSI Driver             | `{}`    |
+| `aws.awsEbsCsiDriver.tolerations`              | Tolerations for AWS EBS CSI Driver          | `[]`    |
+| `aws.awsEbsCsiDriver.kmsKeyID`                 | KMS Key ID for AWS EBS CSI Driver           | `""`    |
+| `aws.awsEbsCsiDriver.valuesOverride`           | Config override from default config values  | `{}`    |
+| `aws.awsEfsCsiDriver.enabled`                  | Flag to enable AWS EFS CSI Driver           | `true`  |
+| `aws.awsEfsCsiDriver.fileSystemId`             | File system ID for AWS EFS CSI Driver       | `""`    |
+| `aws.awsEfsCsiDriver.roleArn`                  | Role ARN for AWS EFS CSI Driver             | `""`    |
+| `aws.awsEfsCsiDriver.affinity`                 | Affinity for AWS EFS CSI Driver             | `{}`    |
+| `aws.awsEfsCsiDriver.tolerations`              | Tolerations for AWS EFS CSI Driver          | `[]`    |
+| `aws.awsEfsCsiDriver.valuesOverride`           | Config override from default config values  | `{}`    |
+| `aws.inferentia.enabled`                       | Flag to enable Inferentia                   | `false` |
+| `aws.inferentia.affinity`                      | Affinity for AWS EFS CSI Driver             | `{}`    |
+| `aws.inferentia.tolerations`                   | Tolerations for AWS EFS CSI Driver          | `[]`    |
+| `aws.inferentia.valuesOverride`                | Config override from default config values  | `{}`    |
+
+### gpu parameters
+
+| Name                 | Description                                | Value    |
+| -------------------- | ------------------------------------------ | -------- |
+| `gpu.enabled`        | Flag to enable Tfy GPU Operator            | `true`   |
+| `gpu.clusterType`    | Cluster type for Tfy GPU Operator          | `awsEks` |
+| `gpu.valuesOverride` | Config override from default config values | `{}`     |
+
+### truefoundry parameters
+
+| Name                          | Description                                | Value   |
+| ----------------------------- | ------------------------------------------ | ------- |
+| `truefoundry.enabled`         | Flag to enable TrueFoundry                 | `false` |
+| `truefoundry.devMode.enabled` | Flag to enable TrueFoundry Dev mode        | `false` |
+| `truefoundry.valuesOverride`  | Config override from default config values | `{}`    |
+
+### truefoundryBootstrap parameters
+
+| Name                                       | Description                                                               | Value  |
+| ------------------------------------------ | ------------------------------------------------------------------------- | ------ |
+| `truefoundry.truefoundryBootstrap.enabled` | Flag to enable bootstrap job to prep cluster for truefoundry installation | `true` |
+
+### Truefoundry virtual service parameters
+
+| Name                                         | Description                                        | Value   |
+| -------------------------------------------- | -------------------------------------------------- | ------- |
+| `truefoundry.virtualservice.enabled`         | Flag to enable virtualservice                      | `false` |
+| `truefoundry.virtualservice.hosts`           | Hosts for truefoundry virtualservice               | `[]`    |
+| `truefoundry.virtualservice.gateways`        | Istio gateways to be configured for virtualservice | `[]`    |
+| `truefoundry.virtualservice.annotations`     | Annotations for truefoundry virtualservice         | `{}`    |
+| `truefoundry.existingTruefoundryCredsSecret` | Secret name for existing Truefoundry creds         | `""`    |
+
+### database. Can be left empty if using the dev mode parameters
+
+| Name                                                | Description                                                | Value   |
+| --------------------------------------------------- | ---------------------------------------------------------- | ------- |
+| `truefoundry.database.host`                         | Hostname of the database                                   | `""`    |
+| `truefoundry.database.name`                         | Name of the database                                       | `""`    |
+| `truefoundry.database.username`                     | Username of the database                                   | `""`    |
+| `truefoundry.database.password`                     | Password of the database                                   | `""`    |
+| `truefoundry.tfyApiKey`                             | API Key for TrueFoundry                                    | `""`    |
+| `truefoundry.imagePullSecrets`                      | Image pull secrets for TrueFoundry                         | `[]`    |
+| `truefoundry.truefoundryImagePullConfigJSON`        | Json config for authenticating to the TrueFoundry registry | `""`    |
+| `truefoundry.truefoundry_iam_role_arn_annotations`  | IAM role annotations for service accounts                  | `{}`    |
+| `truefoundry.defaultCloudProvider`                  | Default cloud provider                                     | `aws`   |
+| `truefoundry.storageConfiguration.awsS3BucketName`  | AWS S3 bucket name                                         | `""`    |
+| `truefoundry.storageConfiguration.awsRegion`        | AWS region                                                 | `""`    |
+| `truefoundry.storageConfiguration.awsAssumeRoleArn` | AWS assume role ARN                                        | `""`    |
+| `truefoundry.s3proxy.enabled`                       | Flag to enable S3 Proxy                                    | `false` |
+| `truefoundry.sparkHistoryServer.enabled`            | Flag to enable Spark History Server                        | `false` |
+| `truefoundry.tfyWorkflowAdmin.enabled`              | Flag to enable Tfy Workflow Admin                          | `false` |
+| `truefoundry.gateway.enabled`                       | Flag to enable Gateway                                     | `false` |
+| `truefoundry.tolerations`                           | Tolerations for the truefoundry components                 | `[]`    |
+| `truefoundry.affinity`                              | Affinity for the truefoundry components                    | `{}`    |
+
+### tfyLogs parameters
+
+| Name                     | Description                                | Value  |
+| ------------------------ | ------------------------------------------ | ------ |
+| `tfyLogs.enabled`        | Flag to enable Tfy Logs                    | `true` |
+| `tfyLogs.valuesOverride` | Config override from default config values | `{}`   |
+| `tfyLogs.affinity`       | Affinity for tfyLogs statefulset pod       | `{}`   |
+| `tfyLogs.tolerations`    | Tolerations for tfyLogs statefulset pod    | `[]`   |
+
+### istio parameters
+
+| Name                                    | Description                                | Value  |
+| --------------------------------------- | ------------------------------------------ | ------ |
+| `istio.enabled`                         | Flag to enable Istio                       | `true` |
+| `istio.enabled`                         | Flag to enable Istio Base                  | `true` |
+| `istio.base.valuesOverride`             | Config override from default config values | `{}`   |
+| `istio.awsElbControllerChecker.enabled` | Flag to enable AWS ELB Controller Checker  | `true` |
+| `istio.gateway.annotations`             | Annotations for Istio Gateway              | `{}`   |
+| `istio.gateway.affinity`                | Affinity for the gateway pods              | `{}`   |
+| `istio.gateway.tolerations`             | Tolerations for the gateway pods           | `[]`   |
+| `istio.gateway.valuesOverride`          | Config override from default config values | `{}`   |
+
+### istio discovery parameters
+
+| Name                             | Description                                | Value                  |
+| -------------------------------- | ------------------------------------------ | ---------------------- |
+| `istio.discovery.hub`            | Hub for the istio image                    | `gcr.io/istio-release` |
+| `istio.discovery.tolerations`    | Tolerations for Istio Discovery            | `[]`                   |
+| `istio.discovery.affinity`       | Affinity for Istio Discovery               | `{}`                   |
+| `istio.discovery.valuesOverride` | Config override from default config values | `{}`                   |
+
+### istio tfyGateway parameters
+
+| Name                                  | Description                                     | Value    |
+| ------------------------------------- | ----------------------------------------------- | -------- |
+| `istio.tfyGateway.httpsRedirect`      | Flag to enable HTTPS redirect for Istio Gateway | `true`   |
+| `istio.tfyGateway.tls.enabled`        | Flag to enable TLS for Istio Gateway            | `false`  |
+| `istio.tfyGateway.tls.mode`           | TLS mode for the Istio Gateway                  | `SIMPLE` |
+| `istio.tfyGateway.tls.credentialName` | Credential name for the TLS certificate         | `""`     |
+| `istio.tfyGateway.domains`            | Domains for the gateway pods                    | `[]`     |
+
+### keda parameters
+
+| Name                  | Description                                | Value  |
+| --------------------- | ------------------------------------------ | ------ |
+| `keda.enabled`        | Flag to enable Keda                        | `true` |
+| `keda.tolerations`    | Tolerations for Keda                       | `[]`   |
+| `keda.affinity`       | Affinity for Keda                          | `{}`   |
+| `keda.valuesOverride` | Config override from default config values | `{}`   |
+
+### sparkOperator parameters
+
+| Name                           | Description                                | Value   |
+| ------------------------------ | ------------------------------------------ | ------- |
+| `sparkOperator.enabled`        | Flag to enable Spark Operator              | `false` |
+| `sparkOperator.tolerations`    | Tolerations for Spark Operator             | `[]`    |
+| `sparkOperator.affinity`       | Affinity for Spark Operator                | `{}`    |
+| `sparkOperator.valuesOverride` | Config override from default config values | `{}`    |
+
+### prometheus parameters
+
+| Name                                     | Description                                                               | Value  |
+| ---------------------------------------- | ------------------------------------------------------------------------- | ------ |
+| `prometheus.enabled`                     | Flag to enable Prometheus                                                 | `true` |
+| `prometheus.additionalScrapeConfigs`     | Additional scrape configs for Prometheus                                  | `[]`   |
+| `prometheus.alertmanager`                | Alertmanager configuration for Prometheus                                 | `{}`   |
+| `prometheus.affinity`                    | Affinity for prometheus statefulset pod                                   | `{}`   |
+| `prometheus.tolerations`                 | Tolerations for prometheus statefulset pod                                | `[]`   |
+| `prometheus.valuesOverride`              | Config override from default config values                                | `{}`   |
+| `prometheus.prometheusNodeExporter.port` | Port for prometheus-node-exporter service and container (default 9100)    | `9100` |
+| `prometheus.config.enabled`              | Flag to enable prometheus config (requires prometheus.enabled to be true) | `true` |
+| `prometheus.config.valuesOverride`       | Config override from default config values                                | `{}`   |
+| `prometheus.config.extraObjects`         | Extra objects for prometheus config                                       | `[]`   |
+
+### grafana parameters
+
+| Name                     | Description                                | Value   |
+| ------------------------ | ------------------------------------------ | ------- |
+| `grafana.enabled`        | Flag to enable Grafana                     | `false` |
+| `grafana.tolerations`    | Tolerations for Grafana                    | `[]`    |
+| `grafana.affinity`       | Affinity for Grafana                       | `{}`    |
+| `grafana.valuesOverride` | Config override from default config values | `{}`    |
+
+### tfyAgent parameters
+
+| Name                          | Description                                | Value  |
+| ----------------------------- | ------------------------------------------ | ------ |
+| `tfyAgent.enabled`            | Flag to enable Tfy Agent                   | `true` |
+| `tfyAgent.valuesOverride`     | Config override from default config values | `{}`   |
+| `tfyAgent.tolerations`        | Tolerations for the agent pods             | `[]`   |
+| `tfyAgent.affinity`           | Affinity for the agent pods                | `{}`   |
+| `tfyAgent.clusterToken`       | cluster token                              | `""`   |
+| `tfyAgent.clusterTokenSecret` | Secret name for cluster token              | `""`   |
+
+### elasti parameters
+
+| Name                    | Description                                | Value  |
+| ----------------------- | ------------------------------------------ | ------ |
+| `elasti.enabled`        | Flag to enable Elasti                      | `true` |
+| `elasti.tolerations`    | Tolerations for Elasti                     | `[]`   |
+| `elasti.affinity`       | Affinity for Elasti                        | `{}`   |
+| `elasti.valuesOverride` | Config override from default config values | `{}`   |
+
+### jspolicy parameters
+
+| Name                             | Description                                              | Value   |
+| -------------------------------- | -------------------------------------------------------- | ------- |
+| `jspolicy.enabled`               | Flag to enable jspolicy. No policy is applied by default | `false` |
+| `jspolicy.enabled`               | Flag to enable jspolicy                                  | `false` |
+| `jspolicy.valuesOverride`        | Config override from default config values               | `{}`    |
+| `jspolicy.affinity`              | Affinity for jspolicy                                    | `{}`    |
+| `jspolicy.tolerations`           | Tolerations for jspolicy                                 | `[]`    |
+| `jspolicy.config.valuesOverride` | Config override from default config values               | `{}`    |
+
+### tfy-workflow-propeller parameters
+
+| Name                                        | Description                                | Value   |
+| ------------------------------------------- | ------------------------------------------ | ------- |
+| `tfyWorkflowPropeller.enabled`              | Flag to enable workflow-propeller.         | `false` |
+| `tfyWorkflowPropeller.valuesOverride`       | Config override from default config values | `{}`    |
+| `tfyWorkflowPropeller.flyteCore.flyteadmin` | Flyteadmin configuration for flyteCore     | `{}`    |
+| `helm.resourcePolicy`                       | Resource policy for the helm chart         | `keep`  |

--- a/charts/tfy-k8s-aws-eks-inframold/templates/tfy-aws/aws-ebs-csi-driver.yaml
+++ b/charts/tfy-k8s-aws-eks-inframold/templates/tfy-aws/aws-ebs-csi-driver.yaml
@@ -104,6 +104,11 @@ spec:
             cluster-name: "{{ .Values.clusterName }}"
             volume-type: csi-ebs
             truefoundry.com/managed: "true"
+            truefoundry-cluster-name: "{{ .Values.clusterName }}"
+            truefoundry-managed: "true"
+            {{- range $k, $v := .Values.tags }}
+            {{ $k }}: {{ $v | quote }}
+            {{- end }}
           {{- if $mergedTolerations }}
           tolerations:
             {{- toYaml $mergedTolerations | nindent 14 }}

--- a/charts/tfy-k8s-aws-eks-inframold/templates/tfy-aws/karpenter-config.yaml
+++ b/charts/tfy-k8s-aws-eks-inframold/templates/tfy-aws/karpenter-config.yaml
@@ -16,7 +16,7 @@ spec:
   source:
     chart: tfy-karpenter-config
     repoURL: {{ (.Values.global | default dict).repoURL | default "https://truefoundry.github.io/infra-charts/" }}
-    targetRevision: 0.1.54
+    targetRevision: 0.1.57
     helm:
       values: |-
         {{- if .Values.aws.karpenter.config.valuesOverride }}
@@ -36,6 +36,12 @@ spec:
             {{- if .Values.aws.karpenter.kmsKeyID }}
             kmsKeyID: {{ .Values.aws.karpenter.kmsKeyID | default "" }}
             {{- end }}
+            {{- if .Values.tags }}
+            extraTags:
+              {{- range $k, $v := .Values.tags }}
+              {{ $k }}: {{ $v | quote }}
+              {{- end }}
+            {{- end }}
           {{- if .Values.gpu.enabled }}
           gpuNodePool:
             zones: {{- range .Values.aws.karpenter.defaultZones }}
@@ -46,31 +52,55 @@ spec:
             {{- if .Values.aws.karpenter.kmsKeyID }}
             kmsKeyID: {{ .Values.aws.karpenter.kmsKeyID | default "" }}
             {{- end }}
+            {{- if .Values.tags }}
+            extraTags:
+              {{- range $k, $v := .Values.tags }}
+              {{ $k }}: {{ $v | quote }}
+              {{- end }}
+            {{- end }}
           {{- end }}
           inferentiaNodePool:
             zones: {{- range .Values.aws.karpenter.defaultZones }}
             - {{ . | quote }}
             {{- end }}
-          {{- if .Values.aws.karpenter.kmsKeyID }}
           inferentiaDefaultNodeTemplate:
+            {{- if .Values.aws.karpenter.kmsKeyID }}
             kmsKeyID: {{ .Values.aws.karpenter.kmsKeyID | default "" }}
-          {{- end }}
+            {{- end }}
+            {{- if .Values.tags }}
+            extraTags:
+              {{- range $k, $v := .Values.tags }}
+              {{ $k }}: {{ $v | quote }}
+              {{- end }}
+            {{- end }}
           critical:
             zones: {{- range .Values.aws.karpenter.defaultZones }}
             - {{ . | quote }}
             {{- end }}
-            {{- if .Values.aws.karpenter.kmsKeyID }}
             nodeclass:
+              {{- if .Values.aws.karpenter.kmsKeyID }}
               kmsKeyID: {{ .Values.aws.karpenter.kmsKeyID | default "" }}
-            {{- end }}
+              {{- end }}
+              {{- if .Values.tags }}
+              extraTags:
+                {{- range $k, $v := .Values.tags }}
+                {{ $k }}: {{ $v | quote }}
+                {{- end }}
+              {{- end }}
           controlPlaneNodePool:
             zones: {{- range .Values.aws.karpenter.defaultZones }}
             - {{ . | quote }}
             {{- end }}
-          {{- if .Values.aws.karpenter.kmsKeyID }}
           controlPlaneNodeTemplate:
+            {{- if .Values.aws.karpenter.kmsKeyID }}
             kmsKeyID: {{ .Values.aws.karpenter.kmsKeyID | default "" }}
-          {{- end }}
+            {{- end }}
+            {{- if .Values.tags }}
+            extraTags:
+              {{- range $k, $v := .Values.tags }}
+              {{ $k }}: {{ $v | quote }}
+              {{- end }}
+            {{- end }}
         {{- end }}
   project: tfy-apps
   syncPolicy:

--- a/charts/tfy-k8s-aws-eks-inframold/templates/tfy-aws/karpenter-config.yaml
+++ b/charts/tfy-k8s-aws-eks-inframold/templates/tfy-aws/karpenter-config.yaml
@@ -63,6 +63,7 @@ spec:
             zones: {{- range .Values.aws.karpenter.defaultZones }}
             - {{ . | quote }}
             {{- end }}
+          {{- if or .Values.aws.karpenter.kmsKeyID .Values.tags }}
           inferentiaDefaultNodeTemplate:
             {{- if .Values.aws.karpenter.kmsKeyID }}
             kmsKeyID: {{ .Values.aws.karpenter.kmsKeyID | default "" }}
@@ -73,6 +74,7 @@ spec:
               {{ $k }}: {{ $v | quote }}
               {{- end }}
             {{- end }}
+          {{- end }}
           critical:
             zones: {{- range .Values.aws.karpenter.defaultZones }}
             - {{ . | quote }}
@@ -91,6 +93,7 @@ spec:
             zones: {{- range .Values.aws.karpenter.defaultZones }}
             - {{ . | quote }}
             {{- end }}
+          {{- if or .Values.aws.karpenter.kmsKeyID .Values.tags }}
           controlPlaneNodeTemplate:
             {{- if .Values.aws.karpenter.kmsKeyID }}
             kmsKeyID: {{ .Values.aws.karpenter.kmsKeyID | default "" }}
@@ -101,6 +104,7 @@ spec:
               {{ $k }}: {{ $v | quote }}
               {{- end }}
             {{- end }}
+          {{- end }}
         {{- end }}
   project: tfy-apps
   syncPolicy:

--- a/charts/tfy-k8s-aws-eks-inframold/templates/truefoundry.yaml
+++ b/charts/tfy-k8s-aws-eks-inframold/templates/truefoundry.yaml
@@ -15,7 +15,7 @@ spec:
     server: https://kubernetes.default.svc
   project: tfy-apps
   source:
-    targetRevision: 0.155.2
+    targetRevision: 0.156.0
     repoURL: "tfy.jfrog.io/tfy-helm"
     chart: truefoundry
     helm:

--- a/charts/tfy-k8s-aws-eks-inframold/values.yaml
+++ b/charts/tfy-k8s-aws-eks-inframold/values.yaml
@@ -35,6 +35,16 @@ controlPlaneURL: ""
 ##
 clusterName: ""
 
+## @param tags [object] AWS resource tags applied to Karpenter-launched EC2 nodes and dynamically-provisioned EBS PVC volumes
+## Key/value pairs are threaded into tfy-karpenter-config extraTags (EC2NodeClass spec.tags)
+## and into the EBS CSI driver controller.extraVolumeTags for all new PVC volumes.
+## Example:
+##   tags:
+##     cost-center: "platform"
+##     environment: "production"
+##
+tags: {}
+
 ## @param registry registry to override in the chart components
 ##
 registry: ""

--- a/charts/tfy-k8s-azure-aks-inframold/Chart.yaml
+++ b/charts/tfy-k8s-azure-aks-inframold/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: tfy-k8s-azure-aks-inframold
-version: 0.1.308
+version: 0.1.309
 description: "Inframold, the superchart that configure your cluster on azure for truefoundry."
 maintainers:
   - name: truefoundry

--- a/charts/tfy-k8s-azure-aks-inframold/README.md
+++ b/charts/tfy-k8s-azure-aks-inframold/README.md
@@ -2,3 +2,248 @@
 Inframold, the superchart that configure your cluster on azure for truefoundry.
 
 ## Parameters
+
+### Global Parameters
+
+| Name               | Description                                                | Value |
+| ------------------ | ---------------------------------------------------------- | ----- |
+| `global.repoURL`   | Override chart repository URL for all Argo CD Applications | `""`  |
+| `tenantName`       | Parameters for tenantName                                  | `""`  |
+| `controlPlaneURL`  | Parameters for controlPlaneURL                             | `""`  |
+| `clusterName`      | Name of the cluster                                        | `""`  |
+| `registry`         | registry to override in the chart components               | `""`  |
+| `imagePullSecrets` | imagePullSecrets to override in the chart components       | `[]`  |
+| `tolerations`      | Tolerations for the all chart components                   | `[]`  |
+| `affinity`         | Affinity for the all chart components                      | `{}`  |
+
+### argocd parameters
+
+| Name                    | Description                                | Value  |
+| ----------------------- | ------------------------------------------ | ------ |
+| `argocd.enabled`        | Flag to enable ArgoCD                      | `true` |
+| `argocd.tolerations`    | Tolerations for ArgoCD                     | `[]`   |
+| `argocd.affinity`       | Affinity for ArgoCD                        | `{}`   |
+| `argocd.valuesOverride` | Config override from default config values | `{}`   |
+
+### argoWorkflows parameters
+
+| Name                           | Description                                | Value  |
+| ------------------------------ | ------------------------------------------ | ------ |
+| `argoWorkflows.enabled`        | Flag to enable Argo Workflows              | `true` |
+| `argoWorkflows.tolerations`    | Tolerations for Argo Workflows             | `[]`   |
+| `argoWorkflows.affinity`       | Affinity for Argo Workflows                | `{}`   |
+| `argoWorkflows.valuesOverride` | Config override from default config values | `{}`   |
+
+### argoRollouts parameters
+
+| Name                          | Description                                | Value  |
+| ----------------------------- | ------------------------------------------ | ------ |
+| `argoRollouts.enabled`        | Flag to enable Argo Rollouts               | `true` |
+| `argoRollouts.tolerations`    | Tolerations for Argo Rollouts              | `[]`   |
+| `argoRollouts.affinity`       | Affinity for Argo Rollouts                 | `{}`   |
+| `argoRollouts.valuesOverride` | Config override from default config values | `{}`   |
+
+### certManager parameters
+
+| Name                                     | Description                                                                       | Value  |
+| ---------------------------------------- | --------------------------------------------------------------------------------- | ------ |
+| `certManager.enabled`                    | Flag to enable Cert Manager                                                       | `true` |
+| `certManager.tolerations`                | Tolerations for Cert Manager                                                      | `[]`   |
+| `certManager.podLabels`                  | Pod labels for Cert Manager. For Azure will be applied to serviceaccount as well. | `{}`   |
+| `certManager.serviceAccount.annotations` | Service account annotations for Cert Manager.                                     | `{}`   |
+| `certManager.affinity`                   | Affinity for Cert Manager                                                         | `{}`   |
+| `certManager.valuesOverride`             | Config override from default config values                                        | `{}`   |
+
+### certManager issuers parameters
+
+| Name                                | Description                                        | Value  |
+| ----------------------------------- | -------------------------------------------------- | ------ |
+| `certManager.config.enabled`        | Flag to enable certManager config                  | `true` |
+| `certManager.config.issuers`        | Map of issuers and their certificate configuration | `{}`   |
+| `certManager.config.valuesOverride` | Config override from default config values         | `{}`   |
+
+### metricsServer parameters
+
+| Name                           | Description                                | Value   |
+| ------------------------------ | ------------------------------------------ | ------- |
+| `metricsServer.enabled`        | Flag to enable Metrics Server              | `false` |
+| `metricsServer.enabled`        | Flag to enable Metrics Server              | `false` |
+| `metricsServer.tolerations`    | Tolerations for Metrics Server             | `[]`    |
+| `metricsServer.affinity`       | Affinity for Metrics Server                | `{}`    |
+| `metricsServer.valuesOverride` | Config override from default config values | `{}`    |
+
+### gpu parameters
+
+| Name                 | Description                                | Value      |
+| -------------------- | ------------------------------------------ | ---------- |
+| `gpu.enabled`        | Flag to enable Tfy GPU Operator            | `true`     |
+| `gpu.clusterType`    | Cluster type for Tfy GPU Operator          | `azureAks` |
+| `gpu.valuesOverride` | Config override from default config values | `{}`       |
+
+### truefoundry parameters
+
+| Name                          | Description                                | Value   |
+| ----------------------------- | ------------------------------------------ | ------- |
+| `truefoundry.enabled`         | Flag to enable TrueFoundry                 | `false` |
+| `truefoundry.devMode.enabled` | Flag to enable TrueFoundry Dev mode        | `false` |
+| `truefoundry.valuesOverride`  | Config override from default config values | `{}`    |
+
+### truefoundryBootstrap parameters
+
+| Name                                       | Description                                                               | Value  |
+| ------------------------------------------ | ------------------------------------------------------------------------- | ------ |
+| `truefoundry.truefoundryBootstrap.enabled` | Flag to enable bootstrap job to prep cluster for truefoundry installation | `true` |
+
+### Truefoundry virtual service parameters
+
+| Name                                         | Description                                        | Value   |
+| -------------------------------------------- | -------------------------------------------------- | ------- |
+| `truefoundry.virtualservice.enabled`         | Flag to enable virtualservice                      | `false` |
+| `truefoundry.virtualservice.hosts`           | Hosts for truefoundry virtualservice               | `[]`    |
+| `truefoundry.virtualservice.gateways`        | Istio gateways to be configured for virtualservice | `[]`    |
+| `truefoundry.virtualservice.annotations`     | Annotations for truefoundry virtualservice         | `{}`    |
+| `truefoundry.existingTruefoundryCredsSecret` | Secret name for existing Truefoundry creds         | `""`    |
+
+### database. Can be left empty if using the dev mode parameters
+
+| Name                                                         | Description                                                | Value   |
+| ------------------------------------------------------------ | ---------------------------------------------------------- | ------- |
+| `truefoundry.database.host`                                  | Hostname of the database                                   | `""`    |
+| `truefoundry.database.name`                                  | Name of the database                                       | `""`    |
+| `truefoundry.database.username`                              | Username of the database                                   | `""`    |
+| `truefoundry.database.password`                              | Password of the database                                   | `""`    |
+| `truefoundry.tfyApiKey`                                      | API Key for TrueFoundry                                    | `""`    |
+| `truefoundry.imagePullSecrets`                               | Image pull secrets for TrueFoundry                         | `[]`    |
+| `truefoundry.truefoundryImagePullConfigJSON`                 | Json config for authenticating to the TrueFoundry registry | `""`    |
+| `truefoundry.truefoundry_iam_role_arn_annotations`           | IAM role annotations for service accounts                  | `{}`    |
+| `truefoundry.defaultCloudProvider`                           | Default cloud provider                                     | `azure` |
+| `truefoundry.storageConfiguration.azureBlobUri`              | Azure blob URI                                             | `""`    |
+| `truefoundry.storageConfiguration.azureBlobConnectionString` | Azure blob connection string                               | `""`    |
+| `truefoundry.s3proxy.enabled`                                | Flag to enable S3 Proxy                                    | `false` |
+| `truefoundry.sparkHistoryServer.enabled`                     | Flag to enable Spark History Server                        | `false` |
+| `truefoundry.tfyWorkflowAdmin.enabled`                       | Flag to enable Tfy Workflow Admin                          | `false` |
+| `truefoundry.gateway.enabled`                                | Flag to enable Gateway                                     | `false` |
+| `truefoundry.tolerations`                                    | Tolerations for the truefoundry components                 | `[]`    |
+| `truefoundry.affinity`                                       | Affinity for the truefoundry components                    | `{}`    |
+
+### tfyLogs parameters
+
+| Name                     | Description                                | Value  |
+| ------------------------ | ------------------------------------------ | ------ |
+| `tfyLogs.enabled`        | Flag to enable Tfy Logs                    | `true` |
+| `tfyLogs.valuesOverride` | Config override from default config values | `{}`   |
+| `tfyLogs.affinity`       | Affinity for tfyLogs statefulset pod       | `{}`   |
+| `tfyLogs.tolerations`    | Tolerations for tfyLogs statefulset pod    | `[]`   |
+
+### istio parameters
+
+| Name                                    | Description                                | Value   |
+| --------------------------------------- | ------------------------------------------ | ------- |
+| `istio.enabled`                         | Flag to enable Istio                       | `true`  |
+| `istio.enabled`                         | Flag to enable Istio Base                  | `true`  |
+| `istio.base.valuesOverride`             | Config override from default config values | `{}`    |
+| `istio.awsElbControllerChecker.enabled` | Flag to enable AWS ELB Controller Checker  | `false` |
+| `istio.gateway.annotations`             | Annotations for Istio Gateway              | `{}`    |
+| `istio.gateway.affinity`                | Affinity for the gateway pods              | `{}`    |
+| `istio.gateway.tolerations`             | Tolerations for the gateway pods           | `[]`    |
+| `istio.gateway.valuesOverride`          | Config override from default config values | `{}`    |
+
+### istio discovery parameters
+
+| Name                             | Description                                | Value                  |
+| -------------------------------- | ------------------------------------------ | ---------------------- |
+| `istio.discovery.hub`            | Hub for the istio image                    | `gcr.io/istio-release` |
+| `istio.discovery.tolerations`    | Tolerations for Istio Discovery            | `[]`                   |
+| `istio.discovery.affinity`       | Affinity for Istio Discovery               | `{}`                   |
+| `istio.discovery.valuesOverride` | Config override from default config values | `{}`                   |
+
+### istio tfyGateway parameters
+
+| Name                                  | Description                                     | Value    |
+| ------------------------------------- | ----------------------------------------------- | -------- |
+| `istio.tfyGateway.httpsRedirect`      | Flag to enable HTTPS redirect for Istio Gateway | `true`   |
+| `istio.tfyGateway.tls.enabled`        | Flag to enable TLS for Istio Gateway            | `false`  |
+| `istio.tfyGateway.tls.mode`           | TLS mode for the Istio Gateway                  | `SIMPLE` |
+| `istio.tfyGateway.tls.credentialName` | Credential name for the TLS certificate         | `""`     |
+| `istio.tfyGateway.domains`            | Domains for the gateway pods                    | `[]`     |
+
+### keda parameters
+
+| Name                  | Description                                | Value  |
+| --------------------- | ------------------------------------------ | ------ |
+| `keda.enabled`        | Flag to enable Keda                        | `true` |
+| `keda.tolerations`    | Tolerations for Keda                       | `[]`   |
+| `keda.affinity`       | Affinity for Keda                          | `{}`   |
+| `keda.valuesOverride` | Config override from default config values | `{}`   |
+
+### sparkOperator parameters
+
+| Name                           | Description                                | Value   |
+| ------------------------------ | ------------------------------------------ | ------- |
+| `sparkOperator.enabled`        | Flag to enable Spark Operator              | `false` |
+| `sparkOperator.tolerations`    | Tolerations for Spark Operator             | `[]`    |
+| `sparkOperator.affinity`       | Affinity for Spark Operator                | `{}`    |
+| `sparkOperator.valuesOverride` | Config override from default config values | `{}`    |
+
+### prometheus parameters
+
+| Name                                     | Description                                                               | Value  |
+| ---------------------------------------- | ------------------------------------------------------------------------- | ------ |
+| `prometheus.enabled`                     | Flag to enable Prometheus                                                 | `true` |
+| `prometheus.additionalScrapeConfigs`     | Additional scrape configs for Prometheus                                  | `[]`   |
+| `prometheus.alertmanager`                | Alertmanager configuration for Prometheus                                 | `{}`   |
+| `prometheus.affinity`                    | Affinity for prometheus statefulset pod                                   | `{}`   |
+| `prometheus.tolerations`                 | Tolerations for prometheus statefulset pod                                | `[]`   |
+| `prometheus.valuesOverride`              | Config override from default config values                                | `{}`   |
+| `prometheus.prometheusNodeExporter.port` | Port for prometheus-node-exporter service and container (default 9100)    | `9100` |
+| `prometheus.config.enabled`              | Flag to enable prometheus config (requires prometheus.enabled to be true) | `true` |
+| `prometheus.config.valuesOverride`       | Config override from default config values                                | `{}`   |
+| `prometheus.config.extraObjects`         | Extra objects for prometheus config                                       | `[]`   |
+
+### grafana parameters
+
+| Name                     | Description                                | Value   |
+| ------------------------ | ------------------------------------------ | ------- |
+| `grafana.enabled`        | Flag to enable Grafana                     | `false` |
+| `grafana.tolerations`    | Tolerations for Grafana                    | `[]`    |
+| `grafana.affinity`       | Affinity for Grafana                       | `{}`    |
+| `grafana.valuesOverride` | Config override from default config values | `{}`    |
+
+### tfyAgent parameters
+
+| Name                          | Description                                | Value  |
+| ----------------------------- | ------------------------------------------ | ------ |
+| `tfyAgent.enabled`            | Flag to enable Tfy Agent                   | `true` |
+| `tfyAgent.valuesOverride`     | Config override from default config values | `{}`   |
+| `tfyAgent.tolerations`        | Tolerations for the agent pods             | `[]`   |
+| `tfyAgent.affinity`           | Affinity for the agent pods                | `{}`   |
+| `tfyAgent.clusterToken`       | cluster token                              | `""`   |
+| `tfyAgent.clusterTokenSecret` | Secret name for cluster token              | `""`   |
+
+### elasti parameters
+
+| Name                    | Description                                | Value  |
+| ----------------------- | ------------------------------------------ | ------ |
+| `elasti.enabled`        | Flag to enable Elasti                      | `true` |
+| `elasti.tolerations`    | Tolerations for Elasti                     | `[]`   |
+| `elasti.affinity`       | Affinity for Elasti                        | `{}`   |
+| `elasti.valuesOverride` | Config override from default config values | `{}`   |
+
+### jspolicy parameters
+
+| Name                             | Description                                              | Value   |
+| -------------------------------- | -------------------------------------------------------- | ------- |
+| `jspolicy.enabled`               | Flag to enable jspolicy. No policy is applied by default | `false` |
+| `jspolicy.enabled`               | Flag to enable jspolicy                                  | `false` |
+| `jspolicy.valuesOverride`        | Config override from default config values               | `{}`    |
+| `jspolicy.affinity`              | Affinity for jspolicy                                    | `{}`    |
+| `jspolicy.tolerations`           | Tolerations for jspolicy                                 | `[]`    |
+| `jspolicy.config.valuesOverride` | Config override from default config values               | `{}`    |
+
+### tfy-workflow-propeller parameters
+
+| Name                                  | Description                                | Value   |
+| ------------------------------------- | ------------------------------------------ | ------- |
+| `tfyWorkflowPropeller.enabled`        | Flag to enable workflow-propeller.         | `false` |
+| `tfyWorkflowPropeller.valuesOverride` | Config override from default config values | `{}`    |
+| `helm.resourcePolicy`                 | Resource policy for the helm chart         | `keep`  |

--- a/charts/tfy-k8s-azure-aks-inframold/templates/truefoundry.yaml
+++ b/charts/tfy-k8s-azure-aks-inframold/templates/truefoundry.yaml
@@ -15,7 +15,7 @@ spec:
     server: https://kubernetes.default.svc
   project: tfy-apps
   source:
-    targetRevision: 0.155.2
+    targetRevision: 0.156.0
     repoURL: "tfy.jfrog.io/tfy-helm"
     chart: truefoundry
     helm:

--- a/charts/tfy-k8s-civo-talos-inframold/Chart.yaml
+++ b/charts/tfy-k8s-civo-talos-inframold/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: tfy-k8s-civo-talos-inframold
-version: 0.1.308
+version: 0.1.309
 description: "Inframold, the superchart that configure your cluster on civo for truefoundry."
 maintainers:
   - name: truefoundry

--- a/charts/tfy-k8s-civo-talos-inframold/README.md
+++ b/charts/tfy-k8s-civo-talos-inframold/README.md
@@ -2,3 +2,247 @@
 Inframold, the superchart that configure your cluster on civo for truefoundry.
 
 ## Parameters
+
+### Global Parameters
+
+| Name               | Description                                                | Value |
+| ------------------ | ---------------------------------------------------------- | ----- |
+| `global.repoURL`   | Override chart repository URL for all Argo CD Applications | `""`  |
+| `tenantName`       | Parameters for tenantName                                  | `""`  |
+| `controlPlaneURL`  | Parameters for controlPlaneURL                             | `""`  |
+| `clusterName`      | Name of the cluster                                        | `""`  |
+| `registry`         | registry to override in the chart components               | `""`  |
+| `imagePullSecrets` | imagePullSecrets to override in the chart components       | `[]`  |
+| `tolerations`      | Tolerations for the all chart components                   | `[]`  |
+| `affinity`         | Affinity for the all chart components                      | `{}`  |
+
+### argocd parameters
+
+| Name                    | Description                                | Value  |
+| ----------------------- | ------------------------------------------ | ------ |
+| `argocd.enabled`        | Flag to enable ArgoCD                      | `true` |
+| `argocd.tolerations`    | Tolerations for ArgoCD                     | `[]`   |
+| `argocd.affinity`       | Affinity for ArgoCD                        | `{}`   |
+| `argocd.valuesOverride` | Config override from default config values | `{}`   |
+
+### argoWorkflows parameters
+
+| Name                           | Description                                | Value  |
+| ------------------------------ | ------------------------------------------ | ------ |
+| `argoWorkflows.enabled`        | Flag to enable Argo Workflows              | `true` |
+| `argoWorkflows.tolerations`    | Tolerations for Argo Workflows             | `[]`   |
+| `argoWorkflows.affinity`       | Affinity for Argo Workflows                | `{}`   |
+| `argoWorkflows.valuesOverride` | Config override from default config values | `{}`   |
+
+### argoRollouts parameters
+
+| Name                          | Description                                | Value  |
+| ----------------------------- | ------------------------------------------ | ------ |
+| `argoRollouts.enabled`        | Flag to enable Argo Rollouts               | `true` |
+| `argoRollouts.tolerations`    | Tolerations for Argo Rollouts              | `[]`   |
+| `argoRollouts.affinity`       | Affinity for Argo Rollouts                 | `{}`   |
+| `argoRollouts.valuesOverride` | Config override from default config values | `{}`   |
+
+### certManager parameters
+
+| Name                                     | Description                                                                       | Value  |
+| ---------------------------------------- | --------------------------------------------------------------------------------- | ------ |
+| `certManager.enabled`                    | Flag to enable Cert Manager                                                       | `true` |
+| `certManager.tolerations`                | Tolerations for Cert Manager                                                      | `[]`   |
+| `certManager.podLabels`                  | Pod labels for Cert Manager. For Azure will be applied to serviceaccount as well. | `{}`   |
+| `certManager.serviceAccount.annotations` | Service account annotations for Cert Manager.                                     | `{}`   |
+| `certManager.affinity`                   | Affinity for Cert Manager                                                         | `{}`   |
+| `certManager.valuesOverride`             | Config override from default config values                                        | `{}`   |
+
+### certManager issuers parameters
+
+| Name                                | Description                                        | Value  |
+| ----------------------------------- | -------------------------------------------------- | ------ |
+| `certManager.config.enabled`        | Flag to enable certManager config                  | `true` |
+| `certManager.config.issuers`        | Map of issuers and their certificate configuration | `{}`   |
+| `certManager.config.valuesOverride` | Config override from default config values         | `{}`   |
+
+### metricsServer parameters
+
+| Name                           | Description                                | Value   |
+| ------------------------------ | ------------------------------------------ | ------- |
+| `metricsServer.enabled`        | Flag to enable Metrics Server              | `false` |
+| `metricsServer.enabled`        | Flag to enable Metrics Server              | `false` |
+| `metricsServer.tolerations`    | Tolerations for Metrics Server             | `[]`    |
+| `metricsServer.affinity`       | Affinity for Metrics Server                | `{}`    |
+| `metricsServer.valuesOverride` | Config override from default config values | `{}`    |
+
+### gpu parameters
+
+| Name                 | Description                                | Value       |
+| -------------------- | ------------------------------------------ | ----------- |
+| `gpu.enabled`        | Flag to enable Tfy GPU Operator            | `true`      |
+| `gpu.clusterType`    | Cluster type for Tfy GPU Operator          | `civoTalos` |
+| `gpu.valuesOverride` | Config override from default config values | `{}`        |
+
+### truefoundry parameters
+
+| Name                          | Description                                | Value   |
+| ----------------------------- | ------------------------------------------ | ------- |
+| `truefoundry.enabled`         | Flag to enable TrueFoundry                 | `false` |
+| `truefoundry.devMode.enabled` | Flag to enable TrueFoundry Dev mode        | `false` |
+| `truefoundry.valuesOverride`  | Config override from default config values | `{}`    |
+
+### truefoundryBootstrap parameters
+
+| Name                                       | Description                                                               | Value  |
+| ------------------------------------------ | ------------------------------------------------------------------------- | ------ |
+| `truefoundry.truefoundryBootstrap.enabled` | Flag to enable bootstrap job to prep cluster for truefoundry installation | `true` |
+
+### Truefoundry virtual service parameters
+
+| Name                                         | Description                                        | Value   |
+| -------------------------------------------- | -------------------------------------------------- | ------- |
+| `truefoundry.virtualservice.enabled`         | Flag to enable virtualservice                      | `false` |
+| `truefoundry.virtualservice.hosts`           | Hosts for truefoundry virtualservice               | `[]`    |
+| `truefoundry.virtualservice.gateways`        | Istio gateways to be configured for virtualservice | `[]`    |
+| `truefoundry.virtualservice.annotations`     | Annotations for truefoundry virtualservice         | `{}`    |
+| `truefoundry.existingTruefoundryCredsSecret` | Secret name for existing Truefoundry creds         | `""`    |
+
+### database. Can be left empty if using the dev mode parameters
+
+| Name                                               | Description                                                | Value     |
+| -------------------------------------------------- | ---------------------------------------------------------- | --------- |
+| `truefoundry.database.host`                        | Hostname of the database                                   | `""`      |
+| `truefoundry.database.name`                        | Name of the database                                       | `""`      |
+| `truefoundry.database.username`                    | Username of the database                                   | `""`      |
+| `truefoundry.database.password`                    | Password of the database                                   | `""`      |
+| `truefoundry.tfyApiKey`                            | API Key for TrueFoundry                                    | `""`      |
+| `truefoundry.imagePullSecrets`                     | Image pull secrets for TrueFoundry                         | `[]`      |
+| `truefoundry.truefoundryImagePullConfigJSON`       | Json config for authenticating to the TrueFoundry registry | `""`      |
+| `truefoundry.truefoundry_iam_role_arn_annotations` | IAM role annotations for service accounts                  | `{}`      |
+| `truefoundry.defaultCloudProvider`                 | Default cloud provider                                     | `generic` |
+| `truefoundry.storageConfiguration`                 | Storage class for the storage configuration                | `{}`      |
+| `truefoundry.s3proxy.enabled`                      | Flag to enable S3 Proxy                                    | `false`   |
+| `truefoundry.sparkHistoryServer.enabled`           | Flag to enable Spark History Server                        | `false`   |
+| `truefoundry.tfyWorkflowAdmin.enabled`             | Flag to enable Tfy Workflow Admin                          | `false`   |
+| `truefoundry.gateway.enabled`                      | Flag to enable Gateway                                     | `false`   |
+| `truefoundry.tolerations`                          | Tolerations for the truefoundry components                 | `[]`      |
+| `truefoundry.affinity`                             | Affinity for the truefoundry components                    | `{}`      |
+
+### tfyLogs parameters
+
+| Name                     | Description                                | Value  |
+| ------------------------ | ------------------------------------------ | ------ |
+| `tfyLogs.enabled`        | Flag to enable Tfy Logs                    | `true` |
+| `tfyLogs.valuesOverride` | Config override from default config values | `{}`   |
+| `tfyLogs.affinity`       | Affinity for tfyLogs statefulset pod       | `{}`   |
+| `tfyLogs.tolerations`    | Tolerations for tfyLogs statefulset pod    | `[]`   |
+
+### istio parameters
+
+| Name                                    | Description                                | Value   |
+| --------------------------------------- | ------------------------------------------ | ------- |
+| `istio.enabled`                         | Flag to enable Istio                       | `true`  |
+| `istio.enabled`                         | Flag to enable Istio Base                  | `true`  |
+| `istio.base.valuesOverride`             | Config override from default config values | `{}`    |
+| `istio.awsElbControllerChecker.enabled` | Flag to enable AWS ELB Controller Checker  | `false` |
+| `istio.gateway.annotations`             | Annotations for Istio Gateway              | `{}`    |
+| `istio.gateway.affinity`                | Affinity for the gateway pods              | `{}`    |
+| `istio.gateway.tolerations`             | Tolerations for the gateway pods           | `[]`    |
+| `istio.gateway.valuesOverride`          | Config override from default config values | `{}`    |
+
+### istio discovery parameters
+
+| Name                             | Description                                | Value                  |
+| -------------------------------- | ------------------------------------------ | ---------------------- |
+| `istio.discovery.hub`            | Hub for the istio image                    | `gcr.io/istio-release` |
+| `istio.discovery.tolerations`    | Tolerations for Istio Discovery            | `[]`                   |
+| `istio.discovery.affinity`       | Affinity for Istio Discovery               | `{}`                   |
+| `istio.discovery.valuesOverride` | Config override from default config values | `{}`                   |
+
+### istio tfyGateway parameters
+
+| Name                                  | Description                                     | Value    |
+| ------------------------------------- | ----------------------------------------------- | -------- |
+| `istio.tfyGateway.httpsRedirect`      | Flag to enable HTTPS redirect for Istio Gateway | `true`   |
+| `istio.tfyGateway.tls.enabled`        | Flag to enable TLS for Istio Gateway            | `false`  |
+| `istio.tfyGateway.tls.mode`           | TLS mode for the Istio Gateway                  | `SIMPLE` |
+| `istio.tfyGateway.tls.credentialName` | Credential name for the TLS certificate         | `""`     |
+| `istio.tfyGateway.domains`            | Domains for the gateway pods                    | `[]`     |
+
+### keda parameters
+
+| Name                  | Description                                | Value  |
+| --------------------- | ------------------------------------------ | ------ |
+| `keda.enabled`        | Flag to enable Keda                        | `true` |
+| `keda.tolerations`    | Tolerations for Keda                       | `[]`   |
+| `keda.affinity`       | Affinity for Keda                          | `{}`   |
+| `keda.valuesOverride` | Config override from default config values | `{}`   |
+
+### sparkOperator parameters
+
+| Name                           | Description                                | Value   |
+| ------------------------------ | ------------------------------------------ | ------- |
+| `sparkOperator.enabled`        | Flag to enable Spark Operator              | `false` |
+| `sparkOperator.tolerations`    | Tolerations for Spark Operator             | `[]`    |
+| `sparkOperator.affinity`       | Affinity for Spark Operator                | `{}`    |
+| `sparkOperator.valuesOverride` | Config override from default config values | `{}`    |
+
+### prometheus parameters
+
+| Name                                     | Description                                                               | Value  |
+| ---------------------------------------- | ------------------------------------------------------------------------- | ------ |
+| `prometheus.enabled`                     | Flag to enable Prometheus                                                 | `true` |
+| `prometheus.additionalScrapeConfigs`     | Additional scrape configs for Prometheus                                  | `[]`   |
+| `prometheus.alertmanager`                | Alertmanager configuration for Prometheus                                 | `{}`   |
+| `prometheus.affinity`                    | Affinity for prometheus statefulset pod                                   | `{}`   |
+| `prometheus.tolerations`                 | Tolerations for prometheus statefulset pod                                | `[]`   |
+| `prometheus.valuesOverride`              | Config override from default config values                                | `{}`   |
+| `prometheus.prometheusNodeExporter.port` | Port for prometheus-node-exporter service and container (default 9100)    | `9100` |
+| `prometheus.config.enabled`              | Flag to enable prometheus config (requires prometheus.enabled to be true) | `true` |
+| `prometheus.config.valuesOverride`       | Config override from default config values                                | `{}`   |
+| `prometheus.config.extraObjects`         | Extra objects for prometheus config                                       | `[]`   |
+
+### grafana parameters
+
+| Name                     | Description                                | Value   |
+| ------------------------ | ------------------------------------------ | ------- |
+| `grafana.enabled`        | Flag to enable Grafana                     | `false` |
+| `grafana.tolerations`    | Tolerations for Grafana                    | `[]`    |
+| `grafana.affinity`       | Affinity for Grafana                       | `{}`    |
+| `grafana.valuesOverride` | Config override from default config values | `{}`    |
+
+### tfyAgent parameters
+
+| Name                          | Description                                | Value  |
+| ----------------------------- | ------------------------------------------ | ------ |
+| `tfyAgent.enabled`            | Flag to enable Tfy Agent                   | `true` |
+| `tfyAgent.valuesOverride`     | Config override from default config values | `{}`   |
+| `tfyAgent.tolerations`        | Tolerations for the agent pods             | `[]`   |
+| `tfyAgent.affinity`           | Affinity for the agent pods                | `{}`   |
+| `tfyAgent.clusterToken`       | cluster token                              | `""`   |
+| `tfyAgent.clusterTokenSecret` | Secret name for cluster token              | `""`   |
+
+### elasti parameters
+
+| Name                    | Description                                | Value  |
+| ----------------------- | ------------------------------------------ | ------ |
+| `elasti.enabled`        | Flag to enable Elasti                      | `true` |
+| `elasti.tolerations`    | Tolerations for Elasti                     | `[]`   |
+| `elasti.affinity`       | Affinity for Elasti                        | `{}`   |
+| `elasti.valuesOverride` | Config override from default config values | `{}`   |
+
+### jspolicy parameters
+
+| Name                             | Description                                              | Value   |
+| -------------------------------- | -------------------------------------------------------- | ------- |
+| `jspolicy.enabled`               | Flag to enable jspolicy. No policy is applied by default | `false` |
+| `jspolicy.enabled`               | Flag to enable jspolicy                                  | `false` |
+| `jspolicy.valuesOverride`        | Config override from default config values               | `{}`    |
+| `jspolicy.affinity`              | Affinity for jspolicy                                    | `{}`    |
+| `jspolicy.tolerations`           | Tolerations for jspolicy                                 | `[]`    |
+| `jspolicy.config.valuesOverride` | Config override from default config values               | `{}`    |
+
+### tfy-workflow-propeller parameters
+
+| Name                                  | Description                                | Value   |
+| ------------------------------------- | ------------------------------------------ | ------- |
+| `tfyWorkflowPropeller.enabled`        | Flag to enable workflow-propeller.         | `false` |
+| `tfyWorkflowPropeller.valuesOverride` | Config override from default config values | `{}`    |
+| `helm.resourcePolicy`                 | Resource policy for the helm chart         | `keep`  |

--- a/charts/tfy-k8s-civo-talos-inframold/templates/truefoundry.yaml
+++ b/charts/tfy-k8s-civo-talos-inframold/templates/truefoundry.yaml
@@ -15,7 +15,7 @@ spec:
     server: https://kubernetes.default.svc
   project: tfy-apps
   source:
-    targetRevision: 0.155.2
+    targetRevision: 0.156.0
     repoURL: "tfy.jfrog.io/tfy-helm"
     chart: truefoundry
     helm:

--- a/charts/tfy-k8s-gcp-gke-standard-inframold/Chart.yaml
+++ b/charts/tfy-k8s-gcp-gke-standard-inframold/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: tfy-k8s-gcp-gke-standard-inframold
-version: 0.1.308
+version: 0.1.309
 description: "Inframold, the superchart that configure your cluster on gcp for truefoundry."
 maintainers:
   - name: truefoundry

--- a/charts/tfy-k8s-gcp-gke-standard-inframold/README.md
+++ b/charts/tfy-k8s-gcp-gke-standard-inframold/README.md
@@ -2,3 +2,249 @@
 Inframold, the superchart that configure your cluster on gcp for truefoundry.
 
 ## Parameters
+
+### Global Parameters
+
+| Name               | Description                                                | Value |
+| ------------------ | ---------------------------------------------------------- | ----- |
+| `global.repoURL`   | Override chart repository URL for all Argo CD Applications | `""`  |
+| `tenantName`       | Parameters for tenantName                                  | `""`  |
+| `controlPlaneURL`  | Parameters for controlPlaneURL                             | `""`  |
+| `clusterName`      | Name of the cluster                                        | `""`  |
+| `registry`         | registry to override in the chart components               | `""`  |
+| `imagePullSecrets` | imagePullSecrets to override in the chart components       | `[]`  |
+| `tolerations`      | Tolerations for the all chart components                   | `[]`  |
+| `affinity`         | Affinity for the all chart components                      | `{}`  |
+
+### argocd parameters
+
+| Name                    | Description                                | Value  |
+| ----------------------- | ------------------------------------------ | ------ |
+| `argocd.enabled`        | Flag to enable ArgoCD                      | `true` |
+| `argocd.tolerations`    | Tolerations for ArgoCD                     | `[]`   |
+| `argocd.affinity`       | Affinity for ArgoCD                        | `{}`   |
+| `argocd.valuesOverride` | Config override from default config values | `{}`   |
+
+### argoWorkflows parameters
+
+| Name                           | Description                                | Value  |
+| ------------------------------ | ------------------------------------------ | ------ |
+| `argoWorkflows.enabled`        | Flag to enable Argo Workflows              | `true` |
+| `argoWorkflows.tolerations`    | Tolerations for Argo Workflows             | `[]`   |
+| `argoWorkflows.affinity`       | Affinity for Argo Workflows                | `{}`   |
+| `argoWorkflows.valuesOverride` | Config override from default config values | `{}`   |
+
+### argoRollouts parameters
+
+| Name                          | Description                                | Value  |
+| ----------------------------- | ------------------------------------------ | ------ |
+| `argoRollouts.enabled`        | Flag to enable Argo Rollouts               | `true` |
+| `argoRollouts.tolerations`    | Tolerations for Argo Rollouts              | `[]`   |
+| `argoRollouts.affinity`       | Affinity for Argo Rollouts                 | `{}`   |
+| `argoRollouts.valuesOverride` | Config override from default config values | `{}`   |
+
+### certManager parameters
+
+| Name                                     | Description                                                                       | Value  |
+| ---------------------------------------- | --------------------------------------------------------------------------------- | ------ |
+| `certManager.enabled`                    | Flag to enable Cert Manager                                                       | `true` |
+| `certManager.tolerations`                | Tolerations for Cert Manager                                                      | `[]`   |
+| `certManager.podLabels`                  | Pod labels for Cert Manager. For Azure will be applied to serviceaccount as well. | `{}`   |
+| `certManager.serviceAccount.annotations` | Service account annotations for Cert Manager.                                     | `{}`   |
+| `certManager.affinity`                   | Affinity for Cert Manager                                                         | `{}`   |
+| `certManager.valuesOverride`             | Config override from default config values                                        | `{}`   |
+
+### certManager issuers parameters
+
+| Name                                | Description                                        | Value  |
+| ----------------------------------- | -------------------------------------------------- | ------ |
+| `certManager.config.enabled`        | Flag to enable certManager config                  | `true` |
+| `certManager.config.issuers`        | Map of issuers and their certificate configuration | `{}`   |
+| `certManager.config.valuesOverride` | Config override from default config values         | `{}`   |
+
+### metricsServer parameters
+
+| Name                           | Description                                | Value   |
+| ------------------------------ | ------------------------------------------ | ------- |
+| `metricsServer.enabled`        | Flag to enable Metrics Server              | `false` |
+| `metricsServer.enabled`        | Flag to enable Metrics Server              | `false` |
+| `metricsServer.tolerations`    | Tolerations for Metrics Server             | `[]`    |
+| `metricsServer.affinity`       | Affinity for Metrics Server                | `{}`    |
+| `metricsServer.valuesOverride` | Config override from default config values | `{}`    |
+
+### gpu parameters
+
+| Name                 | Description                                | Value            |
+| -------------------- | ------------------------------------------ | ---------------- |
+| `gpu.enabled`        | Flag to enable Tfy GPU Operator            | `true`           |
+| `gpu.clusterType`    | Cluster type for Tfy GPU Operator          | `gcpGkeStandard` |
+| `gpu.valuesOverride` | Config override from default config values | `{}`             |
+
+### truefoundry parameters
+
+| Name                          | Description                                | Value   |
+| ----------------------------- | ------------------------------------------ | ------- |
+| `truefoundry.enabled`         | Flag to enable TrueFoundry                 | `false` |
+| `truefoundry.devMode.enabled` | Flag to enable TrueFoundry Dev mode        | `false` |
+| `truefoundry.valuesOverride`  | Config override from default config values | `{}`    |
+
+### truefoundryBootstrap parameters
+
+| Name                                       | Description                                                               | Value  |
+| ------------------------------------------ | ------------------------------------------------------------------------- | ------ |
+| `truefoundry.truefoundryBootstrap.enabled` | Flag to enable bootstrap job to prep cluster for truefoundry installation | `true` |
+
+### Truefoundry virtual service parameters
+
+| Name                                         | Description                                        | Value   |
+| -------------------------------------------- | -------------------------------------------------- | ------- |
+| `truefoundry.virtualservice.enabled`         | Flag to enable virtualservice                      | `false` |
+| `truefoundry.virtualservice.hosts`           | Hosts for truefoundry virtualservice               | `[]`    |
+| `truefoundry.virtualservice.gateways`        | Istio gateways to be configured for virtualservice | `[]`    |
+| `truefoundry.virtualservice.annotations`     | Annotations for truefoundry virtualservice         | `{}`    |
+| `truefoundry.existingTruefoundryCredsSecret` | Secret name for existing Truefoundry creds         | `""`    |
+
+### database. Can be left empty if using the dev mode parameters
+
+| Name                                                                       | Description                                                | Value   |
+| -------------------------------------------------------------------------- | ---------------------------------------------------------- | ------- |
+| `truefoundry.database.host`                                                | Hostname of the database                                   | `""`    |
+| `truefoundry.database.name`                                                | Name of the database                                       | `""`    |
+| `truefoundry.database.username`                                            | Username of the database                                   | `""`    |
+| `truefoundry.database.password`                                            | Password of the database                                   | `""`    |
+| `truefoundry.tfyApiKey`                                                    | API Key for TrueFoundry                                    | `""`    |
+| `truefoundry.imagePullSecrets`                                             | Image pull secrets for TrueFoundry                         | `[]`    |
+| `truefoundry.truefoundryImagePullConfigJSON`                               | Json config for authenticating to the TrueFoundry registry | `""`    |
+| `truefoundry.truefoundry_iam_role_arn_annotations`                         | IAM role annotations for service accounts                  | `{}`    |
+| `truefoundry.defaultCloudProvider`                                         | Default cloud provider                                     | `gcp`   |
+| `truefoundry.storageConfiguration.googleCloudProjectId`                    | Google cloud project ID                                    | `""`    |
+| `truefoundry.storageConfiguration.googleCloudStorageBucketName`            | Google cloud storage bucket name                           | `""`    |
+| `truefoundry.storageConfiguration.googleCloudServiceAccountKeyFileContent` | Google cloud service account key file content              | `""`    |
+| `truefoundry.s3proxy.enabled`                                              | Flag to enable S3 Proxy                                    | `false` |
+| `truefoundry.sparkHistoryServer.enabled`                                   | Flag to enable Spark History Server                        | `false` |
+| `truefoundry.tfyWorkflowAdmin.enabled`                                     | Flag to enable Tfy Workflow Admin                          | `false` |
+| `truefoundry.gateway.enabled`                                              | Flag to enable Gateway                                     | `false` |
+| `truefoundry.tolerations`                                                  | Tolerations for the truefoundry components                 | `[]`    |
+| `truefoundry.affinity`                                                     | Affinity for the truefoundry components                    | `{}`    |
+
+### tfyLogs parameters
+
+| Name                     | Description                                | Value  |
+| ------------------------ | ------------------------------------------ | ------ |
+| `tfyLogs.enabled`        | Flag to enable Tfy Logs                    | `true` |
+| `tfyLogs.valuesOverride` | Config override from default config values | `{}`   |
+| `tfyLogs.affinity`       | Affinity for tfyLogs statefulset pod       | `{}`   |
+| `tfyLogs.tolerations`    | Tolerations for tfyLogs statefulset pod    | `[]`   |
+
+### istio parameters
+
+| Name                                    | Description                                | Value   |
+| --------------------------------------- | ------------------------------------------ | ------- |
+| `istio.enabled`                         | Flag to enable Istio                       | `true`  |
+| `istio.enabled`                         | Flag to enable Istio Base                  | `true`  |
+| `istio.base.valuesOverride`             | Config override from default config values | `{}`    |
+| `istio.awsElbControllerChecker.enabled` | Flag to enable AWS ELB Controller Checker  | `false` |
+| `istio.gateway.annotations`             | Annotations for Istio Gateway              | `{}`    |
+| `istio.gateway.affinity`                | Affinity for the gateway pods              | `{}`    |
+| `istio.gateway.tolerations`             | Tolerations for the gateway pods           | `[]`    |
+| `istio.gateway.valuesOverride`          | Config override from default config values | `{}`    |
+
+### istio discovery parameters
+
+| Name                             | Description                                | Value                  |
+| -------------------------------- | ------------------------------------------ | ---------------------- |
+| `istio.discovery.hub`            | Hub for the istio image                    | `gcr.io/istio-release` |
+| `istio.discovery.tolerations`    | Tolerations for Istio Discovery            | `[]`                   |
+| `istio.discovery.affinity`       | Affinity for Istio Discovery               | `{}`                   |
+| `istio.discovery.valuesOverride` | Config override from default config values | `{}`                   |
+
+### istio tfyGateway parameters
+
+| Name                                  | Description                                     | Value    |
+| ------------------------------------- | ----------------------------------------------- | -------- |
+| `istio.tfyGateway.httpsRedirect`      | Flag to enable HTTPS redirect for Istio Gateway | `true`   |
+| `istio.tfyGateway.tls.enabled`        | Flag to enable TLS for Istio Gateway            | `false`  |
+| `istio.tfyGateway.tls.mode`           | TLS mode for the Istio Gateway                  | `SIMPLE` |
+| `istio.tfyGateway.tls.credentialName` | Credential name for the TLS certificate         | `""`     |
+| `istio.tfyGateway.domains`            | Domains for the gateway pods                    | `[]`     |
+
+### keda parameters
+
+| Name                  | Description                                | Value  |
+| --------------------- | ------------------------------------------ | ------ |
+| `keda.enabled`        | Flag to enable Keda                        | `true` |
+| `keda.tolerations`    | Tolerations for Keda                       | `[]`   |
+| `keda.affinity`       | Affinity for Keda                          | `{}`   |
+| `keda.valuesOverride` | Config override from default config values | `{}`   |
+
+### sparkOperator parameters
+
+| Name                           | Description                                | Value   |
+| ------------------------------ | ------------------------------------------ | ------- |
+| `sparkOperator.enabled`        | Flag to enable Spark Operator              | `false` |
+| `sparkOperator.tolerations`    | Tolerations for Spark Operator             | `[]`    |
+| `sparkOperator.affinity`       | Affinity for Spark Operator                | `{}`    |
+| `sparkOperator.valuesOverride` | Config override from default config values | `{}`    |
+
+### prometheus parameters
+
+| Name                                     | Description                                                               | Value  |
+| ---------------------------------------- | ------------------------------------------------------------------------- | ------ |
+| `prometheus.enabled`                     | Flag to enable Prometheus                                                 | `true` |
+| `prometheus.additionalScrapeConfigs`     | Additional scrape configs for Prometheus                                  | `[]`   |
+| `prometheus.alertmanager`                | Alertmanager configuration for Prometheus                                 | `{}`   |
+| `prometheus.affinity`                    | Affinity for prometheus statefulset pod                                   | `{}`   |
+| `prometheus.tolerations`                 | Tolerations for prometheus statefulset pod                                | `[]`   |
+| `prometheus.valuesOverride`              | Config override from default config values                                | `{}`   |
+| `prometheus.prometheusNodeExporter.port` | Port for prometheus-node-exporter service and container (default 9100)    | `9100` |
+| `prometheus.config.enabled`              | Flag to enable prometheus config (requires prometheus.enabled to be true) | `true` |
+| `prometheus.config.valuesOverride`       | Config override from default config values                                | `{}`   |
+| `prometheus.config.extraObjects`         | Extra objects for prometheus config                                       | `[]`   |
+
+### grafana parameters
+
+| Name                     | Description                                | Value   |
+| ------------------------ | ------------------------------------------ | ------- |
+| `grafana.enabled`        | Flag to enable Grafana                     | `false` |
+| `grafana.tolerations`    | Tolerations for Grafana                    | `[]`    |
+| `grafana.affinity`       | Affinity for Grafana                       | `{}`    |
+| `grafana.valuesOverride` | Config override from default config values | `{}`    |
+
+### tfyAgent parameters
+
+| Name                          | Description                                | Value  |
+| ----------------------------- | ------------------------------------------ | ------ |
+| `tfyAgent.enabled`            | Flag to enable Tfy Agent                   | `true` |
+| `tfyAgent.valuesOverride`     | Config override from default config values | `{}`   |
+| `tfyAgent.tolerations`        | Tolerations for the agent pods             | `[]`   |
+| `tfyAgent.affinity`           | Affinity for the agent pods                | `{}`   |
+| `tfyAgent.clusterToken`       | cluster token                              | `""`   |
+| `tfyAgent.clusterTokenSecret` | Secret name for cluster token              | `""`   |
+
+### elasti parameters
+
+| Name                    | Description                                | Value  |
+| ----------------------- | ------------------------------------------ | ------ |
+| `elasti.enabled`        | Flag to enable Elasti                      | `true` |
+| `elasti.tolerations`    | Tolerations for Elasti                     | `[]`   |
+| `elasti.affinity`       | Affinity for Elasti                        | `{}`   |
+| `elasti.valuesOverride` | Config override from default config values | `{}`   |
+
+### jspolicy parameters
+
+| Name                             | Description                                              | Value   |
+| -------------------------------- | -------------------------------------------------------- | ------- |
+| `jspolicy.enabled`               | Flag to enable jspolicy. No policy is applied by default | `false` |
+| `jspolicy.enabled`               | Flag to enable jspolicy                                  | `false` |
+| `jspolicy.valuesOverride`        | Config override from default config values               | `{}`    |
+| `jspolicy.affinity`              | Affinity for jspolicy                                    | `{}`    |
+| `jspolicy.tolerations`           | Tolerations for jspolicy                                 | `[]`    |
+| `jspolicy.config.valuesOverride` | Config override from default config values               | `{}`    |
+
+### tfy-workflow-propeller parameters
+
+| Name                                  | Description                                | Value   |
+| ------------------------------------- | ------------------------------------------ | ------- |
+| `tfyWorkflowPropeller.enabled`        | Flag to enable workflow-propeller.         | `false` |
+| `tfyWorkflowPropeller.valuesOverride` | Config override from default config values | `{}`    |
+| `helm.resourcePolicy`                 | Resource policy for the helm chart         | `keep`  |

--- a/charts/tfy-k8s-gcp-gke-standard-inframold/templates/truefoundry.yaml
+++ b/charts/tfy-k8s-gcp-gke-standard-inframold/templates/truefoundry.yaml
@@ -15,7 +15,7 @@ spec:
     server: https://kubernetes.default.svc
   project: tfy-apps
   source:
-    targetRevision: 0.155.2
+    targetRevision: 0.156.0
     repoURL: "tfy.jfrog.io/tfy-helm"
     chart: truefoundry
     helm:

--- a/charts/tfy-k8s-generic-inframold/Chart.yaml
+++ b/charts/tfy-k8s-generic-inframold/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: tfy-k8s-generic-inframold
-version: 0.1.308
+version: 0.1.309
 description: "Inframold, the superchart that configure your cluster on generic for truefoundry."
 maintainers:
   - name: truefoundry

--- a/charts/tfy-k8s-generic-inframold/README.md
+++ b/charts/tfy-k8s-generic-inframold/README.md
@@ -2,3 +2,247 @@
 Inframold, the superchart that configure your cluster on generic for truefoundry.
 
 ## Parameters
+
+### Global Parameters
+
+| Name               | Description                                                | Value |
+| ------------------ | ---------------------------------------------------------- | ----- |
+| `global.repoURL`   | Override chart repository URL for all Argo CD Applications | `""`  |
+| `tenantName`       | Parameters for tenantName                                  | `""`  |
+| `controlPlaneURL`  | Parameters for controlPlaneURL                             | `""`  |
+| `clusterName`      | Name of the cluster                                        | `""`  |
+| `registry`         | registry to override in the chart components               | `""`  |
+| `imagePullSecrets` | imagePullSecrets to override in the chart components       | `[]`  |
+| `tolerations`      | Tolerations for the all chart components                   | `[]`  |
+| `affinity`         | Affinity for the all chart components                      | `{}`  |
+
+### argocd parameters
+
+| Name                    | Description                                | Value  |
+| ----------------------- | ------------------------------------------ | ------ |
+| `argocd.enabled`        | Flag to enable ArgoCD                      | `true` |
+| `argocd.tolerations`    | Tolerations for ArgoCD                     | `[]`   |
+| `argocd.affinity`       | Affinity for ArgoCD                        | `{}`   |
+| `argocd.valuesOverride` | Config override from default config values | `{}`   |
+
+### argoWorkflows parameters
+
+| Name                           | Description                                | Value  |
+| ------------------------------ | ------------------------------------------ | ------ |
+| `argoWorkflows.enabled`        | Flag to enable Argo Workflows              | `true` |
+| `argoWorkflows.tolerations`    | Tolerations for Argo Workflows             | `[]`   |
+| `argoWorkflows.affinity`       | Affinity for Argo Workflows                | `{}`   |
+| `argoWorkflows.valuesOverride` | Config override from default config values | `{}`   |
+
+### argoRollouts parameters
+
+| Name                          | Description                                | Value  |
+| ----------------------------- | ------------------------------------------ | ------ |
+| `argoRollouts.enabled`        | Flag to enable Argo Rollouts               | `true` |
+| `argoRollouts.tolerations`    | Tolerations for Argo Rollouts              | `[]`   |
+| `argoRollouts.affinity`       | Affinity for Argo Rollouts                 | `{}`   |
+| `argoRollouts.valuesOverride` | Config override from default config values | `{}`   |
+
+### certManager parameters
+
+| Name                                     | Description                                                                       | Value  |
+| ---------------------------------------- | --------------------------------------------------------------------------------- | ------ |
+| `certManager.enabled`                    | Flag to enable Cert Manager                                                       | `true` |
+| `certManager.tolerations`                | Tolerations for Cert Manager                                                      | `[]`   |
+| `certManager.podLabels`                  | Pod labels for Cert Manager. For Azure will be applied to serviceaccount as well. | `{}`   |
+| `certManager.serviceAccount.annotations` | Service account annotations for Cert Manager.                                     | `{}`   |
+| `certManager.affinity`                   | Affinity for Cert Manager                                                         | `{}`   |
+| `certManager.valuesOverride`             | Config override from default config values                                        | `{}`   |
+
+### certManager issuers parameters
+
+| Name                                | Description                                        | Value  |
+| ----------------------------------- | -------------------------------------------------- | ------ |
+| `certManager.config.enabled`        | Flag to enable certManager config                  | `true` |
+| `certManager.config.issuers`        | Map of issuers and their certificate configuration | `{}`   |
+| `certManager.config.valuesOverride` | Config override from default config values         | `{}`   |
+
+### metricsServer parameters
+
+| Name                           | Description                                | Value   |
+| ------------------------------ | ------------------------------------------ | ------- |
+| `metricsServer.enabled`        | Flag to enable Metrics Server              | `false` |
+| `metricsServer.enabled`        | Flag to enable Metrics Server              | `false` |
+| `metricsServer.tolerations`    | Tolerations for Metrics Server             | `[]`    |
+| `metricsServer.affinity`       | Affinity for Metrics Server                | `{}`    |
+| `metricsServer.valuesOverride` | Config override from default config values | `{}`    |
+
+### gpu parameters
+
+| Name                 | Description                                | Value     |
+| -------------------- | ------------------------------------------ | --------- |
+| `gpu.enabled`        | Flag to enable Tfy GPU Operator            | `true`    |
+| `gpu.clusterType`    | Cluster type for Tfy GPU Operator          | `generic` |
+| `gpu.valuesOverride` | Config override from default config values | `{}`      |
+
+### truefoundry parameters
+
+| Name                          | Description                                | Value   |
+| ----------------------------- | ------------------------------------------ | ------- |
+| `truefoundry.enabled`         | Flag to enable TrueFoundry                 | `false` |
+| `truefoundry.devMode.enabled` | Flag to enable TrueFoundry Dev mode        | `false` |
+| `truefoundry.valuesOverride`  | Config override from default config values | `{}`    |
+
+### truefoundryBootstrap parameters
+
+| Name                                       | Description                                                               | Value  |
+| ------------------------------------------ | ------------------------------------------------------------------------- | ------ |
+| `truefoundry.truefoundryBootstrap.enabled` | Flag to enable bootstrap job to prep cluster for truefoundry installation | `true` |
+
+### Truefoundry virtual service parameters
+
+| Name                                         | Description                                        | Value   |
+| -------------------------------------------- | -------------------------------------------------- | ------- |
+| `truefoundry.virtualservice.enabled`         | Flag to enable virtualservice                      | `false` |
+| `truefoundry.virtualservice.hosts`           | Hosts for truefoundry virtualservice               | `[]`    |
+| `truefoundry.virtualservice.gateways`        | Istio gateways to be configured for virtualservice | `[]`    |
+| `truefoundry.virtualservice.annotations`     | Annotations for truefoundry virtualservice         | `{}`    |
+| `truefoundry.existingTruefoundryCredsSecret` | Secret name for existing Truefoundry creds         | `""`    |
+
+### database. Can be left empty if using the dev mode parameters
+
+| Name                                               | Description                                                | Value     |
+| -------------------------------------------------- | ---------------------------------------------------------- | --------- |
+| `truefoundry.database.host`                        | Hostname of the database                                   | `""`      |
+| `truefoundry.database.name`                        | Name of the database                                       | `""`      |
+| `truefoundry.database.username`                    | Username of the database                                   | `""`      |
+| `truefoundry.database.password`                    | Password of the database                                   | `""`      |
+| `truefoundry.tfyApiKey`                            | API Key for TrueFoundry                                    | `""`      |
+| `truefoundry.imagePullSecrets`                     | Image pull secrets for TrueFoundry                         | `[]`      |
+| `truefoundry.truefoundryImagePullConfigJSON`       | Json config for authenticating to the TrueFoundry registry | `""`      |
+| `truefoundry.truefoundry_iam_role_arn_annotations` | IAM role annotations for service accounts                  | `{}`      |
+| `truefoundry.defaultCloudProvider`                 | Default cloud provider                                     | `generic` |
+| `truefoundry.storageConfiguration`                 | Storage class for the storage configuration                | `{}`      |
+| `truefoundry.s3proxy.enabled`                      | Flag to enable S3 Proxy                                    | `false`   |
+| `truefoundry.sparkHistoryServer.enabled`           | Flag to enable Spark History Server                        | `false`   |
+| `truefoundry.tfyWorkflowAdmin.enabled`             | Flag to enable Tfy Workflow Admin                          | `false`   |
+| `truefoundry.gateway.enabled`                      | Flag to enable Gateway                                     | `false`   |
+| `truefoundry.tolerations`                          | Tolerations for the truefoundry components                 | `[]`      |
+| `truefoundry.affinity`                             | Affinity for the truefoundry components                    | `{}`      |
+
+### tfyLogs parameters
+
+| Name                     | Description                                | Value  |
+| ------------------------ | ------------------------------------------ | ------ |
+| `tfyLogs.enabled`        | Flag to enable Tfy Logs                    | `true` |
+| `tfyLogs.valuesOverride` | Config override from default config values | `{}`   |
+| `tfyLogs.affinity`       | Affinity for tfyLogs statefulset pod       | `{}`   |
+| `tfyLogs.tolerations`    | Tolerations for tfyLogs statefulset pod    | `[]`   |
+
+### istio parameters
+
+| Name                                    | Description                                | Value   |
+| --------------------------------------- | ------------------------------------------ | ------- |
+| `istio.enabled`                         | Flag to enable Istio                       | `true`  |
+| `istio.enabled`                         | Flag to enable Istio Base                  | `true`  |
+| `istio.base.valuesOverride`             | Config override from default config values | `{}`    |
+| `istio.awsElbControllerChecker.enabled` | Flag to enable AWS ELB Controller Checker  | `false` |
+| `istio.gateway.annotations`             | Annotations for Istio Gateway              | `{}`    |
+| `istio.gateway.affinity`                | Affinity for the gateway pods              | `{}`    |
+| `istio.gateway.tolerations`             | Tolerations for the gateway pods           | `[]`    |
+| `istio.gateway.valuesOverride`          | Config override from default config values | `{}`    |
+
+### istio discovery parameters
+
+| Name                             | Description                                | Value                  |
+| -------------------------------- | ------------------------------------------ | ---------------------- |
+| `istio.discovery.hub`            | Hub for the istio image                    | `gcr.io/istio-release` |
+| `istio.discovery.tolerations`    | Tolerations for Istio Discovery            | `[]`                   |
+| `istio.discovery.affinity`       | Affinity for Istio Discovery               | `{}`                   |
+| `istio.discovery.valuesOverride` | Config override from default config values | `{}`                   |
+
+### istio tfyGateway parameters
+
+| Name                                  | Description                                     | Value    |
+| ------------------------------------- | ----------------------------------------------- | -------- |
+| `istio.tfyGateway.httpsRedirect`      | Flag to enable HTTPS redirect for Istio Gateway | `false`  |
+| `istio.tfyGateway.tls.enabled`        | Flag to enable TLS for Istio Gateway            | `false`  |
+| `istio.tfyGateway.tls.mode`           | TLS mode for the Istio Gateway                  | `SIMPLE` |
+| `istio.tfyGateway.tls.credentialName` | Credential name for the TLS certificate         | `""`     |
+| `istio.tfyGateway.domains`            | Domains for the gateway pods                    | `[]`     |
+
+### keda parameters
+
+| Name                  | Description                                | Value  |
+| --------------------- | ------------------------------------------ | ------ |
+| `keda.enabled`        | Flag to enable Keda                        | `true` |
+| `keda.tolerations`    | Tolerations for Keda                       | `[]`   |
+| `keda.affinity`       | Affinity for Keda                          | `{}`   |
+| `keda.valuesOverride` | Config override from default config values | `{}`   |
+
+### sparkOperator parameters
+
+| Name                           | Description                                | Value   |
+| ------------------------------ | ------------------------------------------ | ------- |
+| `sparkOperator.enabled`        | Flag to enable Spark Operator              | `false` |
+| `sparkOperator.tolerations`    | Tolerations for Spark Operator             | `[]`    |
+| `sparkOperator.affinity`       | Affinity for Spark Operator                | `{}`    |
+| `sparkOperator.valuesOverride` | Config override from default config values | `{}`    |
+
+### prometheus parameters
+
+| Name                                     | Description                                                               | Value  |
+| ---------------------------------------- | ------------------------------------------------------------------------- | ------ |
+| `prometheus.enabled`                     | Flag to enable Prometheus                                                 | `true` |
+| `prometheus.additionalScrapeConfigs`     | Additional scrape configs for Prometheus                                  | `[]`   |
+| `prometheus.alertmanager`                | Alertmanager configuration for Prometheus                                 | `{}`   |
+| `prometheus.affinity`                    | Affinity for prometheus statefulset pod                                   | `{}`   |
+| `prometheus.tolerations`                 | Tolerations for prometheus statefulset pod                                | `[]`   |
+| `prometheus.valuesOverride`              | Config override from default config values                                | `{}`   |
+| `prometheus.prometheusNodeExporter.port` | Port for prometheus-node-exporter service and container (default 9100)    | `9100` |
+| `prometheus.config.enabled`              | Flag to enable prometheus config (requires prometheus.enabled to be true) | `true` |
+| `prometheus.config.valuesOverride`       | Config override from default config values                                | `{}`   |
+| `prometheus.config.extraObjects`         | Extra objects for prometheus config                                       | `[]`   |
+
+### grafana parameters
+
+| Name                     | Description                                | Value   |
+| ------------------------ | ------------------------------------------ | ------- |
+| `grafana.enabled`        | Flag to enable Grafana                     | `false` |
+| `grafana.tolerations`    | Tolerations for Grafana                    | `[]`    |
+| `grafana.affinity`       | Affinity for Grafana                       | `{}`    |
+| `grafana.valuesOverride` | Config override from default config values | `{}`    |
+
+### tfyAgent parameters
+
+| Name                          | Description                                | Value  |
+| ----------------------------- | ------------------------------------------ | ------ |
+| `tfyAgent.enabled`            | Flag to enable Tfy Agent                   | `true` |
+| `tfyAgent.valuesOverride`     | Config override from default config values | `{}`   |
+| `tfyAgent.tolerations`        | Tolerations for the agent pods             | `[]`   |
+| `tfyAgent.affinity`           | Affinity for the agent pods                | `{}`   |
+| `tfyAgent.clusterToken`       | cluster token                              | `""`   |
+| `tfyAgent.clusterTokenSecret` | Secret name for cluster token              | `""`   |
+
+### elasti parameters
+
+| Name                    | Description                                | Value  |
+| ----------------------- | ------------------------------------------ | ------ |
+| `elasti.enabled`        | Flag to enable Elasti                      | `true` |
+| `elasti.tolerations`    | Tolerations for Elasti                     | `[]`   |
+| `elasti.affinity`       | Affinity for Elasti                        | `{}`   |
+| `elasti.valuesOverride` | Config override from default config values | `{}`   |
+
+### jspolicy parameters
+
+| Name                             | Description                                              | Value   |
+| -------------------------------- | -------------------------------------------------------- | ------- |
+| `jspolicy.enabled`               | Flag to enable jspolicy. No policy is applied by default | `false` |
+| `jspolicy.enabled`               | Flag to enable jspolicy                                  | `false` |
+| `jspolicy.valuesOverride`        | Config override from default config values               | `{}`    |
+| `jspolicy.affinity`              | Affinity for jspolicy                                    | `{}`    |
+| `jspolicy.tolerations`           | Tolerations for jspolicy                                 | `[]`    |
+| `jspolicy.config.valuesOverride` | Config override from default config values               | `{}`    |
+
+### tfy-workflow-propeller parameters
+
+| Name                                  | Description                                | Value   |
+| ------------------------------------- | ------------------------------------------ | ------- |
+| `tfyWorkflowPropeller.enabled`        | Flag to enable workflow-propeller.         | `false` |
+| `tfyWorkflowPropeller.valuesOverride` | Config override from default config values | `{}`    |
+| `helm.resourcePolicy`                 | Resource policy for the helm chart         | `keep`  |

--- a/charts/tfy-k8s-generic-inframold/templates/truefoundry.yaml
+++ b/charts/tfy-k8s-generic-inframold/templates/truefoundry.yaml
@@ -15,7 +15,7 @@ spec:
     server: https://kubernetes.default.svc
   project: tfy-apps
   source:
-    targetRevision: 0.155.2
+    targetRevision: 0.156.0
     repoURL: "tfy.jfrog.io/tfy-helm"
     chart: truefoundry
     helm:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Argo sync will change EC2/EBS tagging and Karpenter EC2NodeClass specs when `tags` is set, and the TrueFoundry chart bump may alter control-plane behavior on upgrade.
> 
> **Overview**
> **Inframold 0.1.309** bumps all platform supercharts from **0.1.308 → 0.1.309** and refreshes README parameter tables (including the new AWS-only **`tags`** knob on EKS).
> 
> On **AWS EKS**, a top-level **`tags`** map (default `{}`) propagates custom key/value pairs to **Karpenter** node templates (`extraTags` on default, GPU, inferentia, critical, and control-plane pools) and to the **EBS CSI** controller **`extraVolumeTags`** for newly provisioned volumes. The EBS driver also adds **`truefoundry-cluster-name`** and **`truefoundry-managed`** alongside existing cluster tags. **Karpenter config** Argo app revision moves **0.1.54 → 0.1.57**, with template guards relaxed so inferentia/control-plane blocks render when only **`tags`** (not just KMS) are set.
> 
> Every inframold variant that ships the TrueFoundry Argo Application pins **`truefoundry`** chart **0.155.2 → 0.156.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7df4473751ba051094452bdbaabcae2ad5fe26da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->