### PR TITLE
fix: guard karpenter node templates against YAML null (backport to main)

### DIFF
--- a/charts/tfy-k8s-aws-eks-inframold/README.md
+++ b/charts/tfy-k8s-aws-eks-inframold/README.md
@@ -2,3 +2,291 @@
 Inframold, the superchart that configure your cluster on aws for truefoundry.
 
 ## Parameters
+
+### Global Parameters
+
+| Name               | Description                                                                                           | Value |
+| ------------------ | ----------------------------------------------------------------------------------------------------- | ----- |
+| `global.repoURL`   | Override chart repository URL for all Argo CD Applications                                            | `""`  |
+| `tenantName`       | Parameters for tenantName                                                                             | `""`  |
+| `controlPlaneURL`  | Parameters for controlPlaneURL                                                                        | `""`  |
+| `clusterName`      | Name of the cluster                                                                                   | `""`  |
+| `tags`             | AWS resource tags applied to Karpenter-launched EC2 nodes and dynamically-provisioned EBS PVC volumes | `{}`  |
+| `registry`         | registry to override in the chart components                                                          | `""`  |
+| `imagePullSecrets` | imagePullSecrets to override in the chart components                                                  | `[]`  |
+| `tolerations`      | Tolerations for the all chart components                                                              | `[]`  |
+| `affinity`         | Affinity for the all chart components                                                                 | `{}`  |
+
+### argocd parameters
+
+| Name                    | Description                                | Value  |
+| ----------------------- | ------------------------------------------ | ------ |
+| `argocd.enabled`        | Flag to enable ArgoCD                      | `true` |
+| `argocd.tolerations`    | Tolerations for ArgoCD                     | `[]`   |
+| `argocd.affinity`       | Affinity for ArgoCD                        | `{}`   |
+| `argocd.valuesOverride` | Config override from default config values | `{}`   |
+
+### argoWorkflows parameters
+
+| Name                           | Description                                | Value  |
+| ------------------------------ | ------------------------------------------ | ------ |
+| `argoWorkflows.enabled`        | Flag to enable Argo Workflows              | `true` |
+| `argoWorkflows.tolerations`    | Tolerations for Argo Workflows             | `[]`   |
+| `argoWorkflows.affinity`       | Affinity for Argo Workflows                | `{}`   |
+| `argoWorkflows.valuesOverride` | Config override from default config values | `{}`   |
+
+### argoRollouts parameters
+
+| Name                          | Description                                | Value  |
+| ----------------------------- | ------------------------------------------ | ------ |
+| `argoRollouts.enabled`        | Flag to enable Argo Rollouts               | `true` |
+| `argoRollouts.tolerations`    | Tolerations for Argo Rollouts              | `[]`   |
+| `argoRollouts.affinity`       | Affinity for Argo Rollouts                 | `{}`   |
+| `argoRollouts.valuesOverride` | Config override from default config values | `{}`   |
+
+### certManager parameters
+
+| Name                                     | Description                                                                       | Value   |
+| ---------------------------------------- | --------------------------------------------------------------------------------- | ------- |
+| `certManager.enabled`                    | Flag to enable Cert Manager                                                       | `false` |
+| `certManager.tolerations`                | Tolerations for Cert Manager                                                      | `[]`    |
+| `certManager.podLabels`                  | Pod labels for Cert Manager. For Azure will be applied to serviceaccount as well. | `{}`    |
+| `certManager.serviceAccount.annotations` | Service account annotations for Cert Manager.                                     | `{}`    |
+| `certManager.affinity`                   | Affinity for Cert Manager                                                         | `{}`    |
+| `certManager.valuesOverride`             | Config override from default config values                                        | `{}`    |
+
+### certManager issuers parameters
+
+| Name                                | Description                                        | Value  |
+| ----------------------------------- | -------------------------------------------------- | ------ |
+| `certManager.config.enabled`        | Flag to enable certManager config                  | `true` |
+| `certManager.config.issuers`        | Map of issuers and their certificate configuration | `{}`   |
+| `certManager.config.valuesOverride` | Config override from default config values         | `{}`   |
+
+### metricsServer parameters
+
+| Name                           | Description                                | Value  |
+| ------------------------------ | ------------------------------------------ | ------ |
+| `metricsServer.enabled`        | Flag to enable Metrics Server              | `true` |
+| `metricsServer.enabled`        | Flag to enable Metrics Server              | `true` |
+| `metricsServer.tolerations`    | Tolerations for Metrics Server             | `[]`   |
+| `metricsServer.affinity`       | Affinity for Metrics Server                | `{}`   |
+| `metricsServer.valuesOverride` | Config override from default config values | `{}`   |
+
+### AWS parameters
+
+| Name                                           | Description                                 | Value   |
+| ---------------------------------------------- | ------------------------------------------- | ------- |
+| `aws.awsLoadBalancerController.enabled`        | Flag to enable AWS Load Balancer Controller | `true`  |
+| `aws.awsLoadBalancerController.roleArn`        | Role ARN for AWS Load Balancer Controller   | `""`    |
+| `aws.awsLoadBalancerController.vpcId`          | VPC ID of AWS EKS cluster                   | `""`    |
+| `aws.awsLoadBalancerController.region`         | region of AWS EKS cluster                   | `""`    |
+| `aws.awsLoadBalancerController.affinity`       | Affinity for AWS LoadBalancer               | `{}`    |
+| `aws.awsLoadBalancerController.tolerations`    | Tolerations for AWS LoadBalancer            | `[]`    |
+| `aws.awsLoadBalancerController.valuesOverride` | Config override from default config values  | `{}`    |
+| `aws.karpenter.enabled`                        | Flag to enable Karpenter                    | `true`  |
+| `aws.karpenter.clusterEndpoint`                | Cluster endpoint for Karpenter              | `""`    |
+| `aws.karpenter.roleArn`                        | Role ARN for Karpenter                      | `""`    |
+| `aws.karpenter.instanceProfile`                | Instance profile for Karpenter              | `""`    |
+| `aws.karpenter.defaultZones`                   | Default zones list for Karpenter            | `[]`    |
+| `aws.karpenter.affinity`                       | Affinity for Karpenter                      | `{}`    |
+| `aws.karpenter.tolerations`                    | Tolerations for Karpenter                   | `[]`    |
+| `aws.karpenter.kmsKeyID`                       | KMS Key ID for Karpenter                    | `""`    |
+| `aws.karpenter.interruptionQueue`              | Interruption queue name for Karpenter       | `""`    |
+| `aws.karpenter.valuesOverride`                 | Config override from default config values  | `{}`    |
+| `aws.karpenter.config.enabled`                 | Flag to enable karpenter config             | `true`  |
+| `aws.karpenter.config.valuesOverride`          | Config override for karpenter config        | `{}`    |
+| `aws.awsEbsCsiDriver.enabled`                  | Flag to enable AWS EBS CSI Driver           | `true`  |
+| `aws.awsEbsCsiDriver.roleArn`                  | Role ARN for AWS EBS CSI Driver             | `""`    |
+| `aws.awsEbsCsiDriver.affinity`                 | Affinity for AWS EBS CSI Driver             | `{}`    |
+| `aws.awsEbsCsiDriver.tolerations`              | Tolerations for AWS EBS CSI Driver          | `[]`    |
+| `aws.awsEbsCsiDriver.kmsKeyID`                 | KMS Key ID for AWS EBS CSI Driver           | `""`    |
+| `aws.awsEbsCsiDriver.valuesOverride`           | Config override from default config values  | `{}`    |
+| `aws.awsEfsCsiDriver.enabled`                  | Flag to enable AWS EFS CSI Driver           | `true`  |
+| `aws.awsEfsCsiDriver.fileSystemId`             | File system ID for AWS EFS CSI Driver       | `""`    |
+| `aws.awsEfsCsiDriver.roleArn`                  | Role ARN for AWS EFS CSI Driver             | `""`    |
+| `aws.awsEfsCsiDriver.affinity`                 | Affinity for AWS EFS CSI Driver             | `{}`    |
+| `aws.awsEfsCsiDriver.tolerations`              | Tolerations for AWS EFS CSI Driver          | `[]`    |
+| `aws.awsEfsCsiDriver.valuesOverride`           | Config override from default config values  | `{}`    |
+| `aws.inferentia.enabled`                       | Flag to enable Inferentia                   | `false` |
+| `aws.inferentia.affinity`                      | Affinity for AWS EFS CSI Driver             | `{}`    |
+| `aws.inferentia.tolerations`                   | Tolerations for AWS EFS CSI Driver          | `[]`    |
+| `aws.inferentia.valuesOverride`                | Config override from default config values  | `{}`    |
+
+### gpu parameters
+
+| Name                 | Description                                | Value    |
+| -------------------- | ------------------------------------------ | -------- |
+| `gpu.enabled`        | Flag to enable Tfy GPU Operator            | `true`   |
+| `gpu.clusterType`    | Cluster type for Tfy GPU Operator          | `awsEks` |
+| `gpu.valuesOverride` | Config override from default config values | `{}`     |
+
+### truefoundry parameters
+
+| Name                          | Description                                | Value   |
+| ----------------------------- | ------------------------------------------ | ------- |
+| `truefoundry.enabled`         | Flag to enable TrueFoundry                 | `false` |
+| `truefoundry.devMode.enabled` | Flag to enable TrueFoundry Dev mode        | `false` |
+| `truefoundry.valuesOverride`  | Config override from default config values | `{}`    |
+
+### truefoundryBootstrap parameters
+
+| Name                                       | Description                                                               | Value  |
+| ------------------------------------------ | ------------------------------------------------------------------------- | ------ |
+| `truefoundry.truefoundryBootstrap.enabled` | Flag to enable bootstrap job to prep cluster for truefoundry installation | `true` |
+
+### Truefoundry virtual service parameters
+
+| Name                                         | Description                                        | Value   |
+| -------------------------------------------- | -------------------------------------------------- | ------- |
+| `truefoundry.virtualservice.enabled`         | Flag to enable virtualservice                      | `false` |
+| `truefoundry.virtualservice.hosts`           | Hosts for truefoundry virtualservice               | `[]`    |
+| `truefoundry.virtualservice.gateways`        | Istio gateways to be configured for virtualservice | `[]`    |
+| `truefoundry.virtualservice.annotations`     | Annotations for truefoundry virtualservice         | `{}`    |
+| `truefoundry.existingTruefoundryCredsSecret` | Secret name for existing Truefoundry creds         | `""`    |
+
+### database. Can be left empty if using the dev mode parameters
+
+| Name                                                | Description                                                | Value   |
+| --------------------------------------------------- | ---------------------------------------------------------- | ------- |
+| `truefoundry.database.host`                         | Hostname of the database                                   | `""`    |
+| `truefoundry.database.name`                         | Name of the database                                       | `""`    |
+| `truefoundry.database.username`                     | Username of the database                                   | `""`    |
+| `truefoundry.database.password`                     | Password of the database                                   | `""`    |
+| `truefoundry.tfyApiKey`                             | API Key for TrueFoundry                                    | `""`    |
+| `truefoundry.imagePullSecrets`                      | Image pull secrets for TrueFoundry                         | `[]`    |
+| `truefoundry.truefoundryImagePullConfigJSON`        | Json config for authenticating to the TrueFoundry registry | `""`    |
+| `truefoundry.truefoundry_iam_role_arn_annotations`  | IAM role annotations for service accounts                  | `{}`    |
+| `truefoundry.defaultCloudProvider`                  | Default cloud provider                                     | `aws`   |
+| `truefoundry.storageConfiguration.awsS3BucketName`  | AWS S3 bucket name                                         | `""`    |
+| `truefoundry.storageConfiguration.awsRegion`        | AWS region                                                 | `""`    |
+| `truefoundry.storageConfiguration.awsAssumeRoleArn` | AWS assume role ARN                                        | `""`    |
+| `truefoundry.s3proxy.enabled`                       | Flag to enable S3 Proxy                                    | `false` |
+| `truefoundry.sparkHistoryServer.enabled`            | Flag to enable Spark History Server                        | `false` |
+| `truefoundry.tfyWorkflowAdmin.enabled`              | Flag to enable Tfy Workflow Admin                          | `false` |
+| `truefoundry.gateway.enabled`                       | Flag to enable Gateway                                     | `false` |
+| `truefoundry.tolerations`                           | Tolerations for the truefoundry components                 | `[]`    |
+| `truefoundry.affinity`                              | Affinity for the truefoundry components                    | `{}`    |
+
+### tfyLogs parameters
+
+| Name                     | Description                                | Value  |
+| ------------------------ | ------------------------------------------ | ------ |
+| `tfyLogs.enabled`        | Flag to enable Tfy Logs                    | `true` |
+| `tfyLogs.valuesOverride` | Config override from default config values | `{}`   |
+| `tfyLogs.affinity`       | Affinity for tfyLogs statefulset pod       | `{}`   |
+| `tfyLogs.tolerations`    | Tolerations for tfyLogs statefulset pod    | `[]`   |
+
+### istio parameters
+
+| Name                                    | Description                                | Value  |
+| --------------------------------------- | ------------------------------------------ | ------ |
+| `istio.enabled`                         | Flag to enable Istio                       | `true` |
+| `istio.enabled`                         | Flag to enable Istio Base                  | `true` |
+| `istio.base.valuesOverride`             | Config override from default config values | `{}`   |
+| `istio.awsElbControllerChecker.enabled` | Flag to enable AWS ELB Controller Checker  | `true` |
+| `istio.gateway.annotations`             | Annotations for Istio Gateway              | `{}`   |
+| `istio.gateway.affinity`                | Affinity for the gateway pods              | `{}`   |
+| `istio.gateway.tolerations`             | Tolerations for the gateway pods           | `[]`   |
+| `istio.gateway.valuesOverride`          | Config override from default config values | `{}`   |
+
+### istio discovery parameters
+
+| Name                             | Description                                | Value                  |
+| -------------------------------- | ------------------------------------------ | ---------------------- |
+| `istio.discovery.hub`            | Hub for the istio image                    | `gcr.io/istio-release` |
+| `istio.discovery.tolerations`    | Tolerations for Istio Discovery            | `[]`                   |
+| `istio.discovery.affinity`       | Affinity for Istio Discovery               | `{}`                   |
+| `istio.discovery.valuesOverride` | Config override from default config values | `{}`                   |
+
+### istio tfyGateway parameters
+
+| Name                                  | Description                                     | Value    |
+| ------------------------------------- | ----------------------------------------------- | -------- |
+| `istio.tfyGateway.httpsRedirect`      | Flag to enable HTTPS redirect for Istio Gateway | `true`   |
+| `istio.tfyGateway.tls.enabled`        | Flag to enable TLS for Istio Gateway            | `false`  |
+| `istio.tfyGateway.tls.mode`           | TLS mode for the Istio Gateway                  | `SIMPLE` |
+| `istio.tfyGateway.tls.credentialName` | Credential name for the TLS certificate         | `""`     |
+| `istio.tfyGateway.domains`            | Domains for the gateway pods                    | `[]`     |
+
+### keda parameters
+
+| Name                  | Description                                | Value  |
+| --------------------- | ------------------------------------------ | ------ |
+| `keda.enabled`        | Flag to enable Keda                        | `true` |
+| `keda.tolerations`    | Tolerations for Keda                       | `[]`   |
+| `keda.affinity`       | Affinity for Keda                          | `{}`   |
+| `keda.valuesOverride` | Config override from default config values | `{}`   |
+
+### sparkOperator parameters
+
+| Name                           | Description                                | Value   |
+| ------------------------------ | ------------------------------------------ | ------- |
+| `sparkOperator.enabled`        | Flag to enable Spark Operator              | `false` |
+| `sparkOperator.tolerations`    | Tolerations for Spark Operator             | `[]`    |
+| `sparkOperator.affinity`       | Affinity for Spark Operator                | `{}`    |
+| `sparkOperator.valuesOverride` | Config override from default config values | `{}`    |
+
+### prometheus parameters
+
+| Name                                     | Description                                                               | Value  |
+| ---------------------------------------- | ------------------------------------------------------------------------- | ------ |
+| `prometheus.enabled`                     | Flag to enable Prometheus                                                 | `true` |
+| `prometheus.additionalScrapeConfigs`     | Additional scrape configs for Prometheus                                  | `[]`   |
+| `prometheus.alertmanager`                | Alertmanager configuration for Prometheus                                 | `{}`   |
+| `prometheus.affinity`                    | Affinity for prometheus statefulset pod                                   | `{}`   |
+| `prometheus.tolerations`                 | Tolerations for prometheus statefulset pod                                | `[]`   |
+| `prometheus.valuesOverride`              | Config override from default config values                                | `{}`   |
+| `prometheus.prometheusNodeExporter.port` | Port for prometheus-node-exporter service and container (default 9100)    | `9100` |
+| `prometheus.config.enabled`              | Flag to enable prometheus config (requires prometheus.enabled to be true) | `true` |
+| `prometheus.config.valuesOverride`       | Config override from default config values                                | `{}`   |
+| `prometheus.config.extraObjects`         | Extra objects for prometheus config                                       | `[]`   |
+
+### grafana parameters
+
+| Name                     | Description                                | Value   |
+| ------------------------ | ------------------------------------------ | ------- |
+| `grafana.enabled`        | Flag to enable Grafana                     | `false` |
+| `grafana.tolerations`    | Tolerations for Grafana                    | `[]`    |
+| `grafana.affinity`       | Affinity for Grafana                       | `{}`    |
+| `grafana.valuesOverride` | Config override from default config values | `{}`    |
+
+### tfyAgent parameters
+
+| Name                          | Description                                | Value  |
+| ----------------------------- | ------------------------------------------ | ------ |
+| `tfyAgent.enabled`            | Flag to enable Tfy Agent                   | `true` |
+| `tfyAgent.valuesOverride`     | Config override from default config values | `{}`   |
+| `tfyAgent.tolerations`        | Tolerations for the agent pods             | `[]`   |
+| `tfyAgent.affinity`           | Affinity for the agent pods                | `{}`   |
+| `tfyAgent.clusterToken`       | cluster token                              | `""`   |
+| `tfyAgent.clusterTokenSecret` | Secret name for cluster token              | `""`   |
+
+### elasti parameters
+
+| Name                    | Description                                | Value  |
+| ----------------------- | ------------------------------------------ | ------ |
+| `elasti.enabled`        | Flag to enable Elasti                      | `true` |
+| `elasti.tolerations`    | Tolerations for Elasti                     | `[]`   |
+| `elasti.affinity`       | Affinity for Elasti                        | `{}`   |
+| `elasti.valuesOverride` | Config override from default config values | `{}`   |
+
+### jspolicy parameters
+
+| Name                             | Description                                              | Value   |
+| -------------------------------- | -------------------------------------------------------- | ------- |
+| `jspolicy.enabled`               | Flag to enable jspolicy. No policy is applied by default | `false` |
+| `jspolicy.enabled`               | Flag to enable jspolicy                                  | `false` |
+| `jspolicy.valuesOverride`        | Config override from default config values               | `{}`    |
+| `jspolicy.affinity`              | Affinity for jspolicy                                    | `{}`    |
+| `jspolicy.tolerations`           | Tolerations for jspolicy                                 | `[]`    |
+| `jspolicy.config.valuesOverride` | Config override from default config values               | `{}`    |
+
+### tfy-workflow-propeller parameters
+
+| Name                                        | Description                                | Value   |
+| ------------------------------------------- | ------------------------------------------ | ------- |
+| `tfyWorkflowPropeller.enabled`              | Flag to enable workflow-propeller.         | `false` |
+| `tfyWorkflowPropeller.valuesOverride`       | Config override from default config values | `{}`    |
+| `tfyWorkflowPropeller.flyteCore.flyteadmin` | Flyteadmin configuration for flyteCore     | `{}`    |
+| `helm.resourcePolicy`                       | Resource policy for the helm chart         | `keep`  |

--- a/charts/tfy-k8s-aws-eks-inframold/artifacts-manifest.json
+++ b/charts/tfy-k8s-aws-eks-inframold/artifacts-manifest.json
@@ -174,7 +174,7 @@
         "details": {
             "chart": "tfy-karpenter-config",
             "repoURL": "https://truefoundry.github.io/infra-charts/",
-            "targetRevision": "0.1.54",
+            "targetRevision": "0.1.57",
             "images": []
         }
     },
@@ -256,28 +256,29 @@
         "details": {
             "chart": "truefoundry",
             "repoURL": "oci://tfy.jfrog.io/tfy-helm",
-            "targetRevision": "0.154.0",
+            "targetRevision": "0.156.0",
             "images": [
-                "tfy.jfrog.io/tfy-private-images/tfy-llm-gateway:v0.154.0",
-                "tfy.jfrog.io/tfy-private-images/tfy-otel-collector:v0.151.0",
+                "tfy.jfrog.io/tfy-images/tfy-sandbox-server:v0.3.1",
+                "tfy.jfrog.io/tfy-private-images/tfy-llm-gateway:v0.156.0",
+                "tfy.jfrog.io/tfy-private-images/tfy-otel-collector:v0.156.0",
                 "tfy.jfrog.io/tfy-private-images/deltafusion-query-server:v0.151.0-optimized",
                 "tfy.jfrog.io/tfy-private-images/deltafusion-query-server:v0.151.0",
-                "tfy.jfrog.io/tfy-private-images/mlfoundry-server:v0.154.0",
+                "tfy.jfrog.io/tfy-private-images/mlfoundry-server:v0.155.0",
                 "tfy.jfrog.io/tfy-private-images/s3proxy:v0.149.0",
-                "tfy.jfrog.io/tfy-private-images/servicefoundry-server:v0.154.0",
+                "tfy.jfrog.io/tfy-private-images/servicefoundry-server:v0.156.0",
                 "tfy.jfrog.io/tfy-private-images/sfy-manifest-service:v0.148.0",
                 "tfy.jfrog.io/tfy-private-images/spark-history-server:v0.150.0",
                 "tfy.jfrog.io/tfy-private-images/tfy-controller:v0.150.0",
-                "tfy.jfrog.io/tfy-private-images/tfy-k8s-controller:v0.154.0",
-                "tfy.jfrog.io/tfy-private-images/tfy-proxy:v0.154.0",
+                "tfy.jfrog.io/tfy-private-images/tfy-k8s-controller:v0.156.0",
+                "tfy.jfrog.io/tfy-private-images/tfy-proxy:v0.156.0",
                 "tfy.jfrog.io/tfy-private-images/tfy-workflow-admin:v0.150.0",
                 "tfy.jfrog.io/tfy-images/postgresql:16.6.0-debian-12-r2",
                 "tfy.jfrog.io/tfy-mirror/bitnamilegacy/redis:8.2.1-debian-12-r0",
                 "tfy.jfrog.io/tfy-mirror/nats:2.12.6-alpine",
                 "tfy.jfrog.io/tfy-mirror/natsio/nats-server-config-reloader:0.23.0",
                 "tfy.jfrog.io/tfy-mirror/natsio/prometheus-nats-exporter:0.18.0",
-                "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.154.0-optimized",
-                "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.154.0",
+                "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.155.0-optimized",
+                "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.155.0",
                 "tfy.jfrog.io/tfy-mirror/moby/buildkit:v0.26.2",
                 "tfy.jfrog.io/tfy-images/truefoundry-bootstrap:0.1.6"
             ]
@@ -1287,7 +1288,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-llm-gateway:v0.154.0",
+            "registryURL": "tfy.jfrog.io/tfy-images/tfy-sandbox-server:v0.3.1",
             "platforms": [
                 {
                     "os": "linux",
@@ -1303,7 +1304,23 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-otel-collector:v0.151.0",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-llm-gateway:v0.156.0",
+            "platforms": [
+                {
+                    "os": "linux",
+                    "architecture": "amd64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm64"
+                }
+            ]
+        }
+    },
+    {
+        "type": "image",
+        "details": {
+            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-otel-collector:v0.156.0",
             "platforms": [
                 {
                     "os": "linux",
@@ -1351,7 +1368,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/mlfoundry-server:v0.154.0",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/mlfoundry-server:v0.155.0",
             "platforms": [
                 {
                     "os": "linux",
@@ -1383,7 +1400,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/servicefoundry-server:v0.154.0",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/servicefoundry-server:v0.156.0",
             "platforms": [
                 {
                     "os": "linux",
@@ -1447,7 +1464,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-k8s-controller:v0.154.0",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-k8s-controller:v0.156.0",
             "platforms": [
                 {
                     "os": "linux",
@@ -1463,7 +1480,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-proxy:v0.154.0",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-proxy:v0.156.0",
             "platforms": [
                 {
                     "os": "linux",
@@ -1607,7 +1624,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.154.0-optimized",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.155.0-optimized",
             "platforms": [
                 {
                     "os": "linux",
@@ -1619,7 +1636,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.154.0",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.155.0",
             "platforms": [
                 {
                     "os": "linux",

--- a/charts/tfy-k8s-aws-eks-inframold/templates/tfy-aws/karpenter-config.yaml
+++ b/charts/tfy-k8s-aws-eks-inframold/templates/tfy-aws/karpenter-config.yaml
@@ -79,6 +79,7 @@ spec:
             zones: {{- range .Values.aws.karpenter.defaultZones }}
             - {{ . | quote }}
             {{- end }}
+            {{- if or .Values.aws.karpenter.kmsKeyID .Values.tags }}
             nodeclass:
               {{- if .Values.aws.karpenter.kmsKeyID }}
               kmsKeyID: {{ .Values.aws.karpenter.kmsKeyID | default "" }}
@@ -89,6 +90,7 @@ spec:
                 {{ $k }}: {{ $v | quote }}
                 {{- end }}
               {{- end }}
+            {{- end }}
           controlPlaneNodePool:
             zones: {{- range .Values.aws.karpenter.defaultZones }}
             - {{ . | quote }}

--- a/charts/tfy-k8s-aws-eks-inframold/templates/tfy-aws/karpenter-config.yaml
+++ b/charts/tfy-k8s-aws-eks-inframold/templates/tfy-aws/karpenter-config.yaml
@@ -63,6 +63,7 @@ spec:
             zones: {{- range .Values.aws.karpenter.defaultZones }}
             - {{ . | quote }}
             {{- end }}
+          {{- if or .Values.aws.karpenter.kmsKeyID .Values.tags }}
           inferentiaDefaultNodeTemplate:
             {{- if .Values.aws.karpenter.kmsKeyID }}
             kmsKeyID: {{ .Values.aws.karpenter.kmsKeyID | default "" }}
@@ -73,6 +74,7 @@ spec:
               {{ $k }}: {{ $v | quote }}
               {{- end }}
             {{- end }}
+          {{- end }}
           critical:
             zones: {{- range .Values.aws.karpenter.defaultZones }}
             - {{ . | quote }}
@@ -91,6 +93,7 @@ spec:
             zones: {{- range .Values.aws.karpenter.defaultZones }}
             - {{ . | quote }}
             {{- end }}
+          {{- if or .Values.aws.karpenter.kmsKeyID .Values.tags }}
           controlPlaneNodeTemplate:
             {{- if .Values.aws.karpenter.kmsKeyID }}
             kmsKeyID: {{ .Values.aws.karpenter.kmsKeyID | default "" }}
@@ -101,6 +104,7 @@ spec:
               {{ $k }}: {{ $v | quote }}
               {{- end }}
             {{- end }}
+          {{- end }}
         {{- end }}
   project: tfy-apps
   syncPolicy:

--- a/charts/tfy-k8s-azure-aks-inframold/README.md
+++ b/charts/tfy-k8s-azure-aks-inframold/README.md
@@ -2,3 +2,248 @@
 Inframold, the superchart that configure your cluster on azure for truefoundry.
 
 ## Parameters
+
+### Global Parameters
+
+| Name               | Description                                                | Value |
+| ------------------ | ---------------------------------------------------------- | ----- |
+| `global.repoURL`   | Override chart repository URL for all Argo CD Applications | `""`  |
+| `tenantName`       | Parameters for tenantName                                  | `""`  |
+| `controlPlaneURL`  | Parameters for controlPlaneURL                             | `""`  |
+| `clusterName`      | Name of the cluster                                        | `""`  |
+| `registry`         | registry to override in the chart components               | `""`  |
+| `imagePullSecrets` | imagePullSecrets to override in the chart components       | `[]`  |
+| `tolerations`      | Tolerations for the all chart components                   | `[]`  |
+| `affinity`         | Affinity for the all chart components                      | `{}`  |
+
+### argocd parameters
+
+| Name                    | Description                                | Value  |
+| ----------------------- | ------------------------------------------ | ------ |
+| `argocd.enabled`        | Flag to enable ArgoCD                      | `true` |
+| `argocd.tolerations`    | Tolerations for ArgoCD                     | `[]`   |
+| `argocd.affinity`       | Affinity for ArgoCD                        | `{}`   |
+| `argocd.valuesOverride` | Config override from default config values | `{}`   |
+
+### argoWorkflows parameters
+
+| Name                           | Description                                | Value  |
+| ------------------------------ | ------------------------------------------ | ------ |
+| `argoWorkflows.enabled`        | Flag to enable Argo Workflows              | `true` |
+| `argoWorkflows.tolerations`    | Tolerations for Argo Workflows             | `[]`   |
+| `argoWorkflows.affinity`       | Affinity for Argo Workflows                | `{}`   |
+| `argoWorkflows.valuesOverride` | Config override from default config values | `{}`   |
+
+### argoRollouts parameters
+
+| Name                          | Description                                | Value  |
+| ----------------------------- | ------------------------------------------ | ------ |
+| `argoRollouts.enabled`        | Flag to enable Argo Rollouts               | `true` |
+| `argoRollouts.tolerations`    | Tolerations for Argo Rollouts              | `[]`   |
+| `argoRollouts.affinity`       | Affinity for Argo Rollouts                 | `{}`   |
+| `argoRollouts.valuesOverride` | Config override from default config values | `{}`   |
+
+### certManager parameters
+
+| Name                                     | Description                                                                       | Value  |
+| ---------------------------------------- | --------------------------------------------------------------------------------- | ------ |
+| `certManager.enabled`                    | Flag to enable Cert Manager                                                       | `true` |
+| `certManager.tolerations`                | Tolerations for Cert Manager                                                      | `[]`   |
+| `certManager.podLabels`                  | Pod labels for Cert Manager. For Azure will be applied to serviceaccount as well. | `{}`   |
+| `certManager.serviceAccount.annotations` | Service account annotations for Cert Manager.                                     | `{}`   |
+| `certManager.affinity`                   | Affinity for Cert Manager                                                         | `{}`   |
+| `certManager.valuesOverride`             | Config override from default config values                                        | `{}`   |
+
+### certManager issuers parameters
+
+| Name                                | Description                                        | Value  |
+| ----------------------------------- | -------------------------------------------------- | ------ |
+| `certManager.config.enabled`        | Flag to enable certManager config                  | `true` |
+| `certManager.config.issuers`        | Map of issuers and their certificate configuration | `{}`   |
+| `certManager.config.valuesOverride` | Config override from default config values         | `{}`   |
+
+### metricsServer parameters
+
+| Name                           | Description                                | Value   |
+| ------------------------------ | ------------------------------------------ | ------- |
+| `metricsServer.enabled`        | Flag to enable Metrics Server              | `false` |
+| `metricsServer.enabled`        | Flag to enable Metrics Server              | `false` |
+| `metricsServer.tolerations`    | Tolerations for Metrics Server             | `[]`    |
+| `metricsServer.affinity`       | Affinity for Metrics Server                | `{}`    |
+| `metricsServer.valuesOverride` | Config override from default config values | `{}`    |
+
+### gpu parameters
+
+| Name                 | Description                                | Value      |
+| -------------------- | ------------------------------------------ | ---------- |
+| `gpu.enabled`        | Flag to enable Tfy GPU Operator            | `true`     |
+| `gpu.clusterType`    | Cluster type for Tfy GPU Operator          | `azureAks` |
+| `gpu.valuesOverride` | Config override from default config values | `{}`       |
+
+### truefoundry parameters
+
+| Name                          | Description                                | Value   |
+| ----------------------------- | ------------------------------------------ | ------- |
+| `truefoundry.enabled`         | Flag to enable TrueFoundry                 | `false` |
+| `truefoundry.devMode.enabled` | Flag to enable TrueFoundry Dev mode        | `false` |
+| `truefoundry.valuesOverride`  | Config override from default config values | `{}`    |
+
+### truefoundryBootstrap parameters
+
+| Name                                       | Description                                                               | Value  |
+| ------------------------------------------ | ------------------------------------------------------------------------- | ------ |
+| `truefoundry.truefoundryBootstrap.enabled` | Flag to enable bootstrap job to prep cluster for truefoundry installation | `true` |
+
+### Truefoundry virtual service parameters
+
+| Name                                         | Description                                        | Value   |
+| -------------------------------------------- | -------------------------------------------------- | ------- |
+| `truefoundry.virtualservice.enabled`         | Flag to enable virtualservice                      | `false` |
+| `truefoundry.virtualservice.hosts`           | Hosts for truefoundry virtualservice               | `[]`    |
+| `truefoundry.virtualservice.gateways`        | Istio gateways to be configured for virtualservice | `[]`    |
+| `truefoundry.virtualservice.annotations`     | Annotations for truefoundry virtualservice         | `{}`    |
+| `truefoundry.existingTruefoundryCredsSecret` | Secret name for existing Truefoundry creds         | `""`    |
+
+### database. Can be left empty if using the dev mode parameters
+
+| Name                                                         | Description                                                | Value   |
+| ------------------------------------------------------------ | ---------------------------------------------------------- | ------- |
+| `truefoundry.database.host`                                  | Hostname of the database                                   | `""`    |
+| `truefoundry.database.name`                                  | Name of the database                                       | `""`    |
+| `truefoundry.database.username`                              | Username of the database                                   | `""`    |
+| `truefoundry.database.password`                              | Password of the database                                   | `""`    |
+| `truefoundry.tfyApiKey`                                      | API Key for TrueFoundry                                    | `""`    |
+| `truefoundry.imagePullSecrets`                               | Image pull secrets for TrueFoundry                         | `[]`    |
+| `truefoundry.truefoundryImagePullConfigJSON`                 | Json config for authenticating to the TrueFoundry registry | `""`    |
+| `truefoundry.truefoundry_iam_role_arn_annotations`           | IAM role annotations for service accounts                  | `{}`    |
+| `truefoundry.defaultCloudProvider`                           | Default cloud provider                                     | `azure` |
+| `truefoundry.storageConfiguration.azureBlobUri`              | Azure blob URI                                             | `""`    |
+| `truefoundry.storageConfiguration.azureBlobConnectionString` | Azure blob connection string                               | `""`    |
+| `truefoundry.s3proxy.enabled`                                | Flag to enable S3 Proxy                                    | `false` |
+| `truefoundry.sparkHistoryServer.enabled`                     | Flag to enable Spark History Server                        | `false` |
+| `truefoundry.tfyWorkflowAdmin.enabled`                       | Flag to enable Tfy Workflow Admin                          | `false` |
+| `truefoundry.gateway.enabled`                                | Flag to enable Gateway                                     | `false` |
+| `truefoundry.tolerations`                                    | Tolerations for the truefoundry components                 | `[]`    |
+| `truefoundry.affinity`                                       | Affinity for the truefoundry components                    | `{}`    |
+
+### tfyLogs parameters
+
+| Name                     | Description                                | Value  |
+| ------------------------ | ------------------------------------------ | ------ |
+| `tfyLogs.enabled`        | Flag to enable Tfy Logs                    | `true` |
+| `tfyLogs.valuesOverride` | Config override from default config values | `{}`   |
+| `tfyLogs.affinity`       | Affinity for tfyLogs statefulset pod       | `{}`   |
+| `tfyLogs.tolerations`    | Tolerations for tfyLogs statefulset pod    | `[]`   |
+
+### istio parameters
+
+| Name                                    | Description                                | Value   |
+| --------------------------------------- | ------------------------------------------ | ------- |
+| `istio.enabled`                         | Flag to enable Istio                       | `true`  |
+| `istio.enabled`                         | Flag to enable Istio Base                  | `true`  |
+| `istio.base.valuesOverride`             | Config override from default config values | `{}`    |
+| `istio.awsElbControllerChecker.enabled` | Flag to enable AWS ELB Controller Checker  | `false` |
+| `istio.gateway.annotations`             | Annotations for Istio Gateway              | `{}`    |
+| `istio.gateway.affinity`                | Affinity for the gateway pods              | `{}`    |
+| `istio.gateway.tolerations`             | Tolerations for the gateway pods           | `[]`    |
+| `istio.gateway.valuesOverride`          | Config override from default config values | `{}`    |
+
+### istio discovery parameters
+
+| Name                             | Description                                | Value                  |
+| -------------------------------- | ------------------------------------------ | ---------------------- |
+| `istio.discovery.hub`            | Hub for the istio image                    | `gcr.io/istio-release` |
+| `istio.discovery.tolerations`    | Tolerations for Istio Discovery            | `[]`                   |
+| `istio.discovery.affinity`       | Affinity for Istio Discovery               | `{}`                   |
+| `istio.discovery.valuesOverride` | Config override from default config values | `{}`                   |
+
+### istio tfyGateway parameters
+
+| Name                                  | Description                                     | Value    |
+| ------------------------------------- | ----------------------------------------------- | -------- |
+| `istio.tfyGateway.httpsRedirect`      | Flag to enable HTTPS redirect for Istio Gateway | `true`   |
+| `istio.tfyGateway.tls.enabled`        | Flag to enable TLS for Istio Gateway            | `false`  |
+| `istio.tfyGateway.tls.mode`           | TLS mode for the Istio Gateway                  | `SIMPLE` |
+| `istio.tfyGateway.tls.credentialName` | Credential name for the TLS certificate         | `""`     |
+| `istio.tfyGateway.domains`            | Domains for the gateway pods                    | `[]`     |
+
+### keda parameters
+
+| Name                  | Description                                | Value  |
+| --------------------- | ------------------------------------------ | ------ |
+| `keda.enabled`        | Flag to enable Keda                        | `true` |
+| `keda.tolerations`    | Tolerations for Keda                       | `[]`   |
+| `keda.affinity`       | Affinity for Keda                          | `{}`   |
+| `keda.valuesOverride` | Config override from default config values | `{}`   |
+
+### sparkOperator parameters
+
+| Name                           | Description                                | Value   |
+| ------------------------------ | ------------------------------------------ | ------- |
+| `sparkOperator.enabled`        | Flag to enable Spark Operator              | `false` |
+| `sparkOperator.tolerations`    | Tolerations for Spark Operator             | `[]`    |
+| `sparkOperator.affinity`       | Affinity for Spark Operator                | `{}`    |
+| `sparkOperator.valuesOverride` | Config override from default config values | `{}`    |
+
+### prometheus parameters
+
+| Name                                     | Description                                                               | Value  |
+| ---------------------------------------- | ------------------------------------------------------------------------- | ------ |
+| `prometheus.enabled`                     | Flag to enable Prometheus                                                 | `true` |
+| `prometheus.additionalScrapeConfigs`     | Additional scrape configs for Prometheus                                  | `[]`   |
+| `prometheus.alertmanager`                | Alertmanager configuration for Prometheus                                 | `{}`   |
+| `prometheus.affinity`                    | Affinity for prometheus statefulset pod                                   | `{}`   |
+| `prometheus.tolerations`                 | Tolerations for prometheus statefulset pod                                | `[]`   |
+| `prometheus.valuesOverride`              | Config override from default config values                                | `{}`   |
+| `prometheus.prometheusNodeExporter.port` | Port for prometheus-node-exporter service and container (default 9100)    | `9100` |
+| `prometheus.config.enabled`              | Flag to enable prometheus config (requires prometheus.enabled to be true) | `true` |
+| `prometheus.config.valuesOverride`       | Config override from default config values                                | `{}`   |
+| `prometheus.config.extraObjects`         | Extra objects for prometheus config                                       | `[]`   |
+
+### grafana parameters
+
+| Name                     | Description                                | Value   |
+| ------------------------ | ------------------------------------------ | ------- |
+| `grafana.enabled`        | Flag to enable Grafana                     | `false` |
+| `grafana.tolerations`    | Tolerations for Grafana                    | `[]`    |
+| `grafana.affinity`       | Affinity for Grafana                       | `{}`    |
+| `grafana.valuesOverride` | Config override from default config values | `{}`    |
+
+### tfyAgent parameters
+
+| Name                          | Description                                | Value  |
+| ----------------------------- | ------------------------------------------ | ------ |
+| `tfyAgent.enabled`            | Flag to enable Tfy Agent                   | `true` |
+| `tfyAgent.valuesOverride`     | Config override from default config values | `{}`   |
+| `tfyAgent.tolerations`        | Tolerations for the agent pods             | `[]`   |
+| `tfyAgent.affinity`           | Affinity for the agent pods                | `{}`   |
+| `tfyAgent.clusterToken`       | cluster token                              | `""`   |
+| `tfyAgent.clusterTokenSecret` | Secret name for cluster token              | `""`   |
+
+### elasti parameters
+
+| Name                    | Description                                | Value  |
+| ----------------------- | ------------------------------------------ | ------ |
+| `elasti.enabled`        | Flag to enable Elasti                      | `true` |
+| `elasti.tolerations`    | Tolerations for Elasti                     | `[]`   |
+| `elasti.affinity`       | Affinity for Elasti                        | `{}`   |
+| `elasti.valuesOverride` | Config override from default config values | `{}`   |
+
+### jspolicy parameters
+
+| Name                             | Description                                              | Value   |
+| -------------------------------- | -------------------------------------------------------- | ------- |
+| `jspolicy.enabled`               | Flag to enable jspolicy. No policy is applied by default | `false` |
+| `jspolicy.enabled`               | Flag to enable jspolicy                                  | `false` |
+| `jspolicy.valuesOverride`        | Config override from default config values               | `{}`    |
+| `jspolicy.affinity`              | Affinity for jspolicy                                    | `{}`    |
+| `jspolicy.tolerations`           | Tolerations for jspolicy                                 | `[]`    |
+| `jspolicy.config.valuesOverride` | Config override from default config values               | `{}`    |
+
+### tfy-workflow-propeller parameters
+
+| Name                                  | Description                                | Value   |
+| ------------------------------------- | ------------------------------------------ | ------- |
+| `tfyWorkflowPropeller.enabled`        | Flag to enable workflow-propeller.         | `false` |
+| `tfyWorkflowPropeller.valuesOverride` | Config override from default config values | `{}`    |
+| `helm.resourcePolicy`                 | Resource policy for the helm chart         | `keep`  |

--- a/charts/tfy-k8s-azure-aks-inframold/artifacts-manifest.json
+++ b/charts/tfy-k8s-azure-aks-inframold/artifacts-manifest.json
@@ -218,28 +218,29 @@
         "details": {
             "chart": "truefoundry",
             "repoURL": "oci://tfy.jfrog.io/tfy-helm",
-            "targetRevision": "0.154.0",
+            "targetRevision": "0.156.0",
             "images": [
-                "tfy.jfrog.io/tfy-private-images/tfy-llm-gateway:v0.154.0",
-                "tfy.jfrog.io/tfy-private-images/tfy-otel-collector:v0.151.0",
+                "tfy.jfrog.io/tfy-images/tfy-sandbox-server:v0.3.1",
+                "tfy.jfrog.io/tfy-private-images/tfy-llm-gateway:v0.156.0",
+                "tfy.jfrog.io/tfy-private-images/tfy-otel-collector:v0.156.0",
                 "tfy.jfrog.io/tfy-private-images/deltafusion-query-server:v0.151.0-optimized",
                 "tfy.jfrog.io/tfy-private-images/deltafusion-query-server:v0.151.0",
-                "tfy.jfrog.io/tfy-private-images/mlfoundry-server:v0.154.0",
+                "tfy.jfrog.io/tfy-private-images/mlfoundry-server:v0.155.0",
                 "tfy.jfrog.io/tfy-private-images/s3proxy:v0.149.0",
-                "tfy.jfrog.io/tfy-private-images/servicefoundry-server:v0.154.0",
+                "tfy.jfrog.io/tfy-private-images/servicefoundry-server:v0.156.0",
                 "tfy.jfrog.io/tfy-private-images/sfy-manifest-service:v0.148.0",
                 "tfy.jfrog.io/tfy-private-images/spark-history-server:v0.150.0",
                 "tfy.jfrog.io/tfy-private-images/tfy-controller:v0.150.0",
-                "tfy.jfrog.io/tfy-private-images/tfy-k8s-controller:v0.154.0",
-                "tfy.jfrog.io/tfy-private-images/tfy-proxy:v0.154.0",
+                "tfy.jfrog.io/tfy-private-images/tfy-k8s-controller:v0.156.0",
+                "tfy.jfrog.io/tfy-private-images/tfy-proxy:v0.156.0",
                 "tfy.jfrog.io/tfy-private-images/tfy-workflow-admin:v0.150.0",
                 "tfy.jfrog.io/tfy-images/postgresql:16.6.0-debian-12-r2",
                 "tfy.jfrog.io/tfy-mirror/bitnamilegacy/redis:8.2.1-debian-12-r0",
                 "tfy.jfrog.io/tfy-mirror/nats:2.12.6-alpine",
                 "tfy.jfrog.io/tfy-mirror/natsio/nats-server-config-reloader:0.23.0",
                 "tfy.jfrog.io/tfy-mirror/natsio/prometheus-nats-exporter:0.18.0",
-                "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.154.0-optimized",
-                "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.154.0",
+                "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.155.0-optimized",
+                "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.155.0",
                 "tfy.jfrog.io/tfy-mirror/moby/buildkit:v0.26.2",
                 "tfy.jfrog.io/tfy-images/truefoundry-bootstrap:0.1.6"
             ]
@@ -1110,7 +1111,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-llm-gateway:v0.154.0",
+            "registryURL": "tfy.jfrog.io/tfy-images/tfy-sandbox-server:v0.3.1",
             "platforms": [
                 {
                     "os": "linux",
@@ -1126,7 +1127,23 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-otel-collector:v0.151.0",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-llm-gateway:v0.156.0",
+            "platforms": [
+                {
+                    "os": "linux",
+                    "architecture": "amd64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm64"
+                }
+            ]
+        }
+    },
+    {
+        "type": "image",
+        "details": {
+            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-otel-collector:v0.156.0",
             "platforms": [
                 {
                     "os": "linux",
@@ -1174,7 +1191,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/mlfoundry-server:v0.154.0",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/mlfoundry-server:v0.155.0",
             "platforms": [
                 {
                     "os": "linux",
@@ -1206,7 +1223,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/servicefoundry-server:v0.154.0",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/servicefoundry-server:v0.156.0",
             "platforms": [
                 {
                     "os": "linux",
@@ -1270,7 +1287,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-k8s-controller:v0.154.0",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-k8s-controller:v0.156.0",
             "platforms": [
                 {
                     "os": "linux",
@@ -1286,7 +1303,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-proxy:v0.154.0",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-proxy:v0.156.0",
             "platforms": [
                 {
                     "os": "linux",
@@ -1430,7 +1447,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.154.0-optimized",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.155.0-optimized",
             "platforms": [
                 {
                     "os": "linux",
@@ -1442,7 +1459,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.154.0",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.155.0",
             "platforms": [
                 {
                     "os": "linux",

--- a/charts/tfy-k8s-civo-talos-inframold/README.md
+++ b/charts/tfy-k8s-civo-talos-inframold/README.md
@@ -2,3 +2,247 @@
 Inframold, the superchart that configure your cluster on civo for truefoundry.
 
 ## Parameters
+
+### Global Parameters
+
+| Name               | Description                                                | Value |
+| ------------------ | ---------------------------------------------------------- | ----- |
+| `global.repoURL`   | Override chart repository URL for all Argo CD Applications | `""`  |
+| `tenantName`       | Parameters for tenantName                                  | `""`  |
+| `controlPlaneURL`  | Parameters for controlPlaneURL                             | `""`  |
+| `clusterName`      | Name of the cluster                                        | `""`  |
+| `registry`         | registry to override in the chart components               | `""`  |
+| `imagePullSecrets` | imagePullSecrets to override in the chart components       | `[]`  |
+| `tolerations`      | Tolerations for the all chart components                   | `[]`  |
+| `affinity`         | Affinity for the all chart components                      | `{}`  |
+
+### argocd parameters
+
+| Name                    | Description                                | Value  |
+| ----------------------- | ------------------------------------------ | ------ |
+| `argocd.enabled`        | Flag to enable ArgoCD                      | `true` |
+| `argocd.tolerations`    | Tolerations for ArgoCD                     | `[]`   |
+| `argocd.affinity`       | Affinity for ArgoCD                        | `{}`   |
+| `argocd.valuesOverride` | Config override from default config values | `{}`   |
+
+### argoWorkflows parameters
+
+| Name                           | Description                                | Value  |
+| ------------------------------ | ------------------------------------------ | ------ |
+| `argoWorkflows.enabled`        | Flag to enable Argo Workflows              | `true` |
+| `argoWorkflows.tolerations`    | Tolerations for Argo Workflows             | `[]`   |
+| `argoWorkflows.affinity`       | Affinity for Argo Workflows                | `{}`   |
+| `argoWorkflows.valuesOverride` | Config override from default config values | `{}`   |
+
+### argoRollouts parameters
+
+| Name                          | Description                                | Value  |
+| ----------------------------- | ------------------------------------------ | ------ |
+| `argoRollouts.enabled`        | Flag to enable Argo Rollouts               | `true` |
+| `argoRollouts.tolerations`    | Tolerations for Argo Rollouts              | `[]`   |
+| `argoRollouts.affinity`       | Affinity for Argo Rollouts                 | `{}`   |
+| `argoRollouts.valuesOverride` | Config override from default config values | `{}`   |
+
+### certManager parameters
+
+| Name                                     | Description                                                                       | Value  |
+| ---------------------------------------- | --------------------------------------------------------------------------------- | ------ |
+| `certManager.enabled`                    | Flag to enable Cert Manager                                                       | `true` |
+| `certManager.tolerations`                | Tolerations for Cert Manager                                                      | `[]`   |
+| `certManager.podLabels`                  | Pod labels for Cert Manager. For Azure will be applied to serviceaccount as well. | `{}`   |
+| `certManager.serviceAccount.annotations` | Service account annotations for Cert Manager.                                     | `{}`   |
+| `certManager.affinity`                   | Affinity for Cert Manager                                                         | `{}`   |
+| `certManager.valuesOverride`             | Config override from default config values                                        | `{}`   |
+
+### certManager issuers parameters
+
+| Name                                | Description                                        | Value  |
+| ----------------------------------- | -------------------------------------------------- | ------ |
+| `certManager.config.enabled`        | Flag to enable certManager config                  | `true` |
+| `certManager.config.issuers`        | Map of issuers and their certificate configuration | `{}`   |
+| `certManager.config.valuesOverride` | Config override from default config values         | `{}`   |
+
+### metricsServer parameters
+
+| Name                           | Description                                | Value   |
+| ------------------------------ | ------------------------------------------ | ------- |
+| `metricsServer.enabled`        | Flag to enable Metrics Server              | `false` |
+| `metricsServer.enabled`        | Flag to enable Metrics Server              | `false` |
+| `metricsServer.tolerations`    | Tolerations for Metrics Server             | `[]`    |
+| `metricsServer.affinity`       | Affinity for Metrics Server                | `{}`    |
+| `metricsServer.valuesOverride` | Config override from default config values | `{}`    |
+
+### gpu parameters
+
+| Name                 | Description                                | Value       |
+| -------------------- | ------------------------------------------ | ----------- |
+| `gpu.enabled`        | Flag to enable Tfy GPU Operator            | `true`      |
+| `gpu.clusterType`    | Cluster type for Tfy GPU Operator          | `civoTalos` |
+| `gpu.valuesOverride` | Config override from default config values | `{}`        |
+
+### truefoundry parameters
+
+| Name                          | Description                                | Value   |
+| ----------------------------- | ------------------------------------------ | ------- |
+| `truefoundry.enabled`         | Flag to enable TrueFoundry                 | `false` |
+| `truefoundry.devMode.enabled` | Flag to enable TrueFoundry Dev mode        | `false` |
+| `truefoundry.valuesOverride`  | Config override from default config values | `{}`    |
+
+### truefoundryBootstrap parameters
+
+| Name                                       | Description                                                               | Value  |
+| ------------------------------------------ | ------------------------------------------------------------------------- | ------ |
+| `truefoundry.truefoundryBootstrap.enabled` | Flag to enable bootstrap job to prep cluster for truefoundry installation | `true` |
+
+### Truefoundry virtual service parameters
+
+| Name                                         | Description                                        | Value   |
+| -------------------------------------------- | -------------------------------------------------- | ------- |
+| `truefoundry.virtualservice.enabled`         | Flag to enable virtualservice                      | `false` |
+| `truefoundry.virtualservice.hosts`           | Hosts for truefoundry virtualservice               | `[]`    |
+| `truefoundry.virtualservice.gateways`        | Istio gateways to be configured for virtualservice | `[]`    |
+| `truefoundry.virtualservice.annotations`     | Annotations for truefoundry virtualservice         | `{}`    |
+| `truefoundry.existingTruefoundryCredsSecret` | Secret name for existing Truefoundry creds         | `""`    |
+
+### database. Can be left empty if using the dev mode parameters
+
+| Name                                               | Description                                                | Value     |
+| -------------------------------------------------- | ---------------------------------------------------------- | --------- |
+| `truefoundry.database.host`                        | Hostname of the database                                   | `""`      |
+| `truefoundry.database.name`                        | Name of the database                                       | `""`      |
+| `truefoundry.database.username`                    | Username of the database                                   | `""`      |
+| `truefoundry.database.password`                    | Password of the database                                   | `""`      |
+| `truefoundry.tfyApiKey`                            | API Key for TrueFoundry                                    | `""`      |
+| `truefoundry.imagePullSecrets`                     | Image pull secrets for TrueFoundry                         | `[]`      |
+| `truefoundry.truefoundryImagePullConfigJSON`       | Json config for authenticating to the TrueFoundry registry | `""`      |
+| `truefoundry.truefoundry_iam_role_arn_annotations` | IAM role annotations for service accounts                  | `{}`      |
+| `truefoundry.defaultCloudProvider`                 | Default cloud provider                                     | `generic` |
+| `truefoundry.storageConfiguration`                 | Storage class for the storage configuration                | `{}`      |
+| `truefoundry.s3proxy.enabled`                      | Flag to enable S3 Proxy                                    | `false`   |
+| `truefoundry.sparkHistoryServer.enabled`           | Flag to enable Spark History Server                        | `false`   |
+| `truefoundry.tfyWorkflowAdmin.enabled`             | Flag to enable Tfy Workflow Admin                          | `false`   |
+| `truefoundry.gateway.enabled`                      | Flag to enable Gateway                                     | `false`   |
+| `truefoundry.tolerations`                          | Tolerations for the truefoundry components                 | `[]`      |
+| `truefoundry.affinity`                             | Affinity for the truefoundry components                    | `{}`      |
+
+### tfyLogs parameters
+
+| Name                     | Description                                | Value  |
+| ------------------------ | ------------------------------------------ | ------ |
+| `tfyLogs.enabled`        | Flag to enable Tfy Logs                    | `true` |
+| `tfyLogs.valuesOverride` | Config override from default config values | `{}`   |
+| `tfyLogs.affinity`       | Affinity for tfyLogs statefulset pod       | `{}`   |
+| `tfyLogs.tolerations`    | Tolerations for tfyLogs statefulset pod    | `[]`   |
+
+### istio parameters
+
+| Name                                    | Description                                | Value   |
+| --------------------------------------- | ------------------------------------------ | ------- |
+| `istio.enabled`                         | Flag to enable Istio                       | `true`  |
+| `istio.enabled`                         | Flag to enable Istio Base                  | `true`  |
+| `istio.base.valuesOverride`             | Config override from default config values | `{}`    |
+| `istio.awsElbControllerChecker.enabled` | Flag to enable AWS ELB Controller Checker  | `false` |
+| `istio.gateway.annotations`             | Annotations for Istio Gateway              | `{}`    |
+| `istio.gateway.affinity`                | Affinity for the gateway pods              | `{}`    |
+| `istio.gateway.tolerations`             | Tolerations for the gateway pods           | `[]`    |
+| `istio.gateway.valuesOverride`          | Config override from default config values | `{}`    |
+
+### istio discovery parameters
+
+| Name                             | Description                                | Value                  |
+| -------------------------------- | ------------------------------------------ | ---------------------- |
+| `istio.discovery.hub`            | Hub for the istio image                    | `gcr.io/istio-release` |
+| `istio.discovery.tolerations`    | Tolerations for Istio Discovery            | `[]`                   |
+| `istio.discovery.affinity`       | Affinity for Istio Discovery               | `{}`                   |
+| `istio.discovery.valuesOverride` | Config override from default config values | `{}`                   |
+
+### istio tfyGateway parameters
+
+| Name                                  | Description                                     | Value    |
+| ------------------------------------- | ----------------------------------------------- | -------- |
+| `istio.tfyGateway.httpsRedirect`      | Flag to enable HTTPS redirect for Istio Gateway | `true`   |
+| `istio.tfyGateway.tls.enabled`        | Flag to enable TLS for Istio Gateway            | `false`  |
+| `istio.tfyGateway.tls.mode`           | TLS mode for the Istio Gateway                  | `SIMPLE` |
+| `istio.tfyGateway.tls.credentialName` | Credential name for the TLS certificate         | `""`     |
+| `istio.tfyGateway.domains`            | Domains for the gateway pods                    | `[]`     |
+
+### keda parameters
+
+| Name                  | Description                                | Value  |
+| --------------------- | ------------------------------------------ | ------ |
+| `keda.enabled`        | Flag to enable Keda                        | `true` |
+| `keda.tolerations`    | Tolerations for Keda                       | `[]`   |
+| `keda.affinity`       | Affinity for Keda                          | `{}`   |
+| `keda.valuesOverride` | Config override from default config values | `{}`   |
+
+### sparkOperator parameters
+
+| Name                           | Description                                | Value   |
+| ------------------------------ | ------------------------------------------ | ------- |
+| `sparkOperator.enabled`        | Flag to enable Spark Operator              | `false` |
+| `sparkOperator.tolerations`    | Tolerations for Spark Operator             | `[]`    |
+| `sparkOperator.affinity`       | Affinity for Spark Operator                | `{}`    |
+| `sparkOperator.valuesOverride` | Config override from default config values | `{}`    |
+
+### prometheus parameters
+
+| Name                                     | Description                                                               | Value  |
+| ---------------------------------------- | ------------------------------------------------------------------------- | ------ |
+| `prometheus.enabled`                     | Flag to enable Prometheus                                                 | `true` |
+| `prometheus.additionalScrapeConfigs`     | Additional scrape configs for Prometheus                                  | `[]`   |
+| `prometheus.alertmanager`                | Alertmanager configuration for Prometheus                                 | `{}`   |
+| `prometheus.affinity`                    | Affinity for prometheus statefulset pod                                   | `{}`   |
+| `prometheus.tolerations`                 | Tolerations for prometheus statefulset pod                                | `[]`   |
+| `prometheus.valuesOverride`              | Config override from default config values                                | `{}`   |
+| `prometheus.prometheusNodeExporter.port` | Port for prometheus-node-exporter service and container (default 9100)    | `9100` |
+| `prometheus.config.enabled`              | Flag to enable prometheus config (requires prometheus.enabled to be true) | `true` |
+| `prometheus.config.valuesOverride`       | Config override from default config values                                | `{}`   |
+| `prometheus.config.extraObjects`         | Extra objects for prometheus config                                       | `[]`   |
+
+### grafana parameters
+
+| Name                     | Description                                | Value   |
+| ------------------------ | ------------------------------------------ | ------- |
+| `grafana.enabled`        | Flag to enable Grafana                     | `false` |
+| `grafana.tolerations`    | Tolerations for Grafana                    | `[]`    |
+| `grafana.affinity`       | Affinity for Grafana                       | `{}`    |
+| `grafana.valuesOverride` | Config override from default config values | `{}`    |
+
+### tfyAgent parameters
+
+| Name                          | Description                                | Value  |
+| ----------------------------- | ------------------------------------------ | ------ |
+| `tfyAgent.enabled`            | Flag to enable Tfy Agent                   | `true` |
+| `tfyAgent.valuesOverride`     | Config override from default config values | `{}`   |
+| `tfyAgent.tolerations`        | Tolerations for the agent pods             | `[]`   |
+| `tfyAgent.affinity`           | Affinity for the agent pods                | `{}`   |
+| `tfyAgent.clusterToken`       | cluster token                              | `""`   |
+| `tfyAgent.clusterTokenSecret` | Secret name for cluster token              | `""`   |
+
+### elasti parameters
+
+| Name                    | Description                                | Value  |
+| ----------------------- | ------------------------------------------ | ------ |
+| `elasti.enabled`        | Flag to enable Elasti                      | `true` |
+| `elasti.tolerations`    | Tolerations for Elasti                     | `[]`   |
+| `elasti.affinity`       | Affinity for Elasti                        | `{}`   |
+| `elasti.valuesOverride` | Config override from default config values | `{}`   |
+
+### jspolicy parameters
+
+| Name                             | Description                                              | Value   |
+| -------------------------------- | -------------------------------------------------------- | ------- |
+| `jspolicy.enabled`               | Flag to enable jspolicy. No policy is applied by default | `false` |
+| `jspolicy.enabled`               | Flag to enable jspolicy                                  | `false` |
+| `jspolicy.valuesOverride`        | Config override from default config values               | `{}`    |
+| `jspolicy.affinity`              | Affinity for jspolicy                                    | `{}`    |
+| `jspolicy.tolerations`           | Tolerations for jspolicy                                 | `[]`    |
+| `jspolicy.config.valuesOverride` | Config override from default config values               | `{}`    |
+
+### tfy-workflow-propeller parameters
+
+| Name                                  | Description                                | Value   |
+| ------------------------------------- | ------------------------------------------ | ------- |
+| `tfyWorkflowPropeller.enabled`        | Flag to enable workflow-propeller.         | `false` |
+| `tfyWorkflowPropeller.valuesOverride` | Config override from default config values | `{}`    |
+| `helm.resourcePolicy`                 | Resource policy for the helm chart         | `keep`  |

--- a/charts/tfy-k8s-civo-talos-inframold/artifacts-manifest.json
+++ b/charts/tfy-k8s-civo-talos-inframold/artifacts-manifest.json
@@ -219,28 +219,29 @@
         "details": {
             "chart": "truefoundry",
             "repoURL": "oci://tfy.jfrog.io/tfy-helm",
-            "targetRevision": "0.154.0",
+            "targetRevision": "0.156.0",
             "images": [
-                "tfy.jfrog.io/tfy-private-images/tfy-llm-gateway:v0.154.0",
-                "tfy.jfrog.io/tfy-private-images/tfy-otel-collector:v0.151.0",
+                "tfy.jfrog.io/tfy-images/tfy-sandbox-server:v0.3.1",
+                "tfy.jfrog.io/tfy-private-images/tfy-llm-gateway:v0.156.0",
+                "tfy.jfrog.io/tfy-private-images/tfy-otel-collector:v0.156.0",
                 "tfy.jfrog.io/tfy-private-images/deltafusion-query-server:v0.151.0-optimized",
                 "tfy.jfrog.io/tfy-private-images/deltafusion-query-server:v0.151.0",
-                "tfy.jfrog.io/tfy-private-images/mlfoundry-server:v0.154.0",
+                "tfy.jfrog.io/tfy-private-images/mlfoundry-server:v0.155.0",
                 "tfy.jfrog.io/tfy-private-images/s3proxy:v0.149.0",
-                "tfy.jfrog.io/tfy-private-images/servicefoundry-server:v0.154.0",
+                "tfy.jfrog.io/tfy-private-images/servicefoundry-server:v0.156.0",
                 "tfy.jfrog.io/tfy-private-images/sfy-manifest-service:v0.148.0",
                 "tfy.jfrog.io/tfy-private-images/spark-history-server:v0.150.0",
                 "tfy.jfrog.io/tfy-private-images/tfy-controller:v0.150.0",
-                "tfy.jfrog.io/tfy-private-images/tfy-k8s-controller:v0.154.0",
-                "tfy.jfrog.io/tfy-private-images/tfy-proxy:v0.154.0",
+                "tfy.jfrog.io/tfy-private-images/tfy-k8s-controller:v0.156.0",
+                "tfy.jfrog.io/tfy-private-images/tfy-proxy:v0.156.0",
                 "tfy.jfrog.io/tfy-private-images/tfy-workflow-admin:v0.150.0",
                 "tfy.jfrog.io/tfy-images/postgresql:16.6.0-debian-12-r2",
                 "tfy.jfrog.io/tfy-mirror/bitnamilegacy/redis:8.2.1-debian-12-r0",
                 "tfy.jfrog.io/tfy-mirror/nats:2.12.6-alpine",
                 "tfy.jfrog.io/tfy-mirror/natsio/nats-server-config-reloader:0.23.0",
                 "tfy.jfrog.io/tfy-mirror/natsio/prometheus-nats-exporter:0.18.0",
-                "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.154.0-optimized",
-                "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.154.0",
+                "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.155.0-optimized",
+                "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.155.0",
                 "tfy.jfrog.io/tfy-mirror/moby/buildkit:v0.26.2",
                 "tfy.jfrog.io/tfy-images/truefoundry-bootstrap:0.1.6"
             ]
@@ -1151,7 +1152,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-llm-gateway:v0.154.0",
+            "registryURL": "tfy.jfrog.io/tfy-images/tfy-sandbox-server:v0.3.1",
             "platforms": [
                 {
                     "os": "linux",
@@ -1167,7 +1168,23 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-otel-collector:v0.151.0",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-llm-gateway:v0.156.0",
+            "platforms": [
+                {
+                    "os": "linux",
+                    "architecture": "amd64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm64"
+                }
+            ]
+        }
+    },
+    {
+        "type": "image",
+        "details": {
+            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-otel-collector:v0.156.0",
             "platforms": [
                 {
                     "os": "linux",
@@ -1215,7 +1232,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/mlfoundry-server:v0.154.0",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/mlfoundry-server:v0.155.0",
             "platforms": [
                 {
                     "os": "linux",
@@ -1247,7 +1264,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/servicefoundry-server:v0.154.0",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/servicefoundry-server:v0.156.0",
             "platforms": [
                 {
                     "os": "linux",
@@ -1311,7 +1328,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-k8s-controller:v0.154.0",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-k8s-controller:v0.156.0",
             "platforms": [
                 {
                     "os": "linux",
@@ -1327,7 +1344,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-proxy:v0.154.0",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-proxy:v0.156.0",
             "platforms": [
                 {
                     "os": "linux",
@@ -1471,7 +1488,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.154.0-optimized",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.155.0-optimized",
             "platforms": [
                 {
                     "os": "linux",
@@ -1483,7 +1500,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.154.0",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.155.0",
             "platforms": [
                 {
                     "os": "linux",

--- a/charts/tfy-k8s-gcp-gke-standard-inframold/README.md
+++ b/charts/tfy-k8s-gcp-gke-standard-inframold/README.md
@@ -2,3 +2,249 @@
 Inframold, the superchart that configure your cluster on gcp for truefoundry.
 
 ## Parameters
+
+### Global Parameters
+
+| Name               | Description                                                | Value |
+| ------------------ | ---------------------------------------------------------- | ----- |
+| `global.repoURL`   | Override chart repository URL for all Argo CD Applications | `""`  |
+| `tenantName`       | Parameters for tenantName                                  | `""`  |
+| `controlPlaneURL`  | Parameters for controlPlaneURL                             | `""`  |
+| `clusterName`      | Name of the cluster                                        | `""`  |
+| `registry`         | registry to override in the chart components               | `""`  |
+| `imagePullSecrets` | imagePullSecrets to override in the chart components       | `[]`  |
+| `tolerations`      | Tolerations for the all chart components                   | `[]`  |
+| `affinity`         | Affinity for the all chart components                      | `{}`  |
+
+### argocd parameters
+
+| Name                    | Description                                | Value  |
+| ----------------------- | ------------------------------------------ | ------ |
+| `argocd.enabled`        | Flag to enable ArgoCD                      | `true` |
+| `argocd.tolerations`    | Tolerations for ArgoCD                     | `[]`   |
+| `argocd.affinity`       | Affinity for ArgoCD                        | `{}`   |
+| `argocd.valuesOverride` | Config override from default config values | `{}`   |
+
+### argoWorkflows parameters
+
+| Name                           | Description                                | Value  |
+| ------------------------------ | ------------------------------------------ | ------ |
+| `argoWorkflows.enabled`        | Flag to enable Argo Workflows              | `true` |
+| `argoWorkflows.tolerations`    | Tolerations for Argo Workflows             | `[]`   |
+| `argoWorkflows.affinity`       | Affinity for Argo Workflows                | `{}`   |
+| `argoWorkflows.valuesOverride` | Config override from default config values | `{}`   |
+
+### argoRollouts parameters
+
+| Name                          | Description                                | Value  |
+| ----------------------------- | ------------------------------------------ | ------ |
+| `argoRollouts.enabled`        | Flag to enable Argo Rollouts               | `true` |
+| `argoRollouts.tolerations`    | Tolerations for Argo Rollouts              | `[]`   |
+| `argoRollouts.affinity`       | Affinity for Argo Rollouts                 | `{}`   |
+| `argoRollouts.valuesOverride` | Config override from default config values | `{}`   |
+
+### certManager parameters
+
+| Name                                     | Description                                                                       | Value  |
+| ---------------------------------------- | --------------------------------------------------------------------------------- | ------ |
+| `certManager.enabled`                    | Flag to enable Cert Manager                                                       | `true` |
+| `certManager.tolerations`                | Tolerations for Cert Manager                                                      | `[]`   |
+| `certManager.podLabels`                  | Pod labels for Cert Manager. For Azure will be applied to serviceaccount as well. | `{}`   |
+| `certManager.serviceAccount.annotations` | Service account annotations for Cert Manager.                                     | `{}`   |
+| `certManager.affinity`                   | Affinity for Cert Manager                                                         | `{}`   |
+| `certManager.valuesOverride`             | Config override from default config values                                        | `{}`   |
+
+### certManager issuers parameters
+
+| Name                                | Description                                        | Value  |
+| ----------------------------------- | -------------------------------------------------- | ------ |
+| `certManager.config.enabled`        | Flag to enable certManager config                  | `true` |
+| `certManager.config.issuers`        | Map of issuers and their certificate configuration | `{}`   |
+| `certManager.config.valuesOverride` | Config override from default config values         | `{}`   |
+
+### metricsServer parameters
+
+| Name                           | Description                                | Value   |
+| ------------------------------ | ------------------------------------------ | ------- |
+| `metricsServer.enabled`        | Flag to enable Metrics Server              | `false` |
+| `metricsServer.enabled`        | Flag to enable Metrics Server              | `false` |
+| `metricsServer.tolerations`    | Tolerations for Metrics Server             | `[]`    |
+| `metricsServer.affinity`       | Affinity for Metrics Server                | `{}`    |
+| `metricsServer.valuesOverride` | Config override from default config values | `{}`    |
+
+### gpu parameters
+
+| Name                 | Description                                | Value            |
+| -------------------- | ------------------------------------------ | ---------------- |
+| `gpu.enabled`        | Flag to enable Tfy GPU Operator            | `true`           |
+| `gpu.clusterType`    | Cluster type for Tfy GPU Operator          | `gcpGkeStandard` |
+| `gpu.valuesOverride` | Config override from default config values | `{}`             |
+
+### truefoundry parameters
+
+| Name                          | Description                                | Value   |
+| ----------------------------- | ------------------------------------------ | ------- |
+| `truefoundry.enabled`         | Flag to enable TrueFoundry                 | `false` |
+| `truefoundry.devMode.enabled` | Flag to enable TrueFoundry Dev mode        | `false` |
+| `truefoundry.valuesOverride`  | Config override from default config values | `{}`    |
+
+### truefoundryBootstrap parameters
+
+| Name                                       | Description                                                               | Value  |
+| ------------------------------------------ | ------------------------------------------------------------------------- | ------ |
+| `truefoundry.truefoundryBootstrap.enabled` | Flag to enable bootstrap job to prep cluster for truefoundry installation | `true` |
+
+### Truefoundry virtual service parameters
+
+| Name                                         | Description                                        | Value   |
+| -------------------------------------------- | -------------------------------------------------- | ------- |
+| `truefoundry.virtualservice.enabled`         | Flag to enable virtualservice                      | `false` |
+| `truefoundry.virtualservice.hosts`           | Hosts for truefoundry virtualservice               | `[]`    |
+| `truefoundry.virtualservice.gateways`        | Istio gateways to be configured for virtualservice | `[]`    |
+| `truefoundry.virtualservice.annotations`     | Annotations for truefoundry virtualservice         | `{}`    |
+| `truefoundry.existingTruefoundryCredsSecret` | Secret name for existing Truefoundry creds         | `""`    |
+
+### database. Can be left empty if using the dev mode parameters
+
+| Name                                                                       | Description                                                | Value   |
+| -------------------------------------------------------------------------- | ---------------------------------------------------------- | ------- |
+| `truefoundry.database.host`                                                | Hostname of the database                                   | `""`    |
+| `truefoundry.database.name`                                                | Name of the database                                       | `""`    |
+| `truefoundry.database.username`                                            | Username of the database                                   | `""`    |
+| `truefoundry.database.password`                                            | Password of the database                                   | `""`    |
+| `truefoundry.tfyApiKey`                                                    | API Key for TrueFoundry                                    | `""`    |
+| `truefoundry.imagePullSecrets`                                             | Image pull secrets for TrueFoundry                         | `[]`    |
+| `truefoundry.truefoundryImagePullConfigJSON`                               | Json config for authenticating to the TrueFoundry registry | `""`    |
+| `truefoundry.truefoundry_iam_role_arn_annotations`                         | IAM role annotations for service accounts                  | `{}`    |
+| `truefoundry.defaultCloudProvider`                                         | Default cloud provider                                     | `gcp`   |
+| `truefoundry.storageConfiguration.googleCloudProjectId`                    | Google cloud project ID                                    | `""`    |
+| `truefoundry.storageConfiguration.googleCloudStorageBucketName`            | Google cloud storage bucket name                           | `""`    |
+| `truefoundry.storageConfiguration.googleCloudServiceAccountKeyFileContent` | Google cloud service account key file content              | `""`    |
+| `truefoundry.s3proxy.enabled`                                              | Flag to enable S3 Proxy                                    | `false` |
+| `truefoundry.sparkHistoryServer.enabled`                                   | Flag to enable Spark History Server                        | `false` |
+| `truefoundry.tfyWorkflowAdmin.enabled`                                     | Flag to enable Tfy Workflow Admin                          | `false` |
+| `truefoundry.gateway.enabled`                                              | Flag to enable Gateway                                     | `false` |
+| `truefoundry.tolerations`                                                  | Tolerations for the truefoundry components                 | `[]`    |
+| `truefoundry.affinity`                                                     | Affinity for the truefoundry components                    | `{}`    |
+
+### tfyLogs parameters
+
+| Name                     | Description                                | Value  |
+| ------------------------ | ------------------------------------------ | ------ |
+| `tfyLogs.enabled`        | Flag to enable Tfy Logs                    | `true` |
+| `tfyLogs.valuesOverride` | Config override from default config values | `{}`   |
+| `tfyLogs.affinity`       | Affinity for tfyLogs statefulset pod       | `{}`   |
+| `tfyLogs.tolerations`    | Tolerations for tfyLogs statefulset pod    | `[]`   |
+
+### istio parameters
+
+| Name                                    | Description                                | Value   |
+| --------------------------------------- | ------------------------------------------ | ------- |
+| `istio.enabled`                         | Flag to enable Istio                       | `true`  |
+| `istio.enabled`                         | Flag to enable Istio Base                  | `true`  |
+| `istio.base.valuesOverride`             | Config override from default config values | `{}`    |
+| `istio.awsElbControllerChecker.enabled` | Flag to enable AWS ELB Controller Checker  | `false` |
+| `istio.gateway.annotations`             | Annotations for Istio Gateway              | `{}`    |
+| `istio.gateway.affinity`                | Affinity for the gateway pods              | `{}`    |
+| `istio.gateway.tolerations`             | Tolerations for the gateway pods           | `[]`    |
+| `istio.gateway.valuesOverride`          | Config override from default config values | `{}`    |
+
+### istio discovery parameters
+
+| Name                             | Description                                | Value                  |
+| -------------------------------- | ------------------------------------------ | ---------------------- |
+| `istio.discovery.hub`            | Hub for the istio image                    | `gcr.io/istio-release` |
+| `istio.discovery.tolerations`    | Tolerations for Istio Discovery            | `[]`                   |
+| `istio.discovery.affinity`       | Affinity for Istio Discovery               | `{}`                   |
+| `istio.discovery.valuesOverride` | Config override from default config values | `{}`                   |
+
+### istio tfyGateway parameters
+
+| Name                                  | Description                                     | Value    |
+| ------------------------------------- | ----------------------------------------------- | -------- |
+| `istio.tfyGateway.httpsRedirect`      | Flag to enable HTTPS redirect for Istio Gateway | `true`   |
+| `istio.tfyGateway.tls.enabled`        | Flag to enable TLS for Istio Gateway            | `false`  |
+| `istio.tfyGateway.tls.mode`           | TLS mode for the Istio Gateway                  | `SIMPLE` |
+| `istio.tfyGateway.tls.credentialName` | Credential name for the TLS certificate         | `""`     |
+| `istio.tfyGateway.domains`            | Domains for the gateway pods                    | `[]`     |
+
+### keda parameters
+
+| Name                  | Description                                | Value  |
+| --------------------- | ------------------------------------------ | ------ |
+| `keda.enabled`        | Flag to enable Keda                        | `true` |
+| `keda.tolerations`    | Tolerations for Keda                       | `[]`   |
+| `keda.affinity`       | Affinity for Keda                          | `{}`   |
+| `keda.valuesOverride` | Config override from default config values | `{}`   |
+
+### sparkOperator parameters
+
+| Name                           | Description                                | Value   |
+| ------------------------------ | ------------------------------------------ | ------- |
+| `sparkOperator.enabled`        | Flag to enable Spark Operator              | `false` |
+| `sparkOperator.tolerations`    | Tolerations for Spark Operator             | `[]`    |
+| `sparkOperator.affinity`       | Affinity for Spark Operator                | `{}`    |
+| `sparkOperator.valuesOverride` | Config override from default config values | `{}`    |
+
+### prometheus parameters
+
+| Name                                     | Description                                                               | Value  |
+| ---------------------------------------- | ------------------------------------------------------------------------- | ------ |
+| `prometheus.enabled`                     | Flag to enable Prometheus                                                 | `true` |
+| `prometheus.additionalScrapeConfigs`     | Additional scrape configs for Prometheus                                  | `[]`   |
+| `prometheus.alertmanager`                | Alertmanager configuration for Prometheus                                 | `{}`   |
+| `prometheus.affinity`                    | Affinity for prometheus statefulset pod                                   | `{}`   |
+| `prometheus.tolerations`                 | Tolerations for prometheus statefulset pod                                | `[]`   |
+| `prometheus.valuesOverride`              | Config override from default config values                                | `{}`   |
+| `prometheus.prometheusNodeExporter.port` | Port for prometheus-node-exporter service and container (default 9100)    | `9100` |
+| `prometheus.config.enabled`              | Flag to enable prometheus config (requires prometheus.enabled to be true) | `true` |
+| `prometheus.config.valuesOverride`       | Config override from default config values                                | `{}`   |
+| `prometheus.config.extraObjects`         | Extra objects for prometheus config                                       | `[]`   |
+
+### grafana parameters
+
+| Name                     | Description                                | Value   |
+| ------------------------ | ------------------------------------------ | ------- |
+| `grafana.enabled`        | Flag to enable Grafana                     | `false` |
+| `grafana.tolerations`    | Tolerations for Grafana                    | `[]`    |
+| `grafana.affinity`       | Affinity for Grafana                       | `{}`    |
+| `grafana.valuesOverride` | Config override from default config values | `{}`    |
+
+### tfyAgent parameters
+
+| Name                          | Description                                | Value  |
+| ----------------------------- | ------------------------------------------ | ------ |
+| `tfyAgent.enabled`            | Flag to enable Tfy Agent                   | `true` |
+| `tfyAgent.valuesOverride`     | Config override from default config values | `{}`   |
+| `tfyAgent.tolerations`        | Tolerations for the agent pods             | `[]`   |
+| `tfyAgent.affinity`           | Affinity for the agent pods                | `{}`   |
+| `tfyAgent.clusterToken`       | cluster token                              | `""`   |
+| `tfyAgent.clusterTokenSecret` | Secret name for cluster token              | `""`   |
+
+### elasti parameters
+
+| Name                    | Description                                | Value  |
+| ----------------------- | ------------------------------------------ | ------ |
+| `elasti.enabled`        | Flag to enable Elasti                      | `true` |
+| `elasti.tolerations`    | Tolerations for Elasti                     | `[]`   |
+| `elasti.affinity`       | Affinity for Elasti                        | `{}`   |
+| `elasti.valuesOverride` | Config override from default config values | `{}`   |
+
+### jspolicy parameters
+
+| Name                             | Description                                              | Value   |
+| -------------------------------- | -------------------------------------------------------- | ------- |
+| `jspolicy.enabled`               | Flag to enable jspolicy. No policy is applied by default | `false` |
+| `jspolicy.enabled`               | Flag to enable jspolicy                                  | `false` |
+| `jspolicy.valuesOverride`        | Config override from default config values               | `{}`    |
+| `jspolicy.affinity`              | Affinity for jspolicy                                    | `{}`    |
+| `jspolicy.tolerations`           | Tolerations for jspolicy                                 | `[]`    |
+| `jspolicy.config.valuesOverride` | Config override from default config values               | `{}`    |
+
+### tfy-workflow-propeller parameters
+
+| Name                                  | Description                                | Value   |
+| ------------------------------------- | ------------------------------------------ | ------- |
+| `tfyWorkflowPropeller.enabled`        | Flag to enable workflow-propeller.         | `false` |
+| `tfyWorkflowPropeller.valuesOverride` | Config override from default config values | `{}`    |
+| `helm.resourcePolicy`                 | Resource policy for the helm chart         | `keep`  |

--- a/charts/tfy-k8s-gcp-gke-standard-inframold/artifacts-manifest.json
+++ b/charts/tfy-k8s-gcp-gke-standard-inframold/artifacts-manifest.json
@@ -220,28 +220,29 @@
         "details": {
             "chart": "truefoundry",
             "repoURL": "oci://tfy.jfrog.io/tfy-helm",
-            "targetRevision": "0.154.0",
+            "targetRevision": "0.156.0",
             "images": [
-                "tfy.jfrog.io/tfy-private-images/tfy-llm-gateway:v0.154.0",
-                "tfy.jfrog.io/tfy-private-images/tfy-otel-collector:v0.151.0",
+                "tfy.jfrog.io/tfy-images/tfy-sandbox-server:v0.3.1",
+                "tfy.jfrog.io/tfy-private-images/tfy-llm-gateway:v0.156.0",
+                "tfy.jfrog.io/tfy-private-images/tfy-otel-collector:v0.156.0",
                 "tfy.jfrog.io/tfy-private-images/deltafusion-query-server:v0.151.0-optimized",
                 "tfy.jfrog.io/tfy-private-images/deltafusion-query-server:v0.151.0",
-                "tfy.jfrog.io/tfy-private-images/mlfoundry-server:v0.154.0",
+                "tfy.jfrog.io/tfy-private-images/mlfoundry-server:v0.155.0",
                 "tfy.jfrog.io/tfy-private-images/s3proxy:v0.149.0",
-                "tfy.jfrog.io/tfy-private-images/servicefoundry-server:v0.154.0",
+                "tfy.jfrog.io/tfy-private-images/servicefoundry-server:v0.156.0",
                 "tfy.jfrog.io/tfy-private-images/sfy-manifest-service:v0.148.0",
                 "tfy.jfrog.io/tfy-private-images/spark-history-server:v0.150.0",
                 "tfy.jfrog.io/tfy-private-images/tfy-controller:v0.150.0",
-                "tfy.jfrog.io/tfy-private-images/tfy-k8s-controller:v0.154.0",
-                "tfy.jfrog.io/tfy-private-images/tfy-proxy:v0.154.0",
+                "tfy.jfrog.io/tfy-private-images/tfy-k8s-controller:v0.156.0",
+                "tfy.jfrog.io/tfy-private-images/tfy-proxy:v0.156.0",
                 "tfy.jfrog.io/tfy-private-images/tfy-workflow-admin:v0.150.0",
                 "tfy.jfrog.io/tfy-images/postgresql:16.6.0-debian-12-r2",
                 "tfy.jfrog.io/tfy-mirror/bitnamilegacy/redis:8.2.1-debian-12-r0",
                 "tfy.jfrog.io/tfy-mirror/nats:2.12.6-alpine",
                 "tfy.jfrog.io/tfy-mirror/natsio/nats-server-config-reloader:0.23.0",
                 "tfy.jfrog.io/tfy-mirror/natsio/prometheus-nats-exporter:0.18.0",
-                "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.154.0-optimized",
-                "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.154.0",
+                "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.155.0-optimized",
+                "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.155.0",
                 "tfy.jfrog.io/tfy-mirror/moby/buildkit:v0.26.2",
                 "tfy.jfrog.io/tfy-images/truefoundry-bootstrap:0.1.6"
             ]
@@ -1135,7 +1136,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-llm-gateway:v0.154.0",
+            "registryURL": "tfy.jfrog.io/tfy-images/tfy-sandbox-server:v0.3.1",
             "platforms": [
                 {
                     "os": "linux",
@@ -1151,7 +1152,23 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-otel-collector:v0.151.0",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-llm-gateway:v0.156.0",
+            "platforms": [
+                {
+                    "os": "linux",
+                    "architecture": "amd64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm64"
+                }
+            ]
+        }
+    },
+    {
+        "type": "image",
+        "details": {
+            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-otel-collector:v0.156.0",
             "platforms": [
                 {
                     "os": "linux",
@@ -1199,7 +1216,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/mlfoundry-server:v0.154.0",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/mlfoundry-server:v0.155.0",
             "platforms": [
                 {
                     "os": "linux",
@@ -1231,7 +1248,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/servicefoundry-server:v0.154.0",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/servicefoundry-server:v0.156.0",
             "platforms": [
                 {
                     "os": "linux",
@@ -1295,7 +1312,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-k8s-controller:v0.154.0",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-k8s-controller:v0.156.0",
             "platforms": [
                 {
                     "os": "linux",
@@ -1311,7 +1328,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-proxy:v0.154.0",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-proxy:v0.156.0",
             "platforms": [
                 {
                     "os": "linux",
@@ -1455,7 +1472,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.154.0-optimized",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.155.0-optimized",
             "platforms": [
                 {
                     "os": "linux",
@@ -1467,7 +1484,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.154.0",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.155.0",
             "platforms": [
                 {
                     "os": "linux",

--- a/charts/tfy-k8s-generic-inframold/README.md
+++ b/charts/tfy-k8s-generic-inframold/README.md
@@ -2,3 +2,247 @@
 Inframold, the superchart that configure your cluster on generic for truefoundry.
 
 ## Parameters
+
+### Global Parameters
+
+| Name               | Description                                                | Value |
+| ------------------ | ---------------------------------------------------------- | ----- |
+| `global.repoURL`   | Override chart repository URL for all Argo CD Applications | `""`  |
+| `tenantName`       | Parameters for tenantName                                  | `""`  |
+| `controlPlaneURL`  | Parameters for controlPlaneURL                             | `""`  |
+| `clusterName`      | Name of the cluster                                        | `""`  |
+| `registry`         | registry to override in the chart components               | `""`  |
+| `imagePullSecrets` | imagePullSecrets to override in the chart components       | `[]`  |
+| `tolerations`      | Tolerations for the all chart components                   | `[]`  |
+| `affinity`         | Affinity for the all chart components                      | `{}`  |
+
+### argocd parameters
+
+| Name                    | Description                                | Value  |
+| ----------------------- | ------------------------------------------ | ------ |
+| `argocd.enabled`        | Flag to enable ArgoCD                      | `true` |
+| `argocd.tolerations`    | Tolerations for ArgoCD                     | `[]`   |
+| `argocd.affinity`       | Affinity for ArgoCD                        | `{}`   |
+| `argocd.valuesOverride` | Config override from default config values | `{}`   |
+
+### argoWorkflows parameters
+
+| Name                           | Description                                | Value  |
+| ------------------------------ | ------------------------------------------ | ------ |
+| `argoWorkflows.enabled`        | Flag to enable Argo Workflows              | `true` |
+| `argoWorkflows.tolerations`    | Tolerations for Argo Workflows             | `[]`   |
+| `argoWorkflows.affinity`       | Affinity for Argo Workflows                | `{}`   |
+| `argoWorkflows.valuesOverride` | Config override from default config values | `{}`   |
+
+### argoRollouts parameters
+
+| Name                          | Description                                | Value  |
+| ----------------------------- | ------------------------------------------ | ------ |
+| `argoRollouts.enabled`        | Flag to enable Argo Rollouts               | `true` |
+| `argoRollouts.tolerations`    | Tolerations for Argo Rollouts              | `[]`   |
+| `argoRollouts.affinity`       | Affinity for Argo Rollouts                 | `{}`   |
+| `argoRollouts.valuesOverride` | Config override from default config values | `{}`   |
+
+### certManager parameters
+
+| Name                                     | Description                                                                       | Value  |
+| ---------------------------------------- | --------------------------------------------------------------------------------- | ------ |
+| `certManager.enabled`                    | Flag to enable Cert Manager                                                       | `true` |
+| `certManager.tolerations`                | Tolerations for Cert Manager                                                      | `[]`   |
+| `certManager.podLabels`                  | Pod labels for Cert Manager. For Azure will be applied to serviceaccount as well. | `{}`   |
+| `certManager.serviceAccount.annotations` | Service account annotations for Cert Manager.                                     | `{}`   |
+| `certManager.affinity`                   | Affinity for Cert Manager                                                         | `{}`   |
+| `certManager.valuesOverride`             | Config override from default config values                                        | `{}`   |
+
+### certManager issuers parameters
+
+| Name                                | Description                                        | Value  |
+| ----------------------------------- | -------------------------------------------------- | ------ |
+| `certManager.config.enabled`        | Flag to enable certManager config                  | `true` |
+| `certManager.config.issuers`        | Map of issuers and their certificate configuration | `{}`   |
+| `certManager.config.valuesOverride` | Config override from default config values         | `{}`   |
+
+### metricsServer parameters
+
+| Name                           | Description                                | Value   |
+| ------------------------------ | ------------------------------------------ | ------- |
+| `metricsServer.enabled`        | Flag to enable Metrics Server              | `false` |
+| `metricsServer.enabled`        | Flag to enable Metrics Server              | `false` |
+| `metricsServer.tolerations`    | Tolerations for Metrics Server             | `[]`    |
+| `metricsServer.affinity`       | Affinity for Metrics Server                | `{}`    |
+| `metricsServer.valuesOverride` | Config override from default config values | `{}`    |
+
+### gpu parameters
+
+| Name                 | Description                                | Value     |
+| -------------------- | ------------------------------------------ | --------- |
+| `gpu.enabled`        | Flag to enable Tfy GPU Operator            | `true`    |
+| `gpu.clusterType`    | Cluster type for Tfy GPU Operator          | `generic` |
+| `gpu.valuesOverride` | Config override from default config values | `{}`      |
+
+### truefoundry parameters
+
+| Name                          | Description                                | Value   |
+| ----------------------------- | ------------------------------------------ | ------- |
+| `truefoundry.enabled`         | Flag to enable TrueFoundry                 | `false` |
+| `truefoundry.devMode.enabled` | Flag to enable TrueFoundry Dev mode        | `false` |
+| `truefoundry.valuesOverride`  | Config override from default config values | `{}`    |
+
+### truefoundryBootstrap parameters
+
+| Name                                       | Description                                                               | Value  |
+| ------------------------------------------ | ------------------------------------------------------------------------- | ------ |
+| `truefoundry.truefoundryBootstrap.enabled` | Flag to enable bootstrap job to prep cluster for truefoundry installation | `true` |
+
+### Truefoundry virtual service parameters
+
+| Name                                         | Description                                        | Value   |
+| -------------------------------------------- | -------------------------------------------------- | ------- |
+| `truefoundry.virtualservice.enabled`         | Flag to enable virtualservice                      | `false` |
+| `truefoundry.virtualservice.hosts`           | Hosts for truefoundry virtualservice               | `[]`    |
+| `truefoundry.virtualservice.gateways`        | Istio gateways to be configured for virtualservice | `[]`    |
+| `truefoundry.virtualservice.annotations`     | Annotations for truefoundry virtualservice         | `{}`    |
+| `truefoundry.existingTruefoundryCredsSecret` | Secret name for existing Truefoundry creds         | `""`    |
+
+### database. Can be left empty if using the dev mode parameters
+
+| Name                                               | Description                                                | Value     |
+| -------------------------------------------------- | ---------------------------------------------------------- | --------- |
+| `truefoundry.database.host`                        | Hostname of the database                                   | `""`      |
+| `truefoundry.database.name`                        | Name of the database                                       | `""`      |
+| `truefoundry.database.username`                    | Username of the database                                   | `""`      |
+| `truefoundry.database.password`                    | Password of the database                                   | `""`      |
+| `truefoundry.tfyApiKey`                            | API Key for TrueFoundry                                    | `""`      |
+| `truefoundry.imagePullSecrets`                     | Image pull secrets for TrueFoundry                         | `[]`      |
+| `truefoundry.truefoundryImagePullConfigJSON`       | Json config for authenticating to the TrueFoundry registry | `""`      |
+| `truefoundry.truefoundry_iam_role_arn_annotations` | IAM role annotations for service accounts                  | `{}`      |
+| `truefoundry.defaultCloudProvider`                 | Default cloud provider                                     | `generic` |
+| `truefoundry.storageConfiguration`                 | Storage class for the storage configuration                | `{}`      |
+| `truefoundry.s3proxy.enabled`                      | Flag to enable S3 Proxy                                    | `false`   |
+| `truefoundry.sparkHistoryServer.enabled`           | Flag to enable Spark History Server                        | `false`   |
+| `truefoundry.tfyWorkflowAdmin.enabled`             | Flag to enable Tfy Workflow Admin                          | `false`   |
+| `truefoundry.gateway.enabled`                      | Flag to enable Gateway                                     | `false`   |
+| `truefoundry.tolerations`                          | Tolerations for the truefoundry components                 | `[]`      |
+| `truefoundry.affinity`                             | Affinity for the truefoundry components                    | `{}`      |
+
+### tfyLogs parameters
+
+| Name                     | Description                                | Value  |
+| ------------------------ | ------------------------------------------ | ------ |
+| `tfyLogs.enabled`        | Flag to enable Tfy Logs                    | `true` |
+| `tfyLogs.valuesOverride` | Config override from default config values | `{}`   |
+| `tfyLogs.affinity`       | Affinity for tfyLogs statefulset pod       | `{}`   |
+| `tfyLogs.tolerations`    | Tolerations for tfyLogs statefulset pod    | `[]`   |
+
+### istio parameters
+
+| Name                                    | Description                                | Value   |
+| --------------------------------------- | ------------------------------------------ | ------- |
+| `istio.enabled`                         | Flag to enable Istio                       | `true`  |
+| `istio.enabled`                         | Flag to enable Istio Base                  | `true`  |
+| `istio.base.valuesOverride`             | Config override from default config values | `{}`    |
+| `istio.awsElbControllerChecker.enabled` | Flag to enable AWS ELB Controller Checker  | `false` |
+| `istio.gateway.annotations`             | Annotations for Istio Gateway              | `{}`    |
+| `istio.gateway.affinity`                | Affinity for the gateway pods              | `{}`    |
+| `istio.gateway.tolerations`             | Tolerations for the gateway pods           | `[]`    |
+| `istio.gateway.valuesOverride`          | Config override from default config values | `{}`    |
+
+### istio discovery parameters
+
+| Name                             | Description                                | Value                  |
+| -------------------------------- | ------------------------------------------ | ---------------------- |
+| `istio.discovery.hub`            | Hub for the istio image                    | `gcr.io/istio-release` |
+| `istio.discovery.tolerations`    | Tolerations for Istio Discovery            | `[]`                   |
+| `istio.discovery.affinity`       | Affinity for Istio Discovery               | `{}`                   |
+| `istio.discovery.valuesOverride` | Config override from default config values | `{}`                   |
+
+### istio tfyGateway parameters
+
+| Name                                  | Description                                     | Value    |
+| ------------------------------------- | ----------------------------------------------- | -------- |
+| `istio.tfyGateway.httpsRedirect`      | Flag to enable HTTPS redirect for Istio Gateway | `false`  |
+| `istio.tfyGateway.tls.enabled`        | Flag to enable TLS for Istio Gateway            | `false`  |
+| `istio.tfyGateway.tls.mode`           | TLS mode for the Istio Gateway                  | `SIMPLE` |
+| `istio.tfyGateway.tls.credentialName` | Credential name for the TLS certificate         | `""`     |
+| `istio.tfyGateway.domains`            | Domains for the gateway pods                    | `[]`     |
+
+### keda parameters
+
+| Name                  | Description                                | Value  |
+| --------------------- | ------------------------------------------ | ------ |
+| `keda.enabled`        | Flag to enable Keda                        | `true` |
+| `keda.tolerations`    | Tolerations for Keda                       | `[]`   |
+| `keda.affinity`       | Affinity for Keda                          | `{}`   |
+| `keda.valuesOverride` | Config override from default config values | `{}`   |
+
+### sparkOperator parameters
+
+| Name                           | Description                                | Value   |
+| ------------------------------ | ------------------------------------------ | ------- |
+| `sparkOperator.enabled`        | Flag to enable Spark Operator              | `false` |
+| `sparkOperator.tolerations`    | Tolerations for Spark Operator             | `[]`    |
+| `sparkOperator.affinity`       | Affinity for Spark Operator                | `{}`    |
+| `sparkOperator.valuesOverride` | Config override from default config values | `{}`    |
+
+### prometheus parameters
+
+| Name                                     | Description                                                               | Value  |
+| ---------------------------------------- | ------------------------------------------------------------------------- | ------ |
+| `prometheus.enabled`                     | Flag to enable Prometheus                                                 | `true` |
+| `prometheus.additionalScrapeConfigs`     | Additional scrape configs for Prometheus                                  | `[]`   |
+| `prometheus.alertmanager`                | Alertmanager configuration for Prometheus                                 | `{}`   |
+| `prometheus.affinity`                    | Affinity for prometheus statefulset pod                                   | `{}`   |
+| `prometheus.tolerations`                 | Tolerations for prometheus statefulset pod                                | `[]`   |
+| `prometheus.valuesOverride`              | Config override from default config values                                | `{}`   |
+| `prometheus.prometheusNodeExporter.port` | Port for prometheus-node-exporter service and container (default 9100)    | `9100` |
+| `prometheus.config.enabled`              | Flag to enable prometheus config (requires prometheus.enabled to be true) | `true` |
+| `prometheus.config.valuesOverride`       | Config override from default config values                                | `{}`   |
+| `prometheus.config.extraObjects`         | Extra objects for prometheus config                                       | `[]`   |
+
+### grafana parameters
+
+| Name                     | Description                                | Value   |
+| ------------------------ | ------------------------------------------ | ------- |
+| `grafana.enabled`        | Flag to enable Grafana                     | `false` |
+| `grafana.tolerations`    | Tolerations for Grafana                    | `[]`    |
+| `grafana.affinity`       | Affinity for Grafana                       | `{}`    |
+| `grafana.valuesOverride` | Config override from default config values | `{}`    |
+
+### tfyAgent parameters
+
+| Name                          | Description                                | Value  |
+| ----------------------------- | ------------------------------------------ | ------ |
+| `tfyAgent.enabled`            | Flag to enable Tfy Agent                   | `true` |
+| `tfyAgent.valuesOverride`     | Config override from default config values | `{}`   |
+| `tfyAgent.tolerations`        | Tolerations for the agent pods             | `[]`   |
+| `tfyAgent.affinity`           | Affinity for the agent pods                | `{}`   |
+| `tfyAgent.clusterToken`       | cluster token                              | `""`   |
+| `tfyAgent.clusterTokenSecret` | Secret name for cluster token              | `""`   |
+
+### elasti parameters
+
+| Name                    | Description                                | Value  |
+| ----------------------- | ------------------------------------------ | ------ |
+| `elasti.enabled`        | Flag to enable Elasti                      | `true` |
+| `elasti.tolerations`    | Tolerations for Elasti                     | `[]`   |
+| `elasti.affinity`       | Affinity for Elasti                        | `{}`   |
+| `elasti.valuesOverride` | Config override from default config values | `{}`   |
+
+### jspolicy parameters
+
+| Name                             | Description                                              | Value   |
+| -------------------------------- | -------------------------------------------------------- | ------- |
+| `jspolicy.enabled`               | Flag to enable jspolicy. No policy is applied by default | `false` |
+| `jspolicy.enabled`               | Flag to enable jspolicy                                  | `false` |
+| `jspolicy.valuesOverride`        | Config override from default config values               | `{}`    |
+| `jspolicy.affinity`              | Affinity for jspolicy                                    | `{}`    |
+| `jspolicy.tolerations`           | Tolerations for jspolicy                                 | `[]`    |
+| `jspolicy.config.valuesOverride` | Config override from default config values               | `{}`    |
+
+### tfy-workflow-propeller parameters
+
+| Name                                  | Description                                | Value   |
+| ------------------------------------- | ------------------------------------------ | ------- |
+| `tfyWorkflowPropeller.enabled`        | Flag to enable workflow-propeller.         | `false` |
+| `tfyWorkflowPropeller.valuesOverride` | Config override from default config values | `{}`    |
+| `helm.resourcePolicy`                 | Resource policy for the helm chart         | `keep`  |

--- a/charts/tfy-k8s-generic-inframold/artifacts-manifest.json
+++ b/charts/tfy-k8s-generic-inframold/artifacts-manifest.json
@@ -229,28 +229,29 @@
         "details": {
             "chart": "truefoundry",
             "repoURL": "oci://tfy.jfrog.io/tfy-helm",
-            "targetRevision": "0.154.0",
+            "targetRevision": "0.156.0",
             "images": [
-                "tfy.jfrog.io/tfy-private-images/tfy-llm-gateway:v0.154.0",
-                "tfy.jfrog.io/tfy-private-images/tfy-otel-collector:v0.151.0",
+                "tfy.jfrog.io/tfy-images/tfy-sandbox-server:v0.3.1",
+                "tfy.jfrog.io/tfy-private-images/tfy-llm-gateway:v0.156.0",
+                "tfy.jfrog.io/tfy-private-images/tfy-otel-collector:v0.156.0",
                 "tfy.jfrog.io/tfy-private-images/deltafusion-query-server:v0.151.0-optimized",
                 "tfy.jfrog.io/tfy-private-images/deltafusion-query-server:v0.151.0",
-                "tfy.jfrog.io/tfy-private-images/mlfoundry-server:v0.154.0",
+                "tfy.jfrog.io/tfy-private-images/mlfoundry-server:v0.155.0",
                 "tfy.jfrog.io/tfy-private-images/s3proxy:v0.149.0",
-                "tfy.jfrog.io/tfy-private-images/servicefoundry-server:v0.154.0",
+                "tfy.jfrog.io/tfy-private-images/servicefoundry-server:v0.156.0",
                 "tfy.jfrog.io/tfy-private-images/sfy-manifest-service:v0.148.0",
                 "tfy.jfrog.io/tfy-private-images/spark-history-server:v0.150.0",
                 "tfy.jfrog.io/tfy-private-images/tfy-controller:v0.150.0",
-                "tfy.jfrog.io/tfy-private-images/tfy-k8s-controller:v0.154.0",
-                "tfy.jfrog.io/tfy-private-images/tfy-proxy:v0.154.0",
+                "tfy.jfrog.io/tfy-private-images/tfy-k8s-controller:v0.156.0",
+                "tfy.jfrog.io/tfy-private-images/tfy-proxy:v0.156.0",
                 "tfy.jfrog.io/tfy-private-images/tfy-workflow-admin:v0.150.0",
                 "tfy.jfrog.io/tfy-images/postgresql:16.6.0-debian-12-r2",
                 "tfy.jfrog.io/tfy-mirror/bitnamilegacy/redis:8.2.1-debian-12-r0",
                 "tfy.jfrog.io/tfy-mirror/nats:2.12.6-alpine",
                 "tfy.jfrog.io/tfy-mirror/natsio/nats-server-config-reloader:0.23.0",
                 "tfy.jfrog.io/tfy-mirror/natsio/prometheus-nats-exporter:0.18.0",
-                "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.154.0-optimized",
-                "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.154.0",
+                "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.155.0-optimized",
+                "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.155.0",
                 "tfy.jfrog.io/tfy-mirror/moby/buildkit:v0.26.2",
                 "tfy.jfrog.io/tfy-images/truefoundry-bootstrap:0.1.6"
             ]
@@ -1149,7 +1150,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-llm-gateway:v0.154.0",
+            "registryURL": "tfy.jfrog.io/tfy-images/tfy-sandbox-server:v0.3.1",
             "platforms": [
                 {
                     "os": "linux",
@@ -1165,7 +1166,23 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-otel-collector:v0.151.0",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-llm-gateway:v0.156.0",
+            "platforms": [
+                {
+                    "os": "linux",
+                    "architecture": "amd64"
+                },
+                {
+                    "os": "linux",
+                    "architecture": "arm64"
+                }
+            ]
+        }
+    },
+    {
+        "type": "image",
+        "details": {
+            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-otel-collector:v0.156.0",
             "platforms": [
                 {
                     "os": "linux",
@@ -1213,7 +1230,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/mlfoundry-server:v0.154.0",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/mlfoundry-server:v0.155.0",
             "platforms": [
                 {
                     "os": "linux",
@@ -1245,7 +1262,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/servicefoundry-server:v0.154.0",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/servicefoundry-server:v0.156.0",
             "platforms": [
                 {
                     "os": "linux",
@@ -1309,7 +1326,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-k8s-controller:v0.154.0",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-k8s-controller:v0.156.0",
             "platforms": [
                 {
                     "os": "linux",
@@ -1325,7 +1342,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-proxy:v0.154.0",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/tfy-proxy:v0.156.0",
             "platforms": [
                 {
                     "os": "linux",
@@ -1469,7 +1486,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.154.0-optimized",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.155.0-optimized",
             "platforms": [
                 {
                     "os": "linux",
@@ -1481,7 +1498,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.154.0",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/deltafusion-ingestor:v0.155.0",
             "platforms": [
                 {
                     "os": "linux",


### PR DESCRIPTION
## Summary

Cherry-pick of #2972 onto `main`.

When `aws.karpenter.kmsKeyID` and `tags` are both unset (as in `values-artifact-manifest.yaml`), `inferentiaDefaultNodeTemplate` and `controlPlaneNodeTemplate` rendered as bare YAML keys (`key:` with no content), which YAML parses as **null**. A null value overrides Helm chart defaults during merge, causing a nil pointer panic in the `tfy-karpenter-config` chart CI.

This was the root cause of the CI failure in #2964 — the artifact manifest workflow failed, but the PR was merged anyway, leaving `main` with stale artifact manifests.

## Why this PR

Opening this against `main` so the CI (`Generate Inframold Charts Artifacts Manifest`) triggers again — it should now pass and auto-commit the updated artifact manifests that were missed when #2964 merged with a broken CI.

## Related

- Original failing CI: https://github.com/truefoundry/infra-charts/actions/runs/28648704459/job/84962266097
- Fix on inframold-0.1.309: #2972
- Upstream fix in ubermold-base: https://github.com/truefoundry/ubermold-base/pull/2576

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The template change affects Karpenter node provisioning config for clusters without KMS/tags; manifest bumps drive a broad TrueFoundry image rollout when synced.
> 
> **Overview**
> **Fixes Karpenter config rendering on AWS EKS inframold** so `inferentiaDefaultNodeTemplate`, `critical.nodeclass`, and `controlPlaneNodeTemplate` are only emitted when `aws.karpenter.kmsKeyID` or `tags` is set. That avoids empty YAML keys that parse as null and break `tfy-karpenter-config` / artifact-manifest CI when both values are unset.
> 
> **Refreshes inframold artifact manifests** (AWS, Azure, Civo, GCP, generic): bumps `truefoundry` to **0.156.0**, `tfy-karpenter-config` to **0.1.57** on AWS, adds **`tfy-sandbox-server:v0.3.1`**, and updates pinned TrueFoundry service image tags.
> 
> **Adds generated Helm parameter tables** to several inframold chart READMEs (documentation only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 406aa5765c183fe0014c8189a6da10f578e2b68f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->