### PR TITLE
Change reloader enablement to true

### DIFF
--- a/charts/tfy-agent/Chart.yaml
+++ b/charts/tfy-agent/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.97
+version: 0.2.98
 
 maintainers:
   - name: truefoundry

--- a/charts/tfy-agent/README.md
+++ b/charts/tfy-agent/README.md
@@ -307,6 +307,6 @@ If your control plane URL is using self-signed CA certificate, follow these step
 
 ### reloader (stakater/reloader) configuration parameters
 
-| Name               | Description                                                                                 | Value   |
-| ------------------ | ------------------------------------------------------------------------------------------- | ------- |
-| `reloader.enabled` | Bool value to deploy the stakater/reloader subchart. Disable this to use your own Reloader. | `false` |
+| Name               | Description                                                                                 | Value  |
+| ------------------ | ------------------------------------------------------------------------------------------- | ------ |
+| `reloader.enabled` | Bool value to deploy the stakater/reloader subchart. Disable this to use your own Reloader. | `true` |

--- a/charts/tfy-agent/values.yaml
+++ b/charts/tfy-agent/values.yaml
@@ -810,4 +810,4 @@ external-secrets-operator:
 reloader:
   ## @param reloader.enabled Bool value to deploy the stakater/reloader subchart. Disable this to use your own Reloader.
   ##
-  enabled: false
+  enabled: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Turning on Reloader by default adds a cluster controller and can restart pods when secrets/config change; duplicate Reloader installs are possible if customers already deploy their own.
> 
> **Overview**
> **tfy-agent** now ships with the **stakater/reloader** subchart **on by default** (`reloader.enabled: true`), and the chart version is bumped to **0.2.98** with matching README parameter docs.
> 
> Upgrades or installs that do not override values will deploy Reloader in the release namespace, so ConfigMap/Secret changes can trigger rolling restarts on annotated workloads. Set `reloader.enabled: false` if the cluster already runs a separate Reloader instance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5be9e06f1326cd1f263492ba9ed1cbebaeb07298. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->