### PR TITLE
Added permissions for externalsecrets in tfy-agent proxy roles

### DIFF
--- a/charts/tfy-agent/Chart.yaml
+++ b/charts/tfy-agent/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.96
+version: 0.2.97
 
 maintainers:
   - name: truefoundry

--- a/charts/tfy-agent/README.md
+++ b/charts/tfy-agent/README.md
@@ -307,6 +307,6 @@ If your control plane URL is using self-signed CA certificate, follow these step
 
 ### reloader (stakater/reloader) configuration parameters
 
-| Name               | Description                                                                                 | Value  |
-| ------------------ | ------------------------------------------------------------------------------------------- | ------ |
-| `reloader.enabled` | Bool value to deploy the stakater/reloader subchart. Disable this to use your own Reloader. | `true` |
+| Name               | Description                                                                                 | Value   |
+| ------------------ | ------------------------------------------------------------------------------------------- | ------- |
+| `reloader.enabled` | Bool value to deploy the stakater/reloader subchart. Disable this to use your own Reloader. | `false` |

--- a/charts/tfy-agent/templates/tfy-agent-proxy-clusterrole-cs.yaml
+++ b/charts/tfy-agent/templates/tfy-agent-proxy-clusterrole-cs.yaml
@@ -46,6 +46,11 @@ rules:
     resources: ["customresourcedefinitions"]
     verbs: ["list"]
 
+  {{/* Cluster-wide list for ExternalSecret discovery across namespaces */}}
+  - apiGroups: ["external-secrets.io"]
+    resources: ["externalsecrets"]
+    verbs: ["list"]
+
   {{/* This allows us to read Karpenter configuration and status to troubleshoot cluster auto scaling issues */}}
   - apiGroups: ["karpenter.k8s.aws", "karpenter.sh"]
     resources: ["ec2nodeclasses", "nodepools"]

--- a/charts/tfy-agent/templates/tfy-agent-proxy-clusterrole-ns.yaml
+++ b/charts/tfy-agent/templates/tfy-agent-proxy-clusterrole-ns.yaml
@@ -104,6 +104,11 @@ rules:
   - apiGroups: ["sparkoperator.k8s.io"]
     resources: ["sparkapplications", "sparkconnects"]
     verbs: ["create", "get", "delete"]
+
+  {{/* This allows us to manage ExternalSecrets for workloads */}}
+  - apiGroups: ["external-secrets.io"]
+    resources: ["externalsecrets"]
+    verbs: ["get", "list", "create", "patch", "delete"]
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/tfy-agent/values.yaml
+++ b/charts/tfy-agent/values.yaml
@@ -810,4 +810,4 @@ external-secrets-operator:
 reloader:
   ## @param reloader.enabled Bool value to deploy the stakater/reloader subchart. Disable this to use your own Reloader.
   ##
-  enabled: true
+  enabled: false


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Expands agent proxy RBAC over secret-sync CRDs and changes the default Reloader deployment, which can affect upgrades that assumed Reloader was installed by the chart.
> 
> **Overview**
> Grants **tfy-agent-proxy** the Kubernetes permissions needed to work with **External Secrets** when strict / allowed-namespace RBAC is in use. The cluster-scoped role (`-cs`) can **list** `externalsecrets` cluster-wide for discovery; the namespace-scoped role (`-ns`) can **get, list, create, patch, and delete** `externalsecrets` for workload secret management.
> 
> Chart version is bumped to **0.2.97**. The bundled **stakater/reloader** subchart default is changed from **enabled** to **disabled**, so fresh/default installs no longer deploy Reloader unless operators turn it back on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6639ea13b253426dbb66efc1b604a0d1c1fd50a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->