### PR TITLE
fix: guard critical.nodeclass against YAML null in aws-eks inframold

### DIFF
--- a/charts/tfy-k8s-aws-eks-inframold/templates/tfy-aws/karpenter-config.yaml
+++ b/charts/tfy-k8s-aws-eks-inframold/templates/tfy-aws/karpenter-config.yaml
@@ -79,6 +79,7 @@ spec:
             zones: {{- range .Values.aws.karpenter.defaultZones }}
             - {{ . | quote }}
             {{- end }}
+            {{- if or .Values.aws.karpenter.kmsKeyID .Values.tags }}
             nodeclass:
               {{- if .Values.aws.karpenter.kmsKeyID }}
               kmsKeyID: {{ .Values.aws.karpenter.kmsKeyID | default "" }}
@@ -89,6 +90,7 @@ spec:
                 {{ $k }}: {{ $v | quote }}
                 {{- end }}
               {{- end }}
+            {{- end }}
           controlPlaneNodePool:
             zones: {{- range .Values.aws.karpenter.defaultZones }}
             - {{ . | quote }}


### PR DESCRIPTION
## Summary

Follow-up to #2972. `critical.nodeclass` in the karpenter-config template has the same null-override pattern: it contains only conditional sub-keys (`kmsKeyID`, `extraTags`), so when neither `aws.karpenter.kmsKeyID` nor `tags` is set, it renders as a bare `nodeclass:` key — which YAML parses as **null**.

This caused the next CI failure after #2972 was merged:
```
nil pointer evaluating interface {}.name
tfy-karpenter-config/templates/critical/karpenter-critical-nodepool.yaml:15
```

## Fix

Same guard as before: wrap `nodeclass:` in `{{- if or .Values.aws.karpenter.kmsKeyID .Values.tags }}`.

## Related

- #2972 (inferentiaDefaultNodeTemplate + controlPlaneNodeTemplate)
- https://github.com/truefoundry/infra-charts/pull/2974 (backport to main)
- https://github.com/truefoundry/ubermold-base/pull/2576 (upstream fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Helm templating guard aligned with an existing pattern; no runtime logic or security surface changes.
> 
> **Overview**
> **Wraps `critical.nodeclass` in the AWS EKS inframold Karpenter values template** with the same `{{- if or .Values.aws.karpenter.kmsKeyID .Values.tags }}` guard already used for `inferentiaDefaultNodeTemplate` and `controlPlaneNodeTemplate` (#2972).
> 
> When neither KMS key nor cluster tags are configured, the block previously emitted a bare `nodeclass:` key, which YAML treats as **null** and breaks `tfy-karpenter-config` rendering (e.g. nil pointer on `nodeclass.name` in the critical node pool template). The key is now omitted entirely in that case so defaults in the child chart apply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 351f7a7de54e13c6331edd4e704d23a7f17a3e79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->