### PR TITLE
feat: add cron workflow permissons

### DIFF
--- a/charts/tfy-agent/templates/tfy-agent-proxy-clusterrole-ns.yaml
+++ b/charts/tfy-agent/templates/tfy-agent-proxy-clusterrole-ns.yaml
@@ -82,6 +82,11 @@ rules:
     resources: ["workflows"]
     verbs: ["create", "get", "patch"]
 
+  {{/* This allows us to pause/resume scheduled jobs by patching CronWorkflow suspend field */}}
+  - apiGroups: ["argoproj.io"]
+    resources: ["cronworkflows"]
+    verbs: ["get", "patch"]
+
   - apiGroups: ["kubeflow.org"]
     resources: ["notebooks"]
     verbs: ["get", "update", "delete"]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> RBAC-only Helm change with a narrow scope (get/patch on cronworkflows); no application logic changes.
> 
> **Overview**
> Extends the **tfy-agent-proxy** namespace `ClusterRole` with Argo Workflows **`cronworkflows`** permissions: **`get`** and **`patch`**, so the agent can pause and resume scheduled jobs by updating the CronWorkflow **`suspend`** field.
> 
> This sits alongside the existing **`workflows`** rules (`create`, `get`, `patch`) and is documented in-chart with a Helm comment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48fef2e46727ea8f6a6f1cf174211f94102cdee3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->