### PR TITLE
Update image registry URL for tfy-model-downloader to version 0.1.20

### DIFF
--- a/scripts/generate-artifacts-manifest/extra.json
+++ b/scripts/generate-artifacts-manifest/extra.json
@@ -125,7 +125,7 @@
   {
     "type": "image",
     "details": {
-      "registryURL": "tfy.jfrog.io/tfy-images/tfy-model-downloader:0.1.15"
+      "registryURL": "tfy.jfrog.io/tfy-images/tfy-model-downloader:0.1.20"
     }
   },
   {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single version string in a manifest input file; no application logic changes, though deployments will pull a new image tag after manifests are regenerated.
> 
> **Overview**
> Bumps the pinned **`tfy-model-downloader`** container image in `scripts/generate-artifacts-manifest/extra.json` from **0.1.15** to **0.1.20**.
> 
> That list is merged when generating inframold **artifacts manifests**, so the change updates which model-downloader image version is recorded for air-gapped / artifact workflows on the next manifest generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c58e5b23dc34f59d0b7c29bdbbbcccde79c9b42b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->