### PR TITLE
DEL-1948: Add tfytelemetryprocessor to otel collector helm charts

### DIFF
--- a/charts/tfy-otel-collector/templates/configMap.yaml
+++ b/charts/tfy-otel-collector/templates/configMap.yaml
@@ -88,6 +88,7 @@ data:
         cache_ttl: 5m
         timeout: ${env:TFY_OTEL_EXPORTER_TIMEOUT:-60s}
     processors:
+      tfytelemetryprocessor: {}
       batch:
         timeout: 2s
         send_batch_size: 200
@@ -151,7 +152,7 @@ data:
       pipelines:
         traces:
           receivers: [otlp]
-          processors: [resource, filter, groupbyattrs, transform, batch] # resource → filter → groupbyattrs → transform (defaults) → batch
+          processors: [tfytelemetryprocessor, resource, filter, groupbyattrs, transform, batch] # tfytelemetryprocessor → resource → filter → groupbyattrs → transform (defaults) → batch
           exporters: [tfytracesexporter]
         metrics:
           receivers: [otlp]

--- a/charts/truefoundry/charts/tfy-otel-collector/templates/configMap.yaml
+++ b/charts/truefoundry/charts/tfy-otel-collector/templates/configMap.yaml
@@ -88,6 +88,7 @@ data:
         cache_ttl: 5m
         timeout: ${env:TFY_OTEL_EXPORTER_TIMEOUT:-60s}
     processors:
+      tfytelemetryprocessor: {}
       batch:
         timeout: 2s
         send_batch_size: 200
@@ -151,7 +152,7 @@ data:
       pipelines:
         traces:
           receivers: [otlp]
-          processors: [resource, filter, groupbyattrs, transform, batch] # resource → filter → groupbyattrs → transform (defaults) → batch
+          processors: [tfytelemetryprocessor, resource, filter, groupbyattrs, transform, batch] # resource → filter → groupbyattrs → transform (defaults) → batch
           exporters: [tfytracesexporter]
         metrics:
           receivers: [otlp]

--- a/charts/truefoundry/charts/tfy-otel-collector/templates/configMap.yaml
+++ b/charts/truefoundry/charts/tfy-otel-collector/templates/configMap.yaml
@@ -152,7 +152,7 @@ data:
       pipelines:
         traces:
           receivers: [otlp]
-          processors: [tfytelemetryprocessor, resource, filter, groupbyattrs, transform, batch] # resource → filter → groupbyattrs → transform (defaults) → batch
+          processors: [tfytelemetryprocessor, resource, filter, groupbyattrs, transform, batch] # tfytelemetryprocessor → resource → filter → groupbyattrs → transform (defaults) → batch
           exporters: [tfytracesexporter]
         metrics:
           receivers: [otlp]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes live trace processing order for all OTLP traces; misbehavior could affect telemetry before auth/resource enrichment, though scope is limited to Helm config.
> 
> **Overview**
> Wires the custom **`tfytelemetryprocessor`** into the OTel collector trace path for both **`charts/tfy-otel-collector`** and **`charts/truefoundry/charts/tfy-otel-collector`**.
> 
> Each chart’s ConfigMap now declares `tfytelemetryprocessor: {}` under `processors` and runs it **first** in the traces pipeline (`tfytelemetryprocessor` → `resource` → `filter` → `groupbyattrs` → `transform` → `batch`). Metrics pipeline is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f9ad5dab49d18f373a88daa54a3d164e8d33df6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->