### PR TITLE
override tfy version

### DIFF
--- a/charts/truefoundry/README.md
+++ b/charts/truefoundry/README.md
@@ -399,7 +399,7 @@ global:
 | `mlfoundryServer.deploymentAnnotations`                       | Deployment-specific annotations for the mlfoundry server                         | `{}`                                  |
 | `mlfoundryServer.image.registry`                              | Registry for the mlfoundry server image (overrides global.registry if specified) | `""`                                  |
 | `mlfoundryServer.image.repository`                            | Image repository for the mlfoundry server (without registry)                     | `tfy-private-images/mlfoundry-server` |
-| `mlfoundryServer.image.tag`                                   | Image tag for the mlfoundry server                                               | `v0.162.0`                            |
+| `mlfoundryServer.image.tag`                                   | Image tag for the mlfoundry server                                               | `v0.155.0`                            |
 | `mlfoundryServer.environmentName`                             | Environment name for the mlfoundry server                                        | `default`                             |
 | `mlfoundryServer.envSecretName`                               | Secret name for the mlfoundry server environment variables                       | `mlfoundry-server-env-secret`         |
 | `mlfoundryServer.imagePullPolicy`                             | Image pull policy for the mlfoundry server                                       | `IfNotPresent`                        |

--- a/charts/truefoundry/artifacts-manifest.json
+++ b/charts/truefoundry/artifacts-manifest.json
@@ -11,7 +11,7 @@
                 "tfy.jfrog.io/tfy-private-images/tfy-otel-collector:v0.160.0",
                 "tfy.jfrog.io/tfy-private-images/deltafusion-query-server:v0.162.0-optimized",
                 "tfy.jfrog.io/tfy-private-images/deltafusion-query-server:v0.162.0",
-                "tfy.jfrog.io/tfy-private-images/mlfoundry-server:v0.162.0",
+                "tfy.jfrog.io/tfy-private-images/mlfoundry-server:v0.155.0",
                 "tfy.jfrog.io/tfy-private-images/s3proxy:v0.149.0",
                 "tfy.jfrog.io/tfy-private-images/servicefoundry-server:v0.162.0",
                 "tfy.jfrog.io/tfy-private-images/sfy-manifest-service:v0.148.0",
@@ -115,7 +115,7 @@
     {
         "type": "image",
         "details": {
-            "registryURL": "tfy.jfrog.io/tfy-private-images/mlfoundry-server:v0.162.0",
+            "registryURL": "tfy.jfrog.io/tfy-private-images/mlfoundry-server:v0.155.0",
             "platforms": [
                 {
                     "os": "linux",

--- a/charts/truefoundry/templates/mlfoundry-server/_helpers.tpl
+++ b/charts/truefoundry/templates/mlfoundry-server/_helpers.tpl
@@ -216,6 +216,14 @@ Expand the name of the chart.
 - name: MULTITENANT
   value: "true"
 {{- end }}
+- name: K8S_SERVICE_ACCOUNT_NAME
+  valueFrom:
+    fieldRef:
+      fieldPath: spec.serviceAccountName
+- name: MLFOUNDRY_WIF_K8S_NAMESPACE
+  valueFrom:
+    fieldRef:
+      fieldPath: metadata.namespace
 {{- end }}
 
 {{/*
@@ -242,33 +250,33 @@ Resource Tier
 {{- define "mlfoundry-server.defaultResources.small" }}
 requests:
   cpu: 100m
-  memory: 400Mi
+  memory: 512Mi
   ephemeral-storage: 128Mi
 limits:
   cpu: 200m
-  memory: 600Mi
+  memory: 1024Mi
   ephemeral-storage: 256Mi
 {{- end }}
 
 {{- define "mlfoundry-server.defaultResources.medium" }}
 requests:
-  cpu: 100m
-  memory: 500Mi
+  cpu: 200m
+  memory: 1024Mi
   ephemeral-storage: 128Mi
 limits:
-  cpu: 200m
-  memory: 700Mi
+  cpu: 400m
+  memory: 2048Mi
   ephemeral-storage: 256Mi
 {{- end }}
 
 {{- define "mlfoundry-server.defaultResources.large" }}
 requests:
-  cpu: 100m
-  memory: 650Mi
+  cpu: 600m
+  memory: 1536Mi
   ephemeral-storage: 128Mi
 limits:
-  cpu: 200m
-  memory: 850Mi
+  cpu: 1200m
+  memory: 3072Mi
   ephemeral-storage: 256Mi
 {{- end }}
 

--- a/charts/truefoundry/templates/tfy-proxy/configmap.yaml
+++ b/charts/truefoundry/templates/tfy-proxy/configmap.yaml
@@ -346,11 +346,49 @@ data:
             path /api/ml/v1/x/prompt-versions/validate /api/ml/v1/x/prompt-versions/validate/*
             path /api/ml/v1/x/agent-skill-versions/bulk-get /api/ml/v1/x/agent-skill-versions/bulk-get/*
             path /api/ml/v1/x/agent-skill-versions/presigned-urls /api/ml/v1/x/agent-skill-versions/presigned-urls/*
-            path /api/ml/api/2.0/mlflow/runs /api/ml/api/2.0/mlflow/runs/*
-            path /api/ml/api/2.0/mlflow/metrics /api/ml/api/2.0/mlflow/metrics/*
-            path /api/ml/api/2.0/mlflow/mlfoundry-artifacts /api/ml/api/2.0/mlflow/mlfoundry-artifacts/*
-            path /api/ml/api/2.0/mlflow/experiments/hard-delete
             path /api/ml/api/2.0/mlflow/experiments/columns
+            path /api/ml/api/2.0/mlflow/experiments/hard-delete
+            path /api/ml/api/2.0/mlflow/metrics/get-history
+            path /api/ml/api/2.0/mlflow/metrics/list-history
+            path /api/ml/api/2.0/mlflow/mlfoundry-artifacts/artifact-versions/create
+            path /api/ml/api/2.0/mlflow/mlfoundry-artifacts/artifact-versions/delete
+            path /api/ml/api/2.0/mlflow/mlfoundry-artifacts/artifact-versions/finalize
+            path /api/ml/api/2.0/mlflow/mlfoundry-artifacts/artifact-versions/get
+            path /api/ml/api/2.0/mlflow/mlfoundry-artifacts/artifact-versions/get-by-fqn
+            path /api/ml/api/2.0/mlflow/mlfoundry-artifacts/artifact-versions/get-by-name
+            path /api/ml/api/2.0/mlflow/mlfoundry-artifacts/artifact-versions/list
+            path /api/ml/api/2.0/mlflow/mlfoundry-artifacts/artifact-versions/notify-failure
+            path /api/ml/api/2.0/mlflow/mlfoundry-artifacts/artifact-versions/update
+            path /api/ml/api/2.0/mlflow/mlfoundry-artifacts/artifacts/get
+            path /api/ml/api/2.0/mlflow/mlfoundry-artifacts/artifacts/get-by-fqn
+            path /api/ml/api/2.0/mlflow/mlfoundry-artifacts/artifacts/list
+            path /api/ml/api/2.0/mlflow/mlfoundry-artifacts/datasets/create
+            path /api/ml/api/2.0/mlflow/mlfoundry-artifacts/datasets/delete
+            path /api/ml/api/2.0/mlflow/mlfoundry-artifacts/datasets/get-by-fqn
+            path /api/ml/api/2.0/mlflow/mlfoundry-artifacts/datasets/list
+            path /api/ml/api/2.0/mlflow/mlfoundry-artifacts/datasets/update
+            path /api/ml/api/2.0/mlflow/mlfoundry-artifacts/model-versions/get
+            path /api/ml/api/2.0/mlflow/mlfoundry-artifacts/model-versions/get-by-fqn
+            path /api/ml/api/2.0/mlflow/mlfoundry-artifacts/model-versions/get-by-name
+            path /api/ml/api/2.0/mlflow/mlfoundry-artifacts/model-versions/list
+            path /api/ml/api/2.0/mlflow/mlfoundry-artifacts/model-versions/update
+            path /api/ml/api/2.0/mlflow/mlfoundry-artifacts/models/get
+            path /api/ml/api/2.0/mlflow/mlfoundry-artifacts/models/get-by-fqn
+            path /api/ml/api/2.0/mlflow/mlfoundry-artifacts/models/get-by-name
+            path /api/ml/api/2.0/mlflow/runs/create
+            path /api/ml/api/2.0/mlflow/runs/delete
+            path /api/ml/api/2.0/mlflow/runs/delete-tag
+            path /api/ml/api/2.0/mlflow/runs/get
+            path /api/ml/api/2.0/mlflow/runs/get-by-fqn
+            path /api/ml/api/2.0/mlflow/runs/get-by-name
+            path /api/ml/api/2.0/mlflow/runs/hard-delete
+            path /api/ml/api/2.0/mlflow/runs/log-batch
+            path /api/ml/api/2.0/mlflow/runs/log-metric
+            path /api/ml/api/2.0/mlflow/runs/log-parameter
+            path /api/ml/api/2.0/mlflow/runs/restore
+            path /api/ml/api/2.0/mlflow/runs/search
+            path /api/ml/api/2.0/mlflow/runs/set-tag
+            path /api/ml/api/2.0/mlflow/runs/update
             path /api/ml/api/2.0/preview/mlflow/runs/search
             path /api/ml/api/2.0mlflow/runs/get-by-name
           }

--- a/charts/truefoundry/values.yaml
+++ b/charts/truefoundry/values.yaml
@@ -544,7 +544,7 @@ mlfoundryServer:
     ## @param mlfoundryServer.image.repository Image repository for the mlfoundry server (without registry)
     repository: "tfy-private-images/mlfoundry-server"
     ## @param mlfoundryServer.image.tag Image tag for the mlfoundry server
-    tag: "v0.162.0"
+    tag: "v0.155.0"
   ## @skip mlfoundryServer.replicaCount Number of replicas for the mlfoundry server
   # replicaCount: 1
   ## @param mlfoundryServer.environmentName Environment name for the mlfoundry server
@@ -674,15 +674,23 @@ mlfoundryServer:
   extraVolumeMounts: []
   ## @param mlfoundryServer.env [object] Environment variables for the mlfoundry server
   env:
-    NUM_APP_WORKERS: "1"
+    NUM_APP_WORKERS: "2"
     PROMETHEUS_FASTAPI_INSTRUMENTATOR: "1"
     PROMETHEUS_MULTIPROC_DIR: /tmp
     prometheus_multiproc_dir: /tmp
+    DB_NAME: ${k8s-secret/truefoundry-creds/DB_NAME}
+    DB_USERNAME: ${k8s-secret/truefoundry-creds/DB_USERNAME}
+    DB_PASSWORD: ${k8s-secret/truefoundry-creds/DB_PASSWORD}
+    DB_HOST: ${k8s-secret/truefoundry-creds/DB_HOST}
+    DB_POSTGRES_SCHEMA: mlfoundry
+    DB_PORT: "5432"
+    DB_DIALECT: postgresql+psycopg2
     AUTH_SERVER_URL: https://auth.truefoundry.com
     MULTITENANT: "{{ .Values.global.multitenant.enabled }}"
     TENANT_NAME: "{{ .Values.global.tenantName }}"
     TFY_API_KEY: ${k8s-secret/truefoundry-creds/TFY_API_KEY}
     SERVICEFOUNDRY_SERVER_URL: http://{{ .Release.Name }}-servicefoundry-server:3000
+    LLM_GATEWAY_URL: "{{ .Values.global.controlPlaneURL }}/api/llm"
     ENVIRONMENT: production
 ###################################################################################################################
 ####################################### Spark History Server #######################################################


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Image downgrade plus new DB credential wiring and expanded servicefoundry routing for ML APIs can change runtime behavior and which backend serves MLflow traffic on upgrade.
> 
> **Overview**
> Pins **mlfoundry-server** to **`v0.155.0`** (down from `v0.162.0`) in `values.yaml`, README, and `artifacts-manifest.json`.
> 
> **mlfoundry-server** chart behavior is updated: downward-API env vars **`K8S_SERVICE_ACCOUNT_NAME`** and **`MLFOUNDRY_WIF_K8S_NAMESPACE`** for WIF; higher default CPU/memory for small/medium/large tiers; **`NUM_APP_WORKERS`** set to `2`; explicit Postgres **`DB_*`** from `truefoundry-creds`; **`LLM_GATEWAY_URL`** pointing at the control plane.
> 
> **tfy-proxy** `@ml_to_svc` routing replaces broad MLflow path wildcards with an explicit allowlist of runs, metrics, and mlfoundry-artifacts endpoints so those requests go to **servicefoundry** when `mlfToSvcEnabled` is on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a49bae9ee97a6ea251d1380de9a05bcfdc037c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->