### PR TITLE
SPA-56: private custom image support

### DIFF
--- a/charts/truefoundry/templates/tfy-build/build-workflow-workflow-template.yaml
+++ b/charts/truefoundry/templates/tfy-build/build-workflow-workflow-template.yaml
@@ -34,6 +34,12 @@ spec:
         default: ""
       - name: deploymentId
         default: ""
+      - name: baseImageRegistryURL
+        default: ""
+      - name: baseImageRegistryUsername
+        default: ""
+      - name: baseImageRegistryPassword
+        default: ""
   templates:
     - name: build
       inputs:
@@ -49,6 +55,9 @@ spec:
           - name: callbackURL
           - name: applicationId
           - name: deploymentId
+          - name: baseImageRegistryURL
+          - name: baseImageRegistryUsername
+          - name: baseImageRegistryPassword
       steps:
       - - name: should-use-external-buildkit
           template: should-use-external-buildkit
@@ -84,6 +93,12 @@ spec:
               value: "{{`{{inputs.parameters.applicationId}}`}}"
             - name: deploymentId
               value: "{{`{{inputs.parameters.deploymentId}}`}}"
+            - name: baseImageRegistryURL
+              value: "{{`{{inputs.parameters.baseImageRegistryURL}}`}}"
+            - name: baseImageRegistryUsername
+              value: "{{`{{inputs.parameters.baseImageRegistryUsername}}`}}"
+            - name: baseImageRegistryPassword
+              value: "{{`{{inputs.parameters.baseImageRegistryPassword}}`}}"
       - - name: build-and-push-with-external-buildkit
           template: build-and-push-with-external-buildkit
           when: >-
@@ -112,6 +127,12 @@ spec:
               value: "{{`{{inputs.parameters.applicationId}}`}}"
             - name: deploymentId
               value: "{{`{{inputs.parameters.deploymentId}}`}}"
+            - name: baseImageRegistryURL
+              value: "{{`{{inputs.parameters.baseImageRegistryURL}}`}}"
+            - name: baseImageRegistryUsername
+              value: "{{`{{inputs.parameters.baseImageRegistryUsername}}`}}"
+            - name: baseImageRegistryPassword
+              value: "{{`{{inputs.parameters.baseImageRegistryPassword}}`}}"
 
     - name: exit-handler
       inputs:
@@ -267,6 +288,9 @@ spec:
           - name: callbackURL
           - name: applicationId
           - name: deploymentId
+          - name: baseImageRegistryURL
+          - name: baseImageRegistryUsername
+          - name: baseImageRegistryPassword
       outputs:
         parameters:
         - name: tfyBuildStatus
@@ -341,6 +365,12 @@ spec:
             value: "{{`{{inputs.parameters.applicationId}}`}}"
           - name: DEPLOYMENT_ID
             value: "{{`{{inputs.parameters.deploymentId}}`}}"
+          - name: BASE_IMAGE_REGISTRY_URL
+            value: "{{`{{inputs.parameters.baseImageRegistryURL}}`}}"
+          - name: BASE_IMAGE_REGISTRY_USERNAME
+            value: "{{`{{inputs.parameters.baseImageRegistryUsername}}`}}"
+          - name: BASE_IMAGE_REGISTRY_PASSWORD
+            value: "{{`{{inputs.parameters.baseImageRegistryPassword}}`}}"
           - name: DONE_MARKER
             value: {{ .Values.tfyBuild.truefoundryWorkflows.logMarkers.done | quote }}
           - name: FAILED_MARKER
@@ -433,6 +463,9 @@ spec:
           - name: callbackURL
           - name: applicationId
           - name: deploymentId
+          - name: baseImageRegistryURL
+          - name: baseImageRegistryUsername
+          - name: baseImageRegistryPassword
       outputs:
         parameters:
         - name: tfyBuildStatus
@@ -512,6 +545,12 @@ spec:
             value: "{{`{{inputs.parameters.applicationId}}`}}"
           - name: DEPLOYMENT_ID
             value: "{{`{{inputs.parameters.deploymentId}}`}}"
+          - name: BASE_IMAGE_REGISTRY_URL
+            value: "{{`{{inputs.parameters.baseImageRegistryURL}}`}}"
+          - name: BASE_IMAGE_REGISTRY_USERNAME
+            value: "{{`{{inputs.parameters.baseImageRegistryUsername}}`}}"
+          - name: BASE_IMAGE_REGISTRY_PASSWORD
+            value: "{{`{{inputs.parameters.baseImageRegistryPassword}}`}}"
           - name: DONE_MARKER
             value: {{ .Values.tfyBuild.truefoundryWorkflows.logMarkers.done | quote }}
           - name: FAILED_MARKER

--- a/charts/truefoundry/tfy-build-scripts/registry-login.sh
+++ b/charts/truefoundry/tfy-build-scripts/registry-login.sh
@@ -17,3 +17,15 @@ elif [[ $_REGISTRY == index.docker.io* ]] || [[ $_REGISTRY == docker.io* ]]; the
 else
     docker login -u "$DOCKER_REGISTRY_USERNAME" -p "${DOCKER_PASSWORD}" "${DOCKER_REGISTRY_URL}" 2>&1 || { echo "Error: Docker login failed, make sure your authentication credentials are correct in registry!" >&2; exit 1; }
 fi
+
+# Login to the base image registry if credentials are provided (for private FROM images)
+if [[ -n "${BASE_IMAGE_REGISTRY_URL:-}" ]] && [[ -n "${BASE_IMAGE_REGISTRY_PASSWORD:-}" ]]; then
+    echo "Logging into base image registry: $BASE_IMAGE_REGISTRY_URL"
+    BASE_IMAGE_PASSWORD=$(echo "$BASE_IMAGE_REGISTRY_PASSWORD" | base64 -d)
+    _BASE_REGISTRY=$(echo "${BASE_IMAGE_REGISTRY_URL}" | sed -e 's~http[s]*://~~g')
+    if [[ $_BASE_REGISTRY == index.docker.io* ]] || [[ $_BASE_REGISTRY == docker.io* ]]; then
+        docker login -u "$BASE_IMAGE_REGISTRY_USERNAME" -p "${BASE_IMAGE_PASSWORD}" 2>&1 || { echo "Error: Base image registry login failed, make sure your authentication credentials are correct!" >&2; exit 1; }
+    else
+        docker login -u "$BASE_IMAGE_REGISTRY_USERNAME" -p "${BASE_IMAGE_PASSWORD}" "${BASE_IMAGE_REGISTRY_URL}" 2>&1 || { echo "Error: Base image registry login failed, make sure your authentication credentials are correct!" >&2; exit 1; }
+    fi
+fi


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces handling of additional registry credentials in build jobs; behavior is optional and mirrors existing push-registry login, but misconfigured credentials will fail builds at login.
> 
> **Overview**
> Adds optional **base image registry** credentials to the TrueFoundry build Argo workflow so builds can pull private `FROM` images that live in a different registry than the push target.
> 
> The workflow template gains three parameters (`baseImageRegistryURL`, username, password, default empty) and passes them through both BuildKit paths (sidecar and external) as `BASE_IMAGE_REGISTRY_*` env vars on the builder. **`registry-login.sh`** now performs a second `docker login` when URL and password are set, reusing the same Docker Hub URL handling as the existing push-registry login.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3141e6799fc3dca7a03170aa3a394b0120ff077a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->