### PR TITLE
make valuefrom k8s-secret optional

### DIFF
--- a/charts/tfy-llm-gateway/templates/_helpers.tpl
+++ b/charts/tfy-llm-gateway/templates/_helpers.tpl
@@ -324,12 +324,14 @@ app.kubernetes.io/instance: {{ .Release.Name }}
     secretKeyRef:
       name: {{ $.Values.envSecretName }}
       key: {{ index (regexSplit "/" $val -1) 1 | trimSuffix "}" }}
+      optional: true
 {{- else if eq (regexSplit "/" $val -1 | len) 3 }}
 - name: {{ $key }}
   valueFrom:
     secretKeyRef:
       name: {{ index (regexSplit "/" $val -1) 1 }}
       key: {{ index (regexSplit "/" $val -1) 2 | trimSuffix "}" }}
+      optional: true
 {{- else }}
 {{- fail "Invalid secret supplied" }}
 {{- end }}

--- a/charts/tfy-otel-collector/templates/_helpers.tpl
+++ b/charts/tfy-otel-collector/templates/_helpers.tpl
@@ -178,12 +178,14 @@ app.kubernetes.io/instance: {{ .Release.Name }}
     secretKeyRef:
       name: {{ $.Values.envSecretName }}
       key: {{ index (regexSplit "/" $val -1) 1 | trimSuffix "}" }}
+      optional: true
 {{- else if eq (regexSplit "/" $val -1 | len) 3 }}
 - name: {{ $key }}
   valueFrom:
     secretKeyRef:
       name: {{ index (regexSplit "/" $val -1) 1 }}
       key: {{ index (regexSplit "/" $val -1) 2 | trimSuffix "}" }}
+      optional: true
 {{- else }}
 {{- fail "Invalid secret supplied" }}
 {{- end }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Optional secrets let workloads start without required credentials, which can cause runtime misconfiguration if apps assume those env vars are always set.
> 
> **Overview**
> Helm env rendering for **`${k8s-secret...}`** placeholders now sets **`optional: true`** on every generated **`secretKeyRef`**, for both the default env secret name and explicit secret/name/key paths.
> 
> The same change is applied in **`tfy-llm-gateway`** and **`tfy-otel-collector`** `tfy-*.env` helpers so pods can schedule when a referenced secret or key is missing; those env vars are omitted instead of blocking pod creation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35c0b1e4a49b5331ca401ac2cc34c3d625c16af0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->