### PR TITLE
fix(INFRA-1036): disable karpenter-config & istio-ingress when parent addon disabled

### DIFF
--- a/charts/tfy-k8s-aws-eks-inframold/README.md
+++ b/charts/tfy-k8s-aws-eks-inframold/README.md
@@ -198,6 +198,7 @@ Inframold, the superchart that configure your cluster on aws for truefoundry.
 | --------------------------------------- | ------------------------------------------------------- | ------ |
 | `istio.enabled`                         | Flag to enable Istio                                    | `true` |
 | `istio.enabled`                         | Flag to enable Istio Base                               | `true` |
+| `istio.ingress.enabled`                 | Flag to enable Istio Ingress                            | `true` |
 | `istio.base.valuesOverride`             | Config override from default config values              | `{}`   |
 | `istio.base.syncPolicy`                 | ArgoCD syncPolicy for the istio-base Application        | `{}`   |
 | `istio.awsElbControllerChecker.enabled` | Flag to enable AWS ELB Controller Checker               | `true` |

--- a/charts/tfy-k8s-aws-eks-inframold/templates/istio/tfy-istio-ingress.yaml
+++ b/charts/tfy-k8s-aws-eks-inframold/templates/istio/tfy-istio-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.istio.enabled }}
+{{- if and .Values.istio.enabled .Values.istio.ingress.enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:

--- a/charts/tfy-k8s-aws-eks-inframold/templates/tfy-aws/karpenter-config.yaml
+++ b/charts/tfy-k8s-aws-eks-inframold/templates/tfy-aws/karpenter-config.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.aws.karpenter.config.enabled }}
+{{- if and .Values.aws.karpenter.enabled .Values.aws.karpenter.config.enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:

--- a/charts/tfy-k8s-aws-eks-inframold/values-artifact-manifest.yaml
+++ b/charts/tfy-k8s-aws-eks-inframold/values-artifact-manifest.yaml
@@ -76,6 +76,8 @@ tfyLogs:
 
 istio:
   enabled: true
+  ingress:
+    enabled: true
   gateway:
     
     annotations:

--- a/charts/tfy-k8s-aws-eks-inframold/values.yaml
+++ b/charts/tfy-k8s-aws-eks-inframold/values.yaml
@@ -617,6 +617,11 @@ istio:
   ##
   enabled: true
 
+  ## @param istio.ingress.enabled Flag to enable Istio Ingress
+  ##
+  ingress:
+    enabled: true
+
   base:
     ## @param istio.base.valuesOverride [object] Config override from default config values
     ##

--- a/charts/tfy-k8s-azure-aks-inframold/README.md
+++ b/charts/tfy-k8s-azure-aks-inframold/README.md
@@ -150,6 +150,7 @@ Inframold, the superchart that configure your cluster on azure for truefoundry.
 | --------------------------------------- | ------------------------------------------------------- | ------- |
 | `istio.enabled`                         | Flag to enable Istio                                    | `true`  |
 | `istio.enabled`                         | Flag to enable Istio Base                               | `true`  |
+| `istio.ingress.enabled`                 | Flag to enable Istio Ingress                            | `true`  |
 | `istio.base.valuesOverride`             | Config override from default config values              | `{}`    |
 | `istio.base.syncPolicy`                 | ArgoCD syncPolicy for the istio-base Application        | `{}`    |
 | `istio.awsElbControllerChecker.enabled` | Flag to enable AWS ELB Controller Checker               | `false` |

--- a/charts/tfy-k8s-azure-aks-inframold/templates/istio/tfy-istio-ingress.yaml
+++ b/charts/tfy-k8s-azure-aks-inframold/templates/istio/tfy-istio-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.istio.enabled }}
+{{- if and .Values.istio.enabled .Values.istio.ingress.enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:

--- a/charts/tfy-k8s-azure-aks-inframold/values-artifact-manifest.yaml
+++ b/charts/tfy-k8s-azure-aks-inframold/values-artifact-manifest.yaml
@@ -53,6 +53,8 @@ tfyLogs:
 
 istio:
   enabled: true
+  ingress:
+    enabled: true
   gateway:
     
     annotations: {}

--- a/charts/tfy-k8s-azure-aks-inframold/values.yaml
+++ b/charts/tfy-k8s-azure-aks-inframold/values.yaml
@@ -441,6 +441,11 @@ istio:
   ##
   enabled: true
 
+  ## @param istio.ingress.enabled Flag to enable Istio Ingress
+  ##
+  ingress:
+    enabled: true
+
   base:
     ## @param istio.base.valuesOverride [object] Config override from default config values
     ##

--- a/charts/tfy-k8s-civo-talos-inframold/README.md
+++ b/charts/tfy-k8s-civo-talos-inframold/README.md
@@ -149,6 +149,7 @@ Inframold, the superchart that configure your cluster on civo for truefoundry.
 | --------------------------------------- | ------------------------------------------------------- | ------- |
 | `istio.enabled`                         | Flag to enable Istio                                    | `true`  |
 | `istio.enabled`                         | Flag to enable Istio Base                               | `true`  |
+| `istio.ingress.enabled`                 | Flag to enable Istio Ingress                            | `true`  |
 | `istio.base.valuesOverride`             | Config override from default config values              | `{}`    |
 | `istio.base.syncPolicy`                 | ArgoCD syncPolicy for the istio-base Application        | `{}`    |
 | `istio.awsElbControllerChecker.enabled` | Flag to enable AWS ELB Controller Checker               | `false` |

--- a/charts/tfy-k8s-civo-talos-inframold/templates/istio/tfy-istio-ingress.yaml
+++ b/charts/tfy-k8s-civo-talos-inframold/templates/istio/tfy-istio-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.istio.enabled }}
+{{- if and .Values.istio.enabled .Values.istio.ingress.enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:

--- a/charts/tfy-k8s-civo-talos-inframold/values-artifact-manifest.yaml
+++ b/charts/tfy-k8s-civo-talos-inframold/values-artifact-manifest.yaml
@@ -53,6 +53,8 @@ tfyLogs:
 
 istio:
   enabled: true
+  ingress:
+    enabled: true
   gateway:
     
     annotations: {}

--- a/charts/tfy-k8s-civo-talos-inframold/values.yaml
+++ b/charts/tfy-k8s-civo-talos-inframold/values.yaml
@@ -401,6 +401,11 @@ istio:
   ##
   enabled: true
 
+  ## @param istio.ingress.enabled Flag to enable Istio Ingress
+  ##
+  ingress:
+    enabled: true
+
   base:
     ## @param istio.base.valuesOverride [object] Config override from default config values
     ##

--- a/charts/tfy-k8s-gcp-gke-standard-inframold/README.md
+++ b/charts/tfy-k8s-gcp-gke-standard-inframold/README.md
@@ -151,6 +151,7 @@ Inframold, the superchart that configure your cluster on gcp for truefoundry.
 | --------------------------------------- | ------------------------------------------------------- | ------- |
 | `istio.enabled`                         | Flag to enable Istio                                    | `true`  |
 | `istio.enabled`                         | Flag to enable Istio Base                               | `true`  |
+| `istio.ingress.enabled`                 | Flag to enable Istio Ingress                            | `true`  |
 | `istio.base.valuesOverride`             | Config override from default config values              | `{}`    |
 | `istio.base.syncPolicy`                 | ArgoCD syncPolicy for the istio-base Application        | `{}`    |
 | `istio.awsElbControllerChecker.enabled` | Flag to enable AWS ELB Controller Checker               | `false` |

--- a/charts/tfy-k8s-gcp-gke-standard-inframold/templates/istio/tfy-istio-ingress.yaml
+++ b/charts/tfy-k8s-gcp-gke-standard-inframold/templates/istio/tfy-istio-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.istio.enabled }}
+{{- if and .Values.istio.enabled .Values.istio.ingress.enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:

--- a/charts/tfy-k8s-gcp-gke-standard-inframold/values-artifact-manifest.yaml
+++ b/charts/tfy-k8s-gcp-gke-standard-inframold/values-artifact-manifest.yaml
@@ -53,6 +53,8 @@ tfyLogs:
 
 istio:
   enabled: true
+  ingress:
+    enabled: true
   gateway:
     
     annotations: {}

--- a/charts/tfy-k8s-gcp-gke-standard-inframold/values.yaml
+++ b/charts/tfy-k8s-gcp-gke-standard-inframold/values.yaml
@@ -441,6 +441,11 @@ istio:
   ##
   enabled: true
 
+  ## @param istio.ingress.enabled Flag to enable Istio Ingress
+  ##
+  ingress:
+    enabled: true
+
   base:
     ## @param istio.base.valuesOverride [object] Config override from default config values
     ##

--- a/charts/tfy-k8s-generic-inframold/README.md
+++ b/charts/tfy-k8s-generic-inframold/README.md
@@ -149,6 +149,7 @@ Inframold, the superchart that configure your cluster on generic for truefoundry
 | --------------------------------------- | ------------------------------------------------------- | ------- |
 | `istio.enabled`                         | Flag to enable Istio                                    | `true`  |
 | `istio.enabled`                         | Flag to enable Istio Base                               | `true`  |
+| `istio.ingress.enabled`                 | Flag to enable Istio Ingress                            | `true`  |
 | `istio.base.valuesOverride`             | Config override from default config values              | `{}`    |
 | `istio.base.syncPolicy`                 | ArgoCD syncPolicy for the istio-base Application        | `{}`    |
 | `istio.awsElbControllerChecker.enabled` | Flag to enable AWS ELB Controller Checker               | `false` |

--- a/charts/tfy-k8s-generic-inframold/templates/istio/tfy-istio-ingress.yaml
+++ b/charts/tfy-k8s-generic-inframold/templates/istio/tfy-istio-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.istio.enabled }}
+{{- if and .Values.istio.enabled .Values.istio.ingress.enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:

--- a/charts/tfy-k8s-generic-inframold/values-artifact-manifest.yaml
+++ b/charts/tfy-k8s-generic-inframold/values-artifact-manifest.yaml
@@ -53,6 +53,8 @@ tfyLogs:
 
 istio:
   enabled: true
+  ingress:
+    enabled: true
   gateway:
     
     annotations: {}

--- a/charts/tfy-k8s-generic-inframold/values.yaml
+++ b/charts/tfy-k8s-generic-inframold/values.yaml
@@ -401,6 +401,11 @@ istio:
   ##
   enabled: true
 
+  ## @param istio.ingress.enabled Flag to enable Istio Ingress
+  ##
+  ingress:
+    enabled: true
+
   base:
     ## @param istio.base.valuesOverride [object] Config override from default config values
     ##


### PR DESCRIPTION
## What

Fixes the gate so `karpenter-config` and `istio-ingress` ArgoCD Applications are disabled when their parent addon is turned off from the cluster form.

- **karpenter-config**: a prior migration (v0.1.287) moved the gate from `.Values.aws.karpenter.enabled` to `.Values.aws.karpenter.config.enabled`, so disabling karpenter no longer removed the config. Now gated on **both** (`and karpenter.enabled config.enabled`) — matching the existing `prometheus-config` / `cert-manager-config` convention (karpenter-config was the sole outlier).
- **istio-ingress**: split onto a new `.Values.istio.ingress.enabled` flag, gated `and istio.enabled istio.ingress.enabled` across all 5 inframold charts. `istio-base` / `istio-discovery` stay on `istio.enabled` (ingress-only scope). New key defaults `true` → existing clusters unchanged.

## Scope
- 1 karpenter template (aws-eks) + 5 istio-ingress templates (all inframold)
- `istio.ingress.enabled: true` added to 5 `values.yaml` + 5 `values-artifact-manifest.yaml`
- No `Chart.yaml` bump (CI-managed), no `artifacts-manifest.json` edit (CI-regenerated)

## Test
`helm template` matrix (15 scenarios) + `helm lint` ×5 — all pass:
- karpenter.enabled=false → config **and** operator gone (bug fixed)
- config.enabled=false → config gone, operator stays (independent toggle)
- istio.enabled=false → all istio apps gone
- istio.ingress.enabled=false → ingress gone, base/discovery survive

Companion form-side change (exposes these as toggles): `tfy-infra-templates#feat/infra-1036-expose-subflags`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which ArgoCD Applications render when addons are disabled; mis-set values could drop ingress or Karpenter config unexpectedly, though defaults preserve current behavior.
> 
> **Overview**
> Fixes ArgoCD Application rendering so **child config/ingress apps stop when their parent addon is turned off** from cluster values.
> 
> On **AWS EKS**, the `karpenter-config` Application now requires **both** `aws.karpenter.enabled` and `aws.karpenter.config.enabled` (previously only `config.enabled`, so disabling Karpenter could leave config deployed). This aligns with the existing `prometheus-config` / `cert-manager-config` pattern.
> 
> Across **all five inframold charts**, `tfy-istio-ingress` is gated on **`istio.enabled` and a new `istio.ingress.enabled`** (defaults `true`). Istio base/discovery stay on `istio.enabled` only, so ingress can be disabled without removing the mesh control plane.
> 
> Docs and `values-artifact-manifest.yaml` entries document **`istio.ingress.enabled`** alongside the template/value defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed6c8fb398ab8c7d8e73a213a08f61371b1a0f61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->