### PR TITLE
updating resources for cloudflare and caddy

### DIFF
--- a/charts/tfy-cloudflared/Chart.yaml
+++ b/charts/tfy-cloudflared/Chart.yaml
@@ -26,4 +26,4 @@ sources:
 - https://github.com/truefoundry/infra-charts/tree/main/charts/tfy-cloudflared
 - https://github.com/cloudflare/cloudflared
 type: application
-version: 0.4.0
+version: 0.4.1

--- a/charts/tfy-cloudflared/README.md
+++ b/charts/tfy-cloudflared/README.md
@@ -99,6 +99,7 @@ An empty list (the default) preserves the previous behaviour of proxying to any 
 | `probes.readiness.periodSeconds`       | Readiness probe period in seconds                           | `10`                                             |
 | `probes.readiness.timeoutSeconds`      | Readiness probe timeout in seconds                          | `5`                                              |
 | `probes.readiness.failureThreshold`    | Readiness probe failure threshold                           | `3`                                              |
+| `resources`                            | Resource requests and limits for cloudflared                | `{}`                                             |
 | `podSecurityContext`                   | Pod security context                                        | `{}`                                             |
 | `securityContext`                      | Container security context                                  | `{}`                                             |
 | `nodeSelector`                         | Node selector                                               | `{}`                                             |

--- a/charts/tfy-cloudflared/values.yaml
+++ b/charts/tfy-cloudflared/values.yaml
@@ -144,13 +144,14 @@ probes:
     ## @param probes.readiness.failureThreshold Readiness probe failure threshold
     failureThreshold: 3
 
-## @skip resources [object] Resource requests and limits for cloudflared
-resources: {}
-# requests:
-#   cpu: 50m
-#   memory: 64Mi
-# limits:
-#   memory: 128Mi
+## @param resources [object] Resource requests and limits for cloudflared
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi
 
 ## @param podSecurityContext [object] Pod security context
 podSecurityContext: {}
@@ -227,7 +228,13 @@ caddy:
     ## @param caddy.serviceAccount.annotations [object] Caddy service account annotations
     annotations: {}
   ## @param caddy.resources [object] Resource requests and limits for Caddy
-  resources: {}
+  resources:
+    requests:
+      cpu: 300m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
   ## @param caddy.nodeSelector [object] Node selector for Caddy pods
   nodeSelector: {}
   ## @param caddy.tolerations [array] Tolerations for Caddy pods


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Default resource requests affect scheduling and reserved cluster capacity on upgrade; behavior is operational, not security-related, but tight clusters may see scheduling pressure unless values are overridden.
> 
> **Overview**
> Bumps **tfy-cloudflared** chart version to **0.4.1** and replaces empty default resource blocks with explicit **requests and limits** for **cloudflared** (100m/128Mi → 200m/256Mi) and **Caddy** (300m/256Mi → 500m/512Mi).
> 
> The `resources` value is now a documented `@param` in `values.yaml` (no longer `@skip`), and the README parameters table adds a row for cloudflared `resources`. Deployments that relied on unset resources will pick up these defaults on upgrade unless overridden in custom values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f52741520e433bfbd756ac968f03d8b0aac6e32b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->