### PR TITLE
Adding support for extra manifests in tfy-logs

### DIFF
--- a/charts/tfy-logs/Chart.yaml
+++ b/charts/tfy-logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: tfy-logs
 description: Truefoundry Logs chart
-version: 0.1.20
+version: 0.1.21
 maintainers:
   - name: truefoundry
 dependencies:

--- a/charts/tfy-logs/README.md
+++ b/charts/tfy-logs/README.md
@@ -87,9 +87,10 @@ The solution consists of two main components:
 
 ### resourceQuota Add a ResourceQuota to enable priority class in a namespace.
 
-| Name                            | Description                             | Value                      |
-| ------------------------------- | --------------------------------------- | -------------------------- |
-| `resourceQuota.enabled`         | Create the ResourceQuota.               | `true`                     |
-| `resourceQuota.annotations`     | Annotations to add to the ResourceQuota | `{}`                       |
-| `resourceQuota.labels`          | Labels to add to the ResourceQuota      | `{}`                       |
-| `resourceQuota.priorityClasses` | PriorityClasses to enable.              | `["system-node-critical"]` |
+| Name                            | Description                                   | Value                      |
+| ------------------------------- | --------------------------------------------- | -------------------------- |
+| `resourceQuota.enabled`         | Create the ResourceQuota.                     | `true`                     |
+| `resourceQuota.annotations`     | Annotations to add to the ResourceQuota       | `{}`                       |
+| `resourceQuota.labels`          | Labels to add to the ResourceQuota            | `{}`                       |
+| `resourceQuota.priorityClasses` | PriorityClasses to enable.                    | `["system-node-critical"]` |
+| `extraManifests`                | Extra manifests to deploy alongside the chart | `[]`                       |

--- a/charts/tfy-logs/templates/extra-manifests.yaml
+++ b/charts/tfy-logs/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraManifests }}
+---
+{{ toYaml . }}
+{{- end }}

--- a/charts/tfy-logs/values.yaml
+++ b/charts/tfy-logs/values.yaml
@@ -222,3 +222,6 @@ resourceQuota:
   ## @param resourceQuota.priorityClasses PriorityClasses to enable.
   priorityClasses:
     - system-node-critical
+
+## @param extraManifests [array] Extra manifests to deploy alongside the chart
+extraManifests: []


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Opt-in Helm extension with an empty default; risk depends only on what users place in `extraManifests`, not on built-in chart behavior.
> 
> **Overview**
> Adds **`extraManifests`** to the `tfy-logs` Helm chart so operators can ship arbitrary YAML resources with the release (same pattern as charts like `tfy-cloudflared`). A new `templates/extra-manifests.yaml` renders each list entry with `toYaml`; **`values.yaml`** defaults to `[]`, so behavior is unchanged unless manifests are provided.
> 
> Chart version is bumped **0.1.20 → 0.1.21**, and the README documents the new parameter (with minor table column alignment).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 584189c0d834df4cd22f5132996ef8ebfb05120c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->