### PR TITLE
feat: python pip conf for private indexes

### DIFF
--- a/charts/truefoundry/tfy-build-scripts/build-and-push.sh
+++ b/charts/truefoundry/tfy-build-scripts/build-and-push.sh
@@ -46,18 +46,28 @@ eval "BUILD_CONFIG_CORRECTED=$(echo $BUILD_CONFIG)"
 build_secrets=$(echo "$TFY_BUILD_SECRETS" | jq -r '.[] | "--secret id=" + .id + ",src=/truefoundry-build-secrets/" + .id')
 
 if [[ -n "${PYTHON_INDEX_URL:-}" ]]; then
-  mkdir -p /truefoundry-build-secrets
+  _PY_INDEX_DIR="/tmp/truefoundry-python-index"
+  mkdir -p "$_PY_INDEX_DIR"
   if [[ -n "${PYTHON_INDEX_USERNAME:-}" ]] && [[ -n "${PYTHON_INDEX_PASSWORD:-}" ]]; then
-    AUTHED_URL=$(python3 -c "
+    _PY_INDEX_RESOLVED_URL=$(
+      PYTHON_INDEX_URL="$PYTHON_INDEX_URL" \
+      PYTHON_INDEX_USERNAME="$PYTHON_INDEX_USERNAME" \
+      PYTHON_INDEX_PASSWORD="$PYTHON_INDEX_PASSWORD" \
+      python3 -c "
+import os
 from urllib.parse import urlparse, urlunparse, quote
-u = urlparse('${PYTHON_INDEX_URL}')
-print(urlunparse(u._replace(netloc=quote('${PYTHON_INDEX_USERNAME}', safe='') + ':' + quote('${PYTHON_INDEX_PASSWORD}', safe='') + '@' + u.hostname + (':' + str(u.port) if u.port else ''))))
+u = urlparse(os.environ['PYTHON_INDEX_URL'])
+user = quote(os.environ['PYTHON_INDEX_USERNAME'], safe='')
+pwd = quote(os.environ['PYTHON_INDEX_PASSWORD'], safe='')
+port = ':' + str(u.port) if u.port else ''
+print(urlunparse(u._replace(netloc=user + ':' + pwd + '@' + u.hostname + port)))
 ")
-    printf "[global]\nindex-url = %s\n" "$AUTHED_URL" > /truefoundry-build-secrets/pip.conf
   else
-    printf "[global]\nindex-url = %s\n" "$PYTHON_INDEX_URL" > /truefoundry-build-secrets/pip.conf
+    _PY_INDEX_RESOLVED_URL="$PYTHON_INDEX_URL"
   fi
-  build_secrets="$build_secrets --secret id=pip.conf,src=/truefoundry-build-secrets/pip.conf"
+  printf "[global]\nindex-url = %s\n" "$_PY_INDEX_RESOLVED_URL" > "$_PY_INDEX_DIR/pip.conf"
+  printf "[[index]]\nurl = \"%s\"\ndefault = true\n" "$_PY_INDEX_RESOLVED_URL" > "$_PY_INDEX_DIR/uv.toml"
+  build_secrets="$build_secrets --secret id=pip.conf,src=$_PY_INDEX_DIR/pip.conf --secret id=uv.toml,src=$_PY_INDEX_DIR/uv.toml"
 fi
 
 start_time=$(date +%s)

--- a/charts/truefoundry/tfy-build-scripts/build-and-push.sh
+++ b/charts/truefoundry/tfy-build-scripts/build-and-push.sh
@@ -45,6 +45,21 @@ fi
 eval "BUILD_CONFIG_CORRECTED=$(echo $BUILD_CONFIG)"
 build_secrets=$(echo "$TFY_BUILD_SECRETS" | jq -r '.[] | "--secret id=" + .id + ",src=/truefoundry-build-secrets/" + .id')
 
+if [[ -n "${PYTHON_INDEX_URL:-}" ]]; then
+  mkdir -p /truefoundry-build-secrets
+  if [[ -n "${PYTHON_INDEX_USERNAME:-}" ]] && [[ -n "${PYTHON_INDEX_PASSWORD:-}" ]]; then
+    AUTHED_URL=$(python3 -c "
+from urllib.parse import urlparse, urlunparse, quote
+u = urlparse('${PYTHON_INDEX_URL}')
+print(urlunparse(u._replace(netloc=quote('${PYTHON_INDEX_USERNAME}', safe='') + ':' + quote('${PYTHON_INDEX_PASSWORD}', safe='') + '@' + u.hostname + (':' + str(u.port) if u.port else ''))))
+")
+    printf "[global]\nindex-url = %s\n" "$AUTHED_URL" > /truefoundry-build-secrets/pip.conf
+  else
+    printf "[global]\nindex-url = %s\n" "$PYTHON_INDEX_URL" > /truefoundry-build-secrets/pip.conf
+  fi
+  build_secrets="$build_secrets --secret id=pip.conf,src=/truefoundry-build-secrets/pip.conf"
+fi
+
 start_time=$(date +%s)
 tfy build $build_secrets --build-config="$BUILD_CONFIG_CORRECTED" --name="${IMAGE}:$DOCKER_TAG" --tag="${IMAGE}:$DOCKER_TAG" --tag="${IMAGE}:latest" --cache-to="type=registry,ref=${IMAGE}:cache-latest,image-manifest=true,mode=max${REGISTRY_INSECURE_OPTS}" --cache-from=type=registry,ref="${IMAGE}:cache-latest${REGISTRY_INSECURE_OPTS}" --build-context tfy-secrets=/var/run/secrets/ --builder=remote-kubernetes --output=type=image,push=true,compression=gzip,compression-level=0,force-compression=true${REGISTRY_INSECURE_OPTS}
 end_time=$(date +%s)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Build-time handling of PyPI credentials (temp files and embedded auth in index URLs) affects every image build that sets these env vars; misconfiguration could leak creds into build logs or layers if Dockerfiles mount secrets incorrectly.
> 
> **Overview**
> When **`PYTHON_INDEX_URL`** is set, **`build-and-push.sh`** now generates **`pip.conf`** and **`uv.toml`** under a temp directory and appends them to the existing **`tfy build`** secret list so Docker builds can resolve packages from a custom index (including private PyPI).
> 
> If **`PYTHON_INDEX_USERNAME`** and **`PYTHON_INDEX_PASSWORD`** are both set, a short Python snippet URL-encodes the credentials and embeds them in the index URL written into those config files; otherwise the raw **`PYTHON_INDEX_URL`** is used. No change to the build path when the env var is unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 262ccf8f03c050fca8501995aee98337eb57878f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->