### PR TITLE
Added a toggle to disable installation of istio crds

### DIFF
--- a/charts/tfy-istio-ingress/Chart.yaml
+++ b/charts/tfy-istio-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: tfy-istio-ingress
-version: 0.3.6
+version: 0.3.7
 description: "ArgoCD Applications for istio ingress config"
 maintainers:
   - name: truefoundry
@@ -11,3 +11,4 @@ dependencies:
   - name: tfy-gateway-api-crd
     version: 0.1.1
     repository: https://truefoundry.github.io/infra-charts/
+    condition: tfy-gateway-api-crd.enabled

--- a/charts/tfy-istio-ingress/Chart.yaml
+++ b/charts/tfy-istio-ingress/Chart.yaml
@@ -11,4 +11,4 @@ dependencies:
   - name: tfy-gateway-api-crd
     version: 0.1.1
     repository: https://truefoundry.github.io/infra-charts/
-    condition: global.installGatewayCrds
+    condition: installGatewayCrds

--- a/charts/tfy-istio-ingress/Chart.yaml
+++ b/charts/tfy-istio-ingress/Chart.yaml
@@ -11,4 +11,4 @@ dependencies:
   - name: tfy-gateway-api-crd
     version: 0.1.1
     repository: https://truefoundry.github.io/infra-charts/
-    condition: global.installCrds
+    condition: global.installGatewayCrds

--- a/charts/tfy-istio-ingress/Chart.yaml
+++ b/charts/tfy-istio-ingress/Chart.yaml
@@ -11,4 +11,4 @@ dependencies:
   - name: tfy-gateway-api-crd
     version: 0.1.1
     repository: https://truefoundry.github.io/infra-charts/
-    condition: tfy-gateway-api-crd.enabled
+    condition: global.installCrds

--- a/charts/tfy-istio-ingress/README.md
+++ b/charts/tfy-istio-ingress/README.md
@@ -5,8 +5,8 @@ Tfy-istio-ingress is a Helm chart that facilitates the deployment and configurat
 
 ### Gateway API CRDs
 
-| Name                          | Description                                                                                                        | Value  |
-| ----------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------ |
+| Name                          | Description                                                                                                         | Value  |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------ |
 | `tfy-gateway-api-crd.enabled` | Install the Gateway API CRDs sub-chart. Set to false to only install the istio gateway sub-chart and skip the CRDs. | `true` |
 
 ### ALB Configuration

--- a/charts/tfy-istio-ingress/README.md
+++ b/charts/tfy-istio-ingress/README.md
@@ -7,7 +7,7 @@ Tfy-istio-ingress is a Helm chart that facilitates the deployment and configurat
 
 | Name                  | Description                                                                                                         | Value  |
 | --------------------- | ------------------------------------------------------------------------------------------------------------------ | ------ |
-| `global.installCrds`  | Install the Gateway API CRDs sub-chart. Set to false to only install the istio gateway sub-chart and skip the CRDs. | `true` |
+| `global.installGatewayCrds`  | Install the Gateway API CRDs sub-chart. Set to false to only install the istio gateway sub-chart and skip the CRDs. | `true` |
 
 ### ALB Configuration
 

--- a/charts/tfy-istio-ingress/README.md
+++ b/charts/tfy-istio-ingress/README.md
@@ -3,11 +3,11 @@ Tfy-istio-ingress is a Helm chart that facilitates the deployment and configurat
 
 ## Parameters
 
-### Global
+### Gateway API CRDs
 
-| Name                        | Description                                                                                                         | Value  |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------ |
-| `global.installGatewayCrds` | Install the Gateway API CRDs sub-chart. Set to false to only install the istio gateway sub-chart and skip the CRDs. | `true` |
+| Name                  | Description                                                                                                         | Value  |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------ | ------ |
+| `installGatewayCrds`  | Install the Gateway API CRDs sub-chart. Set to false to only install the istio gateway sub-chart and skip the CRDs. | `true` |
 
 ### ALB Configuration
 

--- a/charts/tfy-istio-ingress/README.md
+++ b/charts/tfy-istio-ingress/README.md
@@ -3,6 +3,12 @@ Tfy-istio-ingress is a Helm chart that facilitates the deployment and configurat
 
 ## Parameters
 
+### Gateway API CRDs
+
+| Name                          | Description                                                                                                        | Value  |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------ |
+| `tfy-gateway-api-crd.enabled` | Install the Gateway API CRDs sub-chart. Set to false to only install the istio gateway sub-chart and skip the CRDs. | `true` |
+
 ### ALB Configuration
 
 | Name                               | Description                                | Value   |

--- a/charts/tfy-istio-ingress/README.md
+++ b/charts/tfy-istio-ingress/README.md
@@ -5,9 +5,9 @@ Tfy-istio-ingress is a Helm chart that facilitates the deployment and configurat
 
 ### Global
 
-| Name                  | Description                                                                                                         | Value  |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------ | ------ |
-| `global.installGatewayCrds`  | Install the Gateway API CRDs sub-chart. Set to false to only install the istio gateway sub-chart and skip the CRDs. | `true` |
+| Name                        | Description                                                                                                         | Value  |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------ |
+| `global.installGatewayCrds` | Install the Gateway API CRDs sub-chart. Set to false to only install the istio gateway sub-chart and skip the CRDs. | `true` |
 
 ### ALB Configuration
 

--- a/charts/tfy-istio-ingress/README.md
+++ b/charts/tfy-istio-ingress/README.md
@@ -5,9 +5,9 @@ Tfy-istio-ingress is a Helm chart that facilitates the deployment and configurat
 
 ### Gateway API CRDs
 
-| Name                  | Description                                                                                                         | Value  |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------ | ------ |
-| `installGatewayCrds`  | Install the Gateway API CRDs sub-chart. Set to false to only install the istio gateway sub-chart and skip the CRDs. | `true` |
+| Name                 | Description                                                                                                         | Value  |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------- | ------ |
+| `installGatewayCrds` | Install the Gateway API CRDs sub-chart. Set to false to only install the istio gateway sub-chart and skip the CRDs. | `true` |
 
 ### ALB Configuration
 

--- a/charts/tfy-istio-ingress/README.md
+++ b/charts/tfy-istio-ingress/README.md
@@ -3,11 +3,11 @@ Tfy-istio-ingress is a Helm chart that facilitates the deployment and configurat
 
 ## Parameters
 
-### Gateway API CRDs
+### Global
 
-| Name                          | Description                                                                                                        | Value  |
-| ----------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------ |
-| `tfy-gateway-api-crd.enabled` | Install the Gateway API CRDs sub-chart. Set to false to only install the istio gateway sub-chart and skip the CRDs. | `true` |
+| Name                  | Description                                                                                                         | Value  |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------ | ------ |
+| `global.installCrds`  | Install the Gateway API CRDs sub-chart. Set to false to only install the istio gateway sub-chart and skip the CRDs. | `true` |
 
 ### ALB Configuration
 

--- a/charts/tfy-istio-ingress/values.yaml
+++ b/charts/tfy-istio-ingress/values.yaml
@@ -1,9 +1,8 @@
-## @section Global
+## @section Gateway API CRDs
 ##
-global:
-  ## @param global.installGatewayCrds Install the Gateway API CRDs sub-chart. Set to false to only install the istio gateway sub-chart and skip the CRDs.
-  ##
-  installGatewayCrds: true
+## @param installGatewayCrds Install the Gateway API CRDs sub-chart. Set to false to only install the istio gateway sub-chart and skip the CRDs.
+##
+installGatewayCrds: true
 
 ## @section ALB Configuration
 ## Configuration for AWS Application Load Balancer

--- a/charts/tfy-istio-ingress/values.yaml
+++ b/charts/tfy-istio-ingress/values.yaml
@@ -1,3 +1,11 @@
+## @section Gateway API CRDs
+## Configuration for the bundled Gateway API CRDs sub-chart.
+##
+tfy-gateway-api-crd:
+  ## @param tfy-gateway-api-crd.enabled Install the Gateway API CRDs sub-chart. Set to false to only install the istio gateway sub-chart and skip the CRDs.
+  ##
+  enabled: true
+
 ## @section ALB Configuration
 ## Configuration for AWS Application Load Balancer
 ##

--- a/charts/tfy-istio-ingress/values.yaml
+++ b/charts/tfy-istio-ingress/values.yaml
@@ -1,9 +1,9 @@
 ## @section Global
 ##
 global:
-  ## @param global.installCrds Install the Gateway API CRDs sub-chart. Set to false to only install the istio gateway sub-chart and skip the CRDs.
+  ## @param global.installGatewayCrds Install the Gateway API CRDs sub-chart. Set to false to only install the istio gateway sub-chart and skip the CRDs.
   ##
-  installCrds: true
+  installGatewayCrds: true
 
 ## @section ALB Configuration
 ## Configuration for AWS Application Load Balancer

--- a/charts/tfy-istio-ingress/values.yaml
+++ b/charts/tfy-istio-ingress/values.yaml
@@ -1,10 +1,9 @@
-## @section Gateway API CRDs
-## Configuration for the bundled Gateway API CRDs sub-chart.
+## @section Global
 ##
-tfy-gateway-api-crd:
-  ## @param tfy-gateway-api-crd.enabled Install the Gateway API CRDs sub-chart. Set to false to only install the istio gateway sub-chart and skip the CRDs.
+global:
+  ## @param global.installCrds Install the Gateway API CRDs sub-chart. Set to false to only install the istio gateway sub-chart and skip the CRDs.
   ##
-  enabled: true
+  installCrds: true
 
 ## @section ALB Configuration
 ## Configuration for AWS Application Load Balancer


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Default behavior is unchanged; risk is mainly misconfiguration (CRDs missing when disabled, or duplicate CRD installs if enabled when CRDs already exist).
> 
> **Overview**
> Adds **`installGatewayCrds`** (default **`true`**) so the **`tfy-gateway-api-crd`** dependency is only installed when that flag is enabled, via Helm’s **`condition: installGatewayCrds`** on the sub-chart.
> 
> Chart version is bumped to **0.3.7**; README and **`values.yaml`** document the new parameter. When set to **`false`**, installs can skip CRDs when they are already present cluster-wide and deploy only the Istio **gateway** sub-chart.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 348ac406db3aafb46b246d7cb6d7368f05965d1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->