### PR TITLE
feat: update notebook images to have AI agents

### DIFF
--- a/charts/tfy-configs/files/workbench-images.yaml
+++ b/charts/tfy-configs/files/workbench-images.yaml
@@ -16,7 +16,7 @@ images:
             values:
               - "us-"
         spec:
-          image_uri: "us-docker.pkg.dev/production-01-407505/tfy-docker-us/jupyter:0.4.5-py3.12.12-sudo"
+          image_uri: "us-docker.pkg.dev/production-01-407505/tfy-docker-us/jupyter:0.5.0-py3.12.12-sudo"
       - match:
           - key: cluster_type
             operator: In
@@ -27,7 +27,7 @@ images:
             values:
               - "europe-"
         spec:
-          image_uri: "europe-docker.pkg.dev/production-01-407505/tfy-docker-eu/jupyter:0.4.5-py3.12.12-sudo"
+          image_uri: "europe-docker.pkg.dev/production-01-407505/tfy-docker-eu/jupyter:0.5.0-py3.12.12-sudo"
       - match:
           - key: cluster_type
             operator: In
@@ -38,10 +38,10 @@ images:
             values:
               - "asia-"
         spec:
-          image_uri: "asia-docker.pkg.dev/production-01-407505/tfy-docker-as/jupyter:0.4.5-py3.12.12-sudo"
+          image_uri: "asia-docker.pkg.dev/production-01-407505/tfy-docker-as/jupyter:0.5.0-py3.12.12-sudo"
       - match: []
         spec:
-          image_uri: "public.ecr.aws/truefoundrycloud/jupyter:0.4.5-py3.12.12-sudo"
+          image_uri: "public.ecr.aws/truefoundrycloud/jupyter:0.5.0-py3.12.12-sudo"
 
   - name: Jupyter Lab Cuda 12.9 Image
     type: notebook
@@ -58,7 +58,7 @@ images:
             values:
               - "us-"
         spec:
-          image_uri: "us-docker.pkg.dev/production-01-407505/tfy-docker-us/jupyter:0.4.5-cu129-py3.12.12-sudo"
+          image_uri: "us-docker.pkg.dev/production-01-407505/tfy-docker-us/jupyter:0.5.0-cu129-py3.12.12-sudo"
       - match:
           - key: cluster_type
             operator: In
@@ -69,7 +69,7 @@ images:
             values:
               - "europe-"
         spec:
-          image_uri: "europe-docker.pkg.dev/production-01-407505/tfy-docker-eu/jupyter:0.4.5-cu129-py3.12.12-sudo"
+          image_uri: "europe-docker.pkg.dev/production-01-407505/tfy-docker-eu/jupyter:0.5.0-cu129-py3.12.12-sudo"
       - match:
           - key: cluster_type
             operator: In
@@ -80,10 +80,10 @@ images:
             values:
               - "asia-"
         spec:
-          image_uri: "asia-docker.pkg.dev/production-01-407505/tfy-docker-as/jupyter:0.4.5-cu129-py3.12.12-sudo"
+          image_uri: "asia-docker.pkg.dev/production-01-407505/tfy-docker-as/jupyter:0.5.0-cu129-py3.12.12-sudo"
       - match: []
         spec:
-          image_uri: "public.ecr.aws/truefoundrycloud/jupyter:0.4.5-cu129-py3.12.12-sudo"
+          image_uri: "public.ecr.aws/truefoundrycloud/jupyter:0.5.0-cu129-py3.12.12-sudo"
 
   - name: Jupyter Lab Spark 4.0.2 (Python 3.12) - Databricks 17.3 LTS
     type: spark-notebook


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changing default notebook images affects new and reprovisioned workbenches cluster-wide once the ConfigMap rolls out; risk is moderate if 0.5.0 behavior or availability differs from 0.4.5.
> 
> **Overview**
> Updates default workbench notebook image pins in `workbench-images.yaml` so **Jupyter Lab Minimal** and **Jupyter Lab Cuda 12.9** use tag **`0.5.0`** instead of **`0.4.5`**, keeping the same Python 3.12.12 and CUDA 12.9 variants.
> 
> The change applies to every regional selector (US, Europe, and Asia GCP Artifact Registry paths) and the public ECR fallback for both image types. Spark, SSH, and RStudio entries in the file are not modified in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8aa3bbb4851e816c16d3e3ffad4423bd67457237. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->