### PR TITLE
Bump chart version to 0.2.100

### DIFF
--- a/charts/tfy-agent/Chart.yaml
+++ b/charts/tfy-agent/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.99
+version: 0.2.100
 
 maintainers:
   - name: truefoundry


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version-only metadata change with no runtime or deployment template modifications.
> 
> **Overview**
> Bumps the **tfy-agent** Helm chart version from `0.2.99` to `0.2.100` in `Chart.yaml` for the next chart release. No template, dependency, or application changes are included in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01929a4f149f543586f41edcb504ad5e53a50b03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->