### PR TITLE
Removed virtualservice role binding when strict mode is enabled in tfy-agent

### DIFF
--- a/charts/tfy-agent/Chart.yaml
+++ b/charts/tfy-agent/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.99
+version: 0.2.100
 
 maintainers:
   - name: truefoundry

--- a/charts/tfy-agent/templates/tfy-agent-clusterrole.yaml
+++ b/charts/tfy-agent/templates/tfy-agent-clusterrole.yaml
@@ -15,20 +15,19 @@ rules:
   - apiGroups: ["apps"]
     resources: ["replicasets", "deployments"]
     verbs: ["list", "watch"]
+  {{- if not (or .Values.config.allowedNamespaces .Values.tfyAgentProxy.clusterRole.strictMode) }}
   - apiGroups: ["networking.istio.io"]
     resources: ["gateways", "virtualservices"]
     verbs: ["list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["list", "watch"]
+  {{- end }}
   - apiGroups: ["argoproj.io"]
     resources: ["applications", "rollouts", "workflowtemplates", "workflows"]
     verbs: ["list", "watch"]
-  - apiGroups: ["kubeflow.org"]
-    resources: ["notebooks"]
-    verbs: ["list", "watch"]
   - apiGroups: ["sparkoperator.k8s.io"]
     resources: ["sparkapplications"]
-    verbs: ["list", "watch"]
-  - apiGroups: ["networking.k8s.io"]
-    resources: ["ingresses"]
     verbs: ["list", "watch"]
 {{- end }}
 {{- end }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> RBAC changes alter what cluster state the agent can stream; dropping notebook informer permissions may reduce control-plane visibility for Kubeflow notebooks if those informers are still expected.
> 
> **Overview**
> **Tightens tfy-agent ClusterRole RBAC** when `config.allowedNamespaces` is set or `tfyAgentProxy.clusterRole.strictMode` is enabled: **Istio** (`gateways`, `virtualservices`) and **Ingress** `list`/`watch` rules are omitted so the agent no longer watches those resources in the same “minimum access” posture as the proxy.
> 
> Also **removes** `kubeflow.org/notebooks` `list`/`watch` from the tfy-agent ClusterRole entirely, and bumps the chart version to **0.2.100**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02996986dc75d4bdbe90e7c298a9e61c982c8ce6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->